### PR TITLE
Remove unused import in Data model class test

### DIFF
--- a/src/Model/Data/Data.spec.ts
+++ b/src/Model/Data/Data.spec.ts
@@ -1,5 +1,4 @@
 import Data from './Data';
-import DataSchema from '../../Type/DataSchema';
 import { FeatureCollection, Point, LineString, Polygon } from 'geojson';
 
 it('is defined', () => {


### PR DESCRIPTION
This removes an unused import in the unit test spec for the Data model class. Satisfies the upcoming ts-lint configuration introduced by PR #15.