### PR TITLE
Add OL-map based symbolizer preview

### DIFF
--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -5,6 +5,7 @@ import {
   Filter as GsFilter,
   ComparisonFilter as GsComparisonFilter,
   Rule as GsRule,
+  Symbolizer as GsSymbolizer
 } from 'geostyler-style';
 import { Data as GsData } from 'geostyler-data';
 
@@ -34,6 +35,7 @@ interface RuleState {
   filter: GsFilter | undefined;
   maxScale: number | undefined;
   minScale: number | undefined;
+  symbolizer: GsSymbolizer;
 }
 
 /**
@@ -44,12 +46,18 @@ class Rule extends React.Component<RuleProps, RuleState> {
   constructor(props: RuleProps) {
     super(props);
 
+    const defaultSymb: GsSymbolizer = {
+      kind: 'Line'
+    };
+
     if (this.props.rule) {
+
       this.state = {
         name: this.props.rule.name,
         filter: this.props.rule.filter ? this.props.rule.filter : undefined,
         maxScale: this.props.rule.scaleDenominator ? this.props.rule.scaleDenominator.max : undefined,
-        minScale: this.props.rule.scaleDenominator ? this.props.rule.scaleDenominator.min : undefined
+        minScale: this.props.rule.scaleDenominator ? this.props.rule.scaleDenominator.min : undefined,
+        symbolizer: this.props.rule.symbolizer ? this.props.rule.symbolizer : defaultSymb
       };
 
     } else {
@@ -57,7 +65,8 @@ class Rule extends React.Component<RuleProps, RuleState> {
         name: '',
         filter: undefined,
         maxScale: undefined,
-        minScale: undefined
+        minScale: undefined,
+        symbolizer: defaultSymb
       };
     }
 
@@ -92,6 +101,15 @@ class Rule extends React.Component<RuleProps, RuleState> {
   }
 
   /**
+   * Handles changing rule symbolizer
+   */
+  onSymbolizerChange = (changedSymb: GsSymbolizer) => {
+    this.setState({symbolizer: changedSymb}, () => {
+      this.createGsRule();
+    });
+  }
+
+  /**
    * Creates a GeoStyler compliant rule object according to the UI
    * and pushes it to the passed in 'onRuleChange' function.
    */
@@ -103,12 +121,7 @@ class Rule extends React.Component<RuleProps, RuleState> {
         max: this.state.maxScale
       },
       filter: this.state.filter,
-      // TODO apply symbolizer once we have a UI to create one
-      symbolizer: {
-        kind: 'Line',
-        color: '#000000',
-        width: 3
-      }
+      symbolizer: this.state.symbolizer
     };
 
     this.props.onRuleChange(rule, this.props.keyIndex);
@@ -151,6 +164,7 @@ class Rule extends React.Component<RuleProps, RuleState> {
             <Preview
               symbolizer={this.state.symbolizer}
               features={gsData.exampleFeatures}
+              onSymbolizerChange={this.onSymbolizerChange}
             />
           </Col>
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 
 import { Row, Col } from 'antd';
-import { Filter as GsFilter, ComparisonFilter as GsComparisonFilter, Rule as GsRule } from 'geostyler-style';
+import {
+  Filter as GsFilter,
+  ComparisonFilter as GsComparisonFilter,
+  Rule as GsRule,
+} from 'geostyler-style';
 import { Data as GsData } from 'geostyler-data';
 
 import RuleNameField from './NameField/NameField';
@@ -9,6 +13,7 @@ import ComparisonFilterUi from '../Filter/ComparisonFilter/ComparisonFilter';
 import RuleRemoveButton from './RemoveButton/RemoveButton';
 import ScaleDenominator from '../ScaleDenominator/ScaleDenominator';
 import Fieldset from '../FieldSet/FieldSet';
+import Preview from '../Symbolizer/Preview/Preview';
 
 import './Rule.css';
 
@@ -112,6 +117,8 @@ class Rule extends React.Component<RuleProps, RuleState> {
   render() {
     // cast the current filter object to pass over to ComparisonFilterUi
     const cmpFilter = this.state.filter as GsComparisonFilter;
+    // cast to GeoStyler compliant data model
+    const gsData = this.props.internalDataDef as GsData;
 
     return (
       <div className="gs-rule" >
@@ -141,11 +148,10 @@ class Rule extends React.Component<RuleProps, RuleState> {
         <Row gutter={16}>
 
           <Col span={12}>
-
-            <div style={{margin: 10}}>
-              <img src="http://fillmurray.com/120/120" />
-            </div>
-
+            <Preview
+              symbolizer={this.state.symbolizer}
+              features={gsData.exampleFeatures}
+            />
           </Col>
 
           <Col span={12}>

--- a/src/Component/Symbolizer/Preview/Preview.css
+++ b/src/Component/Symbolizer/Preview/Preview.css
@@ -1,0 +1,8 @@
+
+.gs-symbolizer-preview {
+  margin-top: -35px;
+}
+
+.gs-symbolizer-preview .map {
+  border: 1px solid lightgrey;
+}

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -1,0 +1,9 @@
+import Preview from './Preview';
+
+describe('SymbolizerPreview', () => {
+  
+  it('is defined', () => {
+    expect(Preview).toBeDefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -19,6 +19,7 @@ interface DefaultPreviewProps {
 interface PreviewProps extends Partial<DefaultPreviewProps> {
   features: FeatureCollection<GeometryObject>;
   symbolizer: Symbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
 }
 // state
 interface PreviewState {
@@ -29,6 +30,12 @@ interface PreviewState {
  * Symbolizer preview UI.
  */
 class Preview extends React.Component<PreviewProps, PreviewState> {
+
+  /** reference to the underlying OpenLayers map */
+  map: ol.Map;
+
+  /** refrence to the vector layer for the passed in features  */
+  dataLayer: ol.layer.Vector;
 
   public static defaultProps: DefaultPreviewProps = {
     projection: 'EPSG:3857',
@@ -44,9 +51,6 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
       symbolizer: this.props.symbolizer
     };
   }
-
-  /** reference to the underlying OpenLayers map */
-  map: ol.Map;
 
   public componentDidMount() {
 
@@ -84,6 +88,8 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
 
       map.addLayer(vectorLayer);
 
+      this.dataLayer = vectorLayer;
+
       // zoom to feature extent
       const extent = vectorLayer.getSource().getExtent();
       map.getView().fit(extent);
@@ -91,6 +97,19 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     }
 
     this.map = map;
+  }
+
+  /**
+   * Adapts the style of the vector data in the map according to the changed symbolizer.
+   * Also passes the changed symbolizer to the parent's 'onSymbolizerChange' function.
+   */
+  onSymbolizerChange = (symb: Symbolizer) => {
+
+    if (this.dataLayer) {
+      this.dataLayer.setStyle(this.symbolizer2OlStyle(symb));
+    }
+
+    this.props.onSymbolizerChange(symb);
   }
 
   /**

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -14,6 +14,7 @@ interface DefaultPreviewProps {
   dataProjection: string;
   showOsmBackground: boolean;
   mapHeight: number;
+  map: ol.Map | undefined;
 }
 // non default props
 interface PreviewProps extends Partial<DefaultPreviewProps> {
@@ -41,7 +42,8 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     projection: 'EPSG:3857',
     dataProjection: 'EPSG:4326',
     showOsmBackground: true,
-    mapHeight: 200
+    mapHeight: 200,
+    map: undefined
   };
 
   constructor(props: PreviewProps) {
@@ -54,17 +56,24 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
 
   public componentDidMount() {
 
-    const map = new ol.Map({
-      layers: [],
-      target: 'map',
-      view: new ol.View({
-        projection: this.props.projection,
-        center: [0, 0],
-        zoom: 1
-      })
-    });
+    let map: ol.Map;
+    if (!this.props.map) {
+      // create a new OL map and bind it to this preview DIV
+      map = new ol.Map({
+        layers: [],
+        target: 'map',
+        view: new ol.View({
+          projection: this.props.projection
+        })
+      });
+    } else {
+      // use passed in OL map and bind it to this preview DIV
+      map = this.props.map;
+      map.setTarget('map');
+    }
 
-    if (this.props.showOsmBackground) {
+    // show an OSM background layer if configured and no map was passed in
+    if (!this.props.map && this.props.showOsmBackground) {
       const osmLayer = new ol.layer.Tile({
         source: new ol.source.OSM()
       });

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -1,20 +1,127 @@
 import * as React from 'react';
 
+import * as ol from 'openlayers';
+
+import { FeatureCollection, GeometryObject } from 'geojson';
+import { Symbolizer } from 'geostyler-style';
+
+import 'openlayers/css/ol.css';
+import './Preview.css';
+
 // default props
-interface DefaultPreviewProps {}
+interface DefaultPreviewProps {
+  projection: string;
+  dataProjection: string;
+  showOsmBackground: boolean;
+  mapHeight: number;
+}
 // non default props
-interface PreviewProps extends Partial<DefaultPreviewProps> {}
+interface PreviewProps extends Partial<DefaultPreviewProps> {
+  features: FeatureCollection<GeometryObject>;
+  symbolizer: Symbolizer;
+}
+// state
+interface PreviewState {
+  symbolizer: Symbolizer;
+}
 
 /**
  * Symbolizer preview UI.
  */
-class Preview extends React.Component<PreviewProps, any> {
+class Preview extends React.Component<PreviewProps, PreviewState> {
+
+  public static defaultProps: DefaultPreviewProps = {
+    projection: 'EPSG:3857',
+    dataProjection: 'EPSG:4326',
+    showOsmBackground: true,
+    mapHeight: 200
+  };
+
+  constructor(props: PreviewProps) {
+    super(props);
+
+    this.state = {
+      symbolizer: this.props.symbolizer
+    };
+  }
+
+  /** reference to the underlying OpenLayers map */
+  map: ol.Map;
+
+  public componentDidMount() {
+
+    const map = new ol.Map({
+      layers: [],
+      target: 'map',
+      view: new ol.View({
+        projection: this.props.projection,
+        center: [0, 0],
+        zoom: 1
+      })
+    });
+
+    if (this.props.showOsmBackground) {
+      const osmLayer = new ol.layer.Tile({
+        source: new ol.source.OSM()
+      });
+      map.addLayer(osmLayer);
+    }
+
+    // add features and zoom to them (when existing)
+    if (this.props.features) {
+
+      const format = new ol.format.GeoJSON({
+        defaultDataProjection: this.props.dataProjection,
+        featureProjection: map.getView().getProjection()
+      });
+
+      const vectorLayer = new ol.layer.Vector({
+        source: new ol.source.Vector({
+          features: format.readFeatures(this.props.features)
+        }),
+        style: this.symbolizer2OlStyle(this.state.symbolizer)
+      });
+
+      map.addLayer(vectorLayer);
+
+      // zoom to feature extent
+      const extent = vectorLayer.getSource().getExtent();
+      map.getView().fit(extent);
+
+    }
+
+    this.map = map;
+  }
+
+  /**
+   * Dummy implementation to transform the incoming symbolizer to an OpenLayers
+   * style object.
+   * Will be replaced by an appropiate GeoStyler parser (once it is ready)
+   *
+   * TODO replace parsing logic with appropriate GeoStyler parser
+   */
+  symbolizer2OlStyle = (symbolizer: Symbolizer): any => {
+    if (symbolizer.kind === 'Circle') {
+      return new ol.style.Style({
+        image: new ol.style.Circle({
+          radius: symbolizer.radius || 4,
+          stroke: new ol.style.Stroke({
+            color: symbolizer.strokeColor || symbolizer.color,
+            width: symbolizer.strokeWidth || 1
+          }),
+          fill: new ol.style.Fill({
+            color: symbolizer.color
+          })
+        })
+      });
+    }
+  }
 
   render() {
 
     return (
       <div className="gs-symbolizer-preview" >
-        TODO Preview 
+        <div id="map" className="map" style={{ height: this.props.mapHeight }} />
       </div>
     );
   }

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -15,6 +15,7 @@ interface DefaultPreviewProps {
   showOsmBackground: boolean;
   mapHeight: number;
   map: ol.Map | undefined;
+  layers: ol.layer.Base[] | undefined;
 }
 // non default props
 interface PreviewProps extends Partial<DefaultPreviewProps> {
@@ -43,7 +44,8 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     dataProjection: 'EPSG:4326',
     showOsmBackground: true,
     mapHeight: 200,
-    map: undefined
+    map: undefined,
+    layers: undefined
   };
 
   constructor(props: PreviewProps) {
@@ -80,7 +82,14 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
       map.addLayer(osmLayer);
     }
 
-    // add features and zoom to them (when existing)
+    // add configured additional layers
+    if (this.props.layers) {
+      this.props.layers.forEach((layer) => {
+        map.addLayer(layer);
+      });
+    }
+
+    // add data features to style according to symbolizer and zoom to them (when existing)
     if (this.props.features) {
 
       const format = new ol.format.GeoJSON({

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -16,6 +16,8 @@ interface DefaultPreviewProps {
   mapHeight: number;
   map: ol.Map | undefined;
   layers: ol.layer.Base[] | undefined;
+  controls: ol.control.Control[] | undefined;
+  interactions: ol.interaction.Interaction[] | undefined;
 }
 // non default props
 interface PreviewProps extends Partial<DefaultPreviewProps> {
@@ -45,7 +47,9 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     showOsmBackground: true,
     mapHeight: 200,
     map: undefined,
-    layers: undefined
+    layers: undefined,
+    controls: undefined,
+    interactions: undefined
   };
 
   constructor(props: PreviewProps) {
@@ -63,6 +67,8 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
       // create a new OL map and bind it to this preview DIV
       map = new ol.Map({
         layers: [],
+        controls: [],
+        interactions: [],
         target: 'map',
         view: new ol.View({
           projection: this.props.projection
@@ -80,6 +86,20 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
         source: new ol.source.OSM()
       });
       map.addLayer(osmLayer);
+    }
+
+    // add configured OL control to map, when no map was passed in
+    if (!this.props.map && this.props.controls) {
+      this.props.controls.forEach((ctrl) => {
+        map.addControl(ctrl);
+      });
+    }
+
+    // add configured OL interaction to map, when no map was passed in
+    if (!this.props.map && this.props.interactions) {
+      this.props.interactions.forEach((iac) => {
+        map.addInteraction(iac);
+      });
     }
 
     // add configured additional layers


### PR DESCRIPTION
This adds a symbolizer preview realized as OpenLayers map. The preview component expects somes features (GeoJSON) and a symbolizer to define the style of the features on the map. 

Also a predefined OpenLayers map instance or an array of OpenLayers layers can be passed in to customized the setup of the map.

![image](https://user-images.githubusercontent.com/1185547/40473375-45a3cd82-5f3c-11e8-9182-4e8c197b8273.png)
