### PR TITLE
Cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@types/react-dom": "16.0.5",
     "canvas-prebuilt": "1.6.5-prerelease.1",
     "copyfiles": "2.0.0",
-    "geostyler-data": "git+https://github.com/terrestris/geostyler-data.git",
     "np": "2.20.1",
     "react-styleguidist": "7.0.14",
     "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "antd": "3.5.3",
     "geostyler-data": "0.1.0",
     "geostyler-geojson-parser": "0.1.4",
-    "geostyler-style": "0.2.1",
+    "geostyler-style": "0.3.0",
     "openlayers": "4.6.5",
     "react": "16.4.0",
     "react-dom": "16.4.0",


### PR DESCRIPTION
This introduces minor adaptations to the dependecies in the package.json:

  - Upgrades ``geostyler-style`` to v0.3.0
  - Removes the ``geostyler-data`` from ``devDependencies`` since it is already managed as ``dependency``