### PR TITLE
Improve test setup and add basic unit tests for UI components 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,15 @@
     "release": "np --no-yarn"
   },
   "devDependencies": {
+    "@types/enzyme": "3.1.10",
     "@types/geojson": "7946.0.3",
     "@types/jest": "22.2.3",
     "@types/node": "10.1.2",
     "@types/ol": "4.6.1",
     "@types/react": "16.3.12",
     "@types/react-dom": "16.0.5",
+    "enzyme": "3.3.0",
+    "enzyme-adapter-react-16": "1.1.1",
     "np": "2.20.1",
     "react-styleguidist": "7.0.14",
     "ts-jest": "22.4.6",

--- a/src/Component/FieldSet/FieldSet.spec.tsx
+++ b/src/Component/FieldSet/FieldSet.spec.tsx
@@ -1,7 +1,19 @@
 import FieldSet from './FieldSet';
+import TestUtil from '../../Util/TestUtil';
 
 describe('FieldSet', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.mountComponent(FieldSet);
+  });
+
   it('is defined', () => {
     expect(FieldSet).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/FieldSet/FieldSet.spec.tsx
+++ b/src/Component/FieldSet/FieldSet.spec.tsx
@@ -1,0 +1,7 @@
+import FieldSet from './FieldSet';
+
+describe('FieldSet', () => {
+  it('is defined', () => {
+    expect(FieldSet).toBeDefined();
+  });
+});

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
@@ -1,0 +1,7 @@
+import AttributeCombo from './AttributeCombo';
+
+describe('AttributeCombo', () => {
+  it('is defined', () => {
+    expect(AttributeCombo).toBeDefined();
+  });
+});

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
@@ -1,7 +1,23 @@
 import AttributeCombo from './AttributeCombo';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('AttributeCombo', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(AttributeCombo, {internalDataDef: dummyData, onAttributeChange: dummyFn});
+  });
+
   it('is defined', () => {
     expect(AttributeCombo).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
   });
 });

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
@@ -1,0 +1,7 @@
+import BoolFilterField from './BoolFilterField';
+
+describe('BoolFilterField', () => {
+  it('is defined', () => {
+    expect(BoolFilterField).toBeDefined();
+  });
+});

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
@@ -1,7 +1,24 @@
+import TestUtil from '../../../Util/TestUtil';
 import BoolFilterField from './BoolFilterField';
 
 describe('BoolFilterField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(BoolFilterField, {internalDataDef: dummyData, onValueChange: dummyFn});
+  });
+
   it('is defined', () => {
     expect(BoolFilterField).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
@@ -1,0 +1,7 @@
+import ComparisonFilter from './ComparisonFilter';
+
+describe('ComparisonFilter', () => {
+  it('is defined', () => {
+    expect(ComparisonFilter).toBeDefined();
+  });
+});

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
@@ -1,7 +1,25 @@
 import ComparisonFilter from './ComparisonFilter';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('ComparisonFilter', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    // wrapper = TestUtil.mountComponent(AttributeCombo);
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(ComparisonFilter, {internalDataDef: dummyData, onFilterChange: dummyFn});
+  });
+
   it('is defined', () => {
     expect(ComparisonFilter).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
@@ -1,0 +1,7 @@
+import NumberFilterField from './NumberFilterField';
+
+describe('NumberFilterField', () => {
+  it('is defined', () => {
+    expect(NumberFilterField).toBeDefined();
+  });
+});

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
@@ -1,7 +1,28 @@
 import NumberFilterField from './NumberFilterField';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('NumberFilterField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(NumberFilterField, {
+      internalDataDef: dummyData,
+      onValueChange: dummyFn,
+      selectedAttribute: 'foo'
+    });
+  });
+
   it('is defined', () => {
     expect(NumberFilterField).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
@@ -1,7 +1,27 @@
 import OperatorCombo from './OperatorCombo';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('OperatorCombo', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(OperatorCombo, {
+      internalDataDef: dummyData,
+      onOperatorChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(OperatorCombo).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
@@ -1,0 +1,7 @@
+import OperatorCombo from './OperatorCombo';
+
+describe('OperatorCombo', () => {
+  it('is defined', () => {
+    expect(OperatorCombo).toBeDefined();
+  });
+});

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -1,7 +1,27 @@
 import TextFilterField from './TextFilterField';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('TextFilterField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(TextFilterField, {
+      internalDataDef: dummyData,
+      onOperatorChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(TextFilterField).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -1,0 +1,7 @@
+import TextFilterField from './TextFilterField';
+
+describe('TextFilterField', () => {
+  it('is defined', () => {
+    expect(TextFilterField).toBeDefined();
+  });
+});

--- a/src/Component/Rule/NameField/NameField.spec.tsx
+++ b/src/Component/Rule/NameField/NameField.spec.tsx
@@ -1,7 +1,26 @@
 import NameField from './NameField';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('NameField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    wrapper = TestUtil.shallowRenderComponent(NameField, {
+      value: 'foo',
+      onChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(NameField).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Rule/NameField/NameField.spec.tsx
+++ b/src/Component/Rule/NameField/NameField.spec.tsx
@@ -1,0 +1,7 @@
+import NameField from './NameField';
+
+describe('NameField', () => {
+  it('is defined', () => {
+    expect(NameField).toBeDefined();
+  });
+});

--- a/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
@@ -1,7 +1,26 @@
 import RemoveButton from './RemoveButton';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('RemoveButton', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    wrapper = TestUtil.shallowRenderComponent(RemoveButton, {
+      ruleIdx: 1,
+      onClick: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(RemoveButton).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
@@ -1,0 +1,7 @@
+import RemoveButton from './RemoveButton';
+
+describe('RemoveButton', () => {
+  it('is defined', () => {
+    expect(RemoveButton).toBeDefined();
+  });
+});

--- a/src/Component/Rule/Rule.spec.tsx
+++ b/src/Component/Rule/Rule.spec.tsx
@@ -1,7 +1,29 @@
 import Rule from './Rule';
+import TestUtil from '../../Util/TestUtil';
 
 describe('Rule', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    const dummyData = TestUtil.getDummyGsData();
+    wrapper = TestUtil.shallowRenderComponent(Rule, {
+      keyIndex: 0,
+      internalDataDef: dummyData,
+      onRuleChange: dummyFn,
+      onRemove: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(Rule).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Rule/Rule.spec.tsx
+++ b/src/Component/Rule/Rule.spec.tsx
@@ -1,0 +1,7 @@
+import Rule from './Rule';
+
+describe('Rule', () => {
+  it('is defined', () => {
+    expect(Rule).toBeDefined();
+  });
+});

--- a/src/Component/Rule/TitleField/TitleField.spec.tsx
+++ b/src/Component/Rule/TitleField/TitleField.spec.tsx
@@ -1,7 +1,25 @@
 import TitleField from './TitleField';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('TitleField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+    wrapper = TestUtil.shallowRenderComponent(TitleField, {
+      onChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(TitleField).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Rule/TitleField/TitleField.spec.tsx
+++ b/src/Component/Rule/TitleField/TitleField.spec.tsx
@@ -1,0 +1,7 @@
+import TitleField from './TitleField';
+
+describe('TitleField', () => {
+  it('is defined', () => {
+    expect(TitleField).toBeDefined();
+  });
+});

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
@@ -1,0 +1,7 @@
+import MaxScaleDenominator from './MaxScaleDenominator';
+
+describe('MaxScaleDenominator', () => {
+  it('is defined', () => {
+    expect(MaxScaleDenominator).toBeDefined();
+  });
+});

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
@@ -1,7 +1,27 @@
 import MaxScaleDenominator from './MaxScaleDenominator';
+import TestUtil from '../../Util/TestUtil';
 
 describe('MaxScaleDenominator', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+
+    wrapper = TestUtil.shallowRenderComponent(MaxScaleDenominator, {
+      value: 0,
+      onChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(MaxScaleDenominator).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
@@ -1,0 +1,7 @@
+import MinScaleDenominator from './MinScaleDenominator';
+
+describe('MinScaleDenominator', () => {
+  it('is defined', () => {
+    expect(MinScaleDenominator).toBeDefined();
+  });
+});

--- a/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
@@ -1,7 +1,27 @@
 import MinScaleDenominator from './MinScaleDenominator';
+import TestUtil from '../../Util/TestUtil';
 
 describe('MinScaleDenominator', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+
+    wrapper = TestUtil.shallowRenderComponent(MinScaleDenominator, {
+      value: 0,
+      onChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(MinScaleDenominator).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
@@ -1,0 +1,7 @@
+import ScaleDenominator from './ScaleDenominator';
+
+describe('ScaleDenominator', () => {
+  it('is defined', () => {
+    expect(ScaleDenominator).toBeDefined();
+  });
+});

--- a/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
@@ -1,7 +1,28 @@
 import ScaleDenominator from './ScaleDenominator';
+import TestUtil from '../../Util/TestUtil';
 
 describe('ScaleDenominator', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    let i = 0;
+    const dummyFn = () => {
+      i = i + 1;
+    };
+
+    wrapper = TestUtil.shallowRenderComponent(ScaleDenominator, {
+      minScaleDenom: 0,
+      maxScaleDenom: 1000,
+      onChange: dummyFn
+    });
+  });
+
   it('is defined', () => {
     expect(ScaleDenominator).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -1,0 +1,7 @@
+import Preview from './Preview';
+
+describe('Preview', () => {
+  it('is defined', () => {
+    expect(Preview).toBeDefined();
+  });
+});

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -1,7 +1,18 @@
 import Preview from './Preview';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('Preview', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(Preview, {});
+  });
+
   it('is defined', () => {
     expect(Preview).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
   });
 });

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -16,4 +16,3 @@ describe('Preview', () => {
     expect(wrapper).not.toBeUndefined();
   });
 });
-

--- a/src/Component/UploadButton/UploadButton.spec.tsx
+++ b/src/Component/UploadButton/UploadButton.spec.tsx
@@ -1,0 +1,7 @@
+import UploadButton from './UploadButton';
+
+describe('UploadButton', () => {
+  it('is defined', () => {
+    expect(UploadButton).toBeDefined();
+  });
+});

--- a/src/Component/UploadButton/UploadButton.spec.tsx
+++ b/src/Component/UploadButton/UploadButton.spec.tsx
@@ -1,7 +1,19 @@
 import UploadButton from './UploadButton';
+import TestUtil from '../../Util/TestUtil';
 
 describe('UploadButton', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(UploadButton, {});
+  });
+
   it('is defined', () => {
     expect(UploadButton).toBeDefined();
   });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
 });

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+
+/**
+ * A set of some useful static helper methods.
+ *
+ * @class
+ */
+export class TestUtil {
+
+  /**
+   * Mounts the given component.
+   *
+   * @param {Component} Component The Component to render.
+   * @param {Object} props The props to be used.
+   * @param {Object} options The options to be set.
+   */
+  static mountComponent = (Component: any, props?: any, options?: any) => {
+    const wrapper = mount(<Component {...props} />, options);
+    return wrapper;
+  }
+
+  /**
+   * Shallow rendering for the given component.
+   * Useful for testing components as a unit, and to ensure that your tests
+   * aren't indirectly asserting on behavior of child components.
+   *
+   * @param {Component} Component The Component to render.
+   * @param {Object} props The props to be used.
+   * @param {Object} options The options to be set.
+   */
+  static shallowRenderComponent = (Component: any, props?: any, options?: any) => {
+    const wrapper = shallow(<Component {...props} />, options);
+    return wrapper;
+  }
+
+  /**
+   *
+   */
+  static getDummyGsData = () => {
+    return {
+      schema: {
+        properties: {
+          foo: {
+            type: 'number',
+            min: 1,
+            max: 1
+          },
+          bar: {
+            type: 'string',
+          }
+        }
+      },
+      exampleFeatures: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              foo: 1
+            },
+            geometry: {
+              type: 'Point',
+              coordinates: [0, 0]
+            }
+          }
+        ]
+      }
+    };
+  }
+}
+
+export default TestUtil;

--- a/src/app/Demo/DataProvider/DataProviderUi.spec.tsx
+++ b/src/app/Demo/DataProvider/DataProviderUi.spec.tsx
@@ -1,19 +1,18 @@
-import RuleDemo from './RuleDemo';
+import DataProviderUi from './DataProviderUi';
 import TestUtil from '../../../Util/TestUtil';
 
-describe('RuleDemo', () => {
+describe('FilterDemo', () => {
 
   let wrapper: any;
   beforeEach(() => {
-    wrapper = TestUtil.shallowRenderComponent(RuleDemo, {});
+    wrapper = TestUtil.shallowRenderComponent(DataProviderUi, {});
   });
 
   it('is defined', () => {
-    expect(RuleDemo).toBeDefined();
+    expect(DataProviderUi).toBeDefined();
   });
 
   it('renders correctly', () => {
     expect(wrapper).not.toBeUndefined();
   });
-
 });

--- a/src/app/Demo/FilterUi/FilterDemo.spec.tsx
+++ b/src/app/Demo/FilterUi/FilterDemo.spec.tsx
@@ -1,0 +1,7 @@
+import FilterDemo from './FilterDemo';
+
+describe('FilterDemo', () => {
+  it('is defined', () => {
+    expect(FilterDemo).toBeDefined();
+  });
+});

--- a/src/app/Demo/FilterUi/FilterDemo.spec.tsx
+++ b/src/app/Demo/FilterUi/FilterDemo.spec.tsx
@@ -1,7 +1,18 @@
 import FilterDemo from './FilterDemo';
+import TestUtil from '../../../Util/TestUtil';
 
 describe('FilterDemo', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(FilterDemo, {});
+  });
+
   it('is defined', () => {
     expect(FilterDemo).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
   });
 });

--- a/src/app/Demo/Rule/RuleDemo.spec.tsx
+++ b/src/app/Demo/Rule/RuleDemo.spec.tsx
@@ -1,0 +1,7 @@
+import RuleDemo from './RuleDemo';
+
+describe('RuleDemo', () => {
+  it('is defined', () => {
+    expect(RuleDemo).toBeDefined();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
This adds a util class for useful static unit test helper methods. Herewith ``enzyme`` and the corresponding ``enzyme-react-adapter`` are added as dev-dependency and are setup correctly.

Also adds basic rendering unit tests for the UI components.