### PR TITLE
Compile lib to dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "lint": "tslint --project tsconfig.json --config tslint.json",
-    "release": "np --no-yarn"
+    "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags"
   },
   "devDependencies": {
     "@types/geojson": "7946.0.3",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "",
   "main": "src/index.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/terrestris/geostyler.git"
@@ -29,8 +32,9 @@
     "react-scripts-ts": "2.16.0"
   },
   "scripts": {
+    "prebuild": "rimraf dist/**",
     "start": "react-scripts-ts start",
-    "build": "react-scripts-ts build",
+    "build": "tsc -p ./",
     "pretest": "npm run lint",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
@@ -48,6 +52,7 @@
     "@types/react-dom": "16.0.5",
     "np": "2.20.1",
     "react-styleguidist": "7.0.14",
+    "rimraf": "2.6.1",
     "ts-jest": "22.4.6",
     "typescript": "2.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geostyler",
   "version": "0.1.0",
   "description": "",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],
@@ -34,7 +34,7 @@
   "scripts": {
     "prebuild": "rimraf dist/**",
     "start": "react-scripts-ts start",
-    "build": "tsc -p ./",
+    "build": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
     "pretest": "npm run lint",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
@@ -50,9 +50,11 @@
     "@types/ol": "4.6.1",
     "@types/react": "16.3.12",
     "@types/react-dom": "16.0.5",
+    "copyfiles": "2.0.0",
+    "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
     "np": "2.20.1",
     "react-styleguidist": "7.0.14",
-    "rimraf": "2.6.1",
+    "rimraf": "2.6.2",
     "ts-jest": "22.4.6",
     "typescript": "2.8.1"
   }

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { Select } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Select, Form } from 'antd';
 const Option = Select.Option;
 
 // default props
@@ -71,7 +70,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
     return (
       <div className="gs-attr-combo">
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Select
             defaultValue={this.state.value}
@@ -82,7 +81,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
               {options}
           </Select>
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { Checkbox } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Checkbox, Form } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox/Checkbox';
 
 // default props
@@ -52,14 +51,14 @@ class BoolFilterField extends React.Component<BoolFilterFieldProps, BoolFilterFi
     return (
       <div className="gs-text-filter-fld">
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Checkbox
             checked={this.state.value}
             onChange={this.onChange}
           />
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
 import { ComparisonOperator } from 'geostyler-style';
-import { Select } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Select, Form } from 'antd';
 const Option = Select.Option;
 
 // default props
@@ -62,7 +61,7 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
     return (
       <div className="gs-operator-combo">
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Select
             defaultValue={this.state.value}
@@ -73,7 +72,7 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
               {options}
           </Select>
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { Input } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Input, Form } from 'antd';
 
 // default props
 interface DefaultTextFilterFieldProps {
@@ -53,7 +52,7 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
     return (
       <div className="gs-text-filter-fld">
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Input
             value={this.state.value}
@@ -62,7 +61,7 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
             placeholder={this.props.placeholder}
           />
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/Rule/NameField/NameField.tsx
+++ b/src/Component/Rule/NameField/NameField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Input } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Input, Form } from 'antd';
 
 import './NameField.css';
 
@@ -39,7 +38,7 @@ class NameField extends React.Component<NameFieldProps, any> {
     return (
       <div className="gs-rule-namefield" >
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Input
             className="gs-rule-namefield-input"
@@ -48,7 +47,7 @@ class NameField extends React.Component<NameFieldProps, any> {
             placeholder={this.props.placeholder}
           />
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/Rule/TitleField/TitleField.tsx
+++ b/src/Component/Rule/TitleField/TitleField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Input } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { Input, Form } from 'antd';
 
 import './TitleField.css';
 
@@ -38,7 +37,7 @@ class TitleField extends React.Component<TitleFieldProps, any> {
     return (
       <div className="gs-rule-titlefield" >
 
-        <FormItem label={this.props.label} colon={false} >
+        <Form.Item label={this.props.label} colon={false} >
 
           <Input
             className="gs-rule-titlefield-input"
@@ -46,7 +45,7 @@ class TitleField extends React.Component<TitleFieldProps, any> {
             placeholder={this.props.placeholder}
           />
 
-        </FormItem>
+        </Form.Item>
 
       </div>
     );

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { InputNumber } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { InputNumber, Form } from 'antd';
 
 import './MaxScaleDenominator.css';
 
@@ -28,7 +27,7 @@ class MaxScaleDenominator extends React.Component<ScaleDenominatorProps, any> {
   render() {
 
     return (
-      <FormItem className="gs-max-scaledenominator" label={this.props.label} colon={false} >
+      <Form.Item className="gs-max-scaledenominator" label={this.props.label} colon={false} >
 
         <InputNumber
           className="gs-max-scaledenominator-input"
@@ -38,7 +37,7 @@ class MaxScaleDenominator extends React.Component<ScaleDenominatorProps, any> {
           onChange={this.props.onChange}
         />
 
-      </FormItem>
+      </Form.Item>
     );
   }
 }

--- a/src/Component/ScaleDenominator/MinScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { InputNumber } from 'antd';
-import FormItem from 'antd/lib/form/FormItem';
+import { InputNumber, Form } from 'antd';
 
 import './MinScaleDenominator.css';
 
@@ -28,17 +27,17 @@ class MinScaleDenominator extends React.Component<ScaleDenominatorProps, any> {
   render() {
 
     return (
-        <FormItem className="gs-min-scaledenominator" label={this.props.label} colon={false} >
+        <Form.Item className="gs-min-scaledenominator" label={this.props.label} colon={false} >
 
           <InputNumber
             className="gs-min-scaledenominator-input"
             value={this.props.value}
-            min={0} 
-            placeholder={this.props.placeholder} 
-            onChange={this.props.onChange} 
+            min={0}
+            placeholder={this.props.placeholder}
+            onChange={this.props.onChange}
           />
 
-        </FormItem>
+        </Form.Item>
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,33 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
+import FieldSet from './Component/FieldSet/FieldSet';
+import AttributeCombo from './Component/Filter/AttributeCombo/AttributeCombo';
+import BoolFilterField from './Component/Filter/BoolFilterField/BoolFilterField';
+import ComparisonFilter from './Component/Filter/ComparisonFilter/ComparisonFilter';
+import NumberFilterField from './Component/Filter/NumberFilterField/NumberFilterField';
+import OperatorCombo from './Component/Filter/OperatorCombo/OperatorCombo';
+import TextFilterField from './Component/Filter/TextFilterField/TextFilterField';
+import NameField from './Component/Rule/NameField/NameField';
+import RemoveButton from './Component/Rule/RemoveButton/RemoveButton';
+import TitleField from './Component/Rule/TitleField/TitleField';
+import Rule from './Component/Rule/Rule';
+import MaxScaleDenominator from './Component/ScaleDenominator/MaxScaleDenominator';
+import MinScaleDenominator from './Component/ScaleDenominator/MinScaleDenominator';
+import Preview from './Component/Symbolizer/Preview/Preview';
+import UploadButton from './Component/UploadButton/UploadButton'
 
-ReactDOM.render(<App />, document.getElementById('root'));
+export {
+  FieldSet,
+  AttributeCombo,
+  BoolFilterField,
+  ComparisonFilter,
+  NumberFilterField,
+  OperatorCombo,
+  TextFilterField,
+  NameField,
+  RemoveButton,
+  TitleField,
+  Rule,
+  MaxScaleDenominator,
+  MinScaleDenominator,
+  Preview,
+  UploadButton
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "acceptance-tests",
     "webpack",
     "jest",
-    "src/setupTests.ts"
+    "src/setupTests.ts",
+    "src/index.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "build/dist",
-    "module": "esnext",
+    "outDir": "dist",
+    "module": "commonjs",
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,
@@ -20,7 +20,7 @@
   },
   "exclude": [
     "node_modules",
-    "build",
+    "dist",
     "scripts",
     "acceptance-tests",
     "webpack",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "exclude": [
     "node_modules",
+    "build",
     "dist",
     "scripts",
     "acceptance-tests",


### PR DESCRIPTION
This PR enhances build procedure of `geostyler` to enable its usage in other projects (e.g. `react-geo`). 

In particular:

* compliled output (using `tsc`) and CSS files are exposed in `dist` folder by running `npm run build`
* Named exports of each included module (as in `react-geo`)
