### PR TITLE
 Introduces basic Symbolizer Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /coverage
 
 # production
+/dist
 /build
 
 # misc

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,30 @@
         }
       }
     },
+    "@types/color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
+      "dev": true,
+      "requires": {
+        "@types/color-convert": "1.9.0"
+      }
+    },
+    "@types/color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "1.1.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.0.tgz",
+      "integrity": "sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==",
+      "dev": true
+    },
     "@types/geojson": {
       "version": "7946.0.3",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
@@ -72,6 +96,15 @@
       "dev": true,
       "requires": {
         "csstype": "2.5.1"
+      }
+    },
+    "@types/react-color": {
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-2.13.5.tgz",
+      "integrity": "sha512-MShVbkZSUs/IJiaYDvZ7gubK1+T2CEGSFwImtOAc3PVLqvR5aQdbwaGZ1hYkKmQAC55eCoQ9BQTHJASyNWjvjw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "16.3.12"
       }
     },
     "@types/react-dom": {
@@ -2393,13 +2426,12 @@
       }
     },
     "color": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "clone": "1.0.4",
         "color-convert": "1.9.1",
-        "color-string": "0.3.0"
+        "color-string": "1.5.2"
       }
     },
     "color-convert": {
@@ -2416,11 +2448,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
       }
     },
     "colormin": {
@@ -2431,6 +2464,26 @@
         "color": "0.11.4",
         "css-color-names": "0.0.4",
         "has": "1.0.1"
+      },
+      "dependencies": {
+        "color": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+          "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+          "requires": {
+            "clone": "1.0.4",
+            "color-convert": "1.9.1",
+            "color-string": "0.3.0"
+          }
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        }
       }
     },
     "colors": {
@@ -2523,7 +2576,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
         "accepts": "1.3.5",
@@ -8992,6 +9045,11 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
+    "material-colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.5.tgz",
+      "integrity": "sha1-UpJZPmdUyxvMK5gDDk4Najr8nqE="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -12237,9 +12295,9 @@
       }
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
+      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -12252,6 +12310,18 @@
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-4.3.0.tgz",
       "integrity": "sha512-tC0n9CHgrQYc976pUlKOaVJYEHAAYTVMers04gNy6jbkFf4rbPlw72y7bbOAfkHHvu6COG5S629Fek30bvHe8w==",
       "dev": true
+    },
+    "react-color": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
+      "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
+      "requires": {
+        "lodash": "4.17.10",
+        "material-colors": "1.2.5",
+        "prop-types": "15.6.0",
+        "reactcss": "1.2.3",
+        "tinycolor2": "1.4.1"
+      }
     },
     "react-dev-utils": {
       "version": "5.0.1",
@@ -12356,9 +12426,9 @@
       }
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
+      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -13122,6 +13192,14 @@
             "camelcase": "3.0.0"
           }
         }
+      }
+    },
+    "reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "requires": {
+        "lodash": "4.17.10"
       }
     },
     "read-pkg": {
@@ -14062,6 +14140,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+          "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -14900,6 +14993,11 @@
       "requires": {
         "setimmediate": "1.0.5"
       }
+    },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "homepage": "https://github.com/terrestris/geostyler#readme",
   "dependencies": {
     "antd": "3.5.3",
+    "color": "3.0.0",
     "geostyler-data": "0.1.0",
     "geostyler-geojson-parser": "0.1.4",
     "geostyler-style": "0.2.1",
     "openlayers": "4.6.5",
     "react": "16.4.0",
+    "react-color": "2.14.1",
     "react-dom": "16.4.0",
     "react-scripts-ts": "2.16.0"
   },
@@ -40,11 +42,13 @@
     "release": "np --no-yarn"
   },
   "devDependencies": {
+    "@types/color": "3.0.0",
     "@types/geojson": "7946.0.3",
     "@types/jest": "22.2.3",
     "@types/node": "10.1.2",
     "@types/ol": "4.6.1",
     "@types/react": "16.3.12",
+    "@types/react-color": "2.13.5",
     "@types/react-dom": "16.0.5",
     "np": "2.20.1",
     "react-styleguidist": "7.0.14",

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -36,6 +36,7 @@ interface RuleState {
   maxScale: number | undefined;
   minScale: number | undefined;
   symbolizer: GsSymbolizer;
+  symbolizerEditorVisible: boolean;
 }
 
 /**
@@ -47,26 +48,26 @@ class Rule extends React.Component<RuleProps, RuleState> {
     super(props);
 
     const defaultSymb: GsSymbolizer = {
-      kind: 'Line'
+      kind: 'Circle'
     };
 
     if (this.props.rule) {
-
       this.state = {
         name: this.props.rule.name,
         filter: this.props.rule.filter ? this.props.rule.filter : undefined,
         maxScale: this.props.rule.scaleDenominator ? this.props.rule.scaleDenominator.max : undefined,
         minScale: this.props.rule.scaleDenominator ? this.props.rule.scaleDenominator.min : undefined,
-        symbolizer: this.props.rule.symbolizer ? this.props.rule.symbolizer : defaultSymb
+        symbolizer: this.props.rule.symbolizer ? this.props.rule.symbolizer : defaultSymb,
+        symbolizerEditorVisible: false
       };
-
     } else {
       this.state = {
         name: '',
         filter: undefined,
         maxScale: undefined,
         minScale: undefined,
-        symbolizer: defaultSymb
+        symbolizer: defaultSymb,
+        symbolizerEditorVisible: false
       };
     }
 
@@ -103,9 +104,15 @@ class Rule extends React.Component<RuleProps, RuleState> {
   /**
    * Handles changing rule symbolizer
    */
-  onSymbolizerChange = (changedSymb: GsSymbolizer) => {
-    this.setState({symbolizer: changedSymb}, () => {
+  onSymbolizerChange = (symbolizer: GsSymbolizer) => {
+    this.setState({symbolizer}, () => {
       this.createGsRule();
+    });
+  }
+
+  onEditPreviewButtonClicked = () => {
+    this.setState({
+      symbolizerEditorVisible: !this.state.symbolizerEditorVisible
     });
   }
 
@@ -128,48 +135,45 @@ class Rule extends React.Component<RuleProps, RuleState> {
   }
 
   render() {
+    const {
+      filter,
+      name,
+      minScale,
+      maxScale,
+      symbolizer
+    } = this.state;
+
     // cast the current filter object to pass over to ComparisonFilterUi
-    const cmpFilter = this.state.filter as GsComparisonFilter;
+    const cmpFilter = filter as GsComparisonFilter;
+
     // cast to GeoStyler compliant data model
     const gsData = this.props.internalDataDef as GsData;
 
     return (
       <div className="gs-rule" >
-
         <Row gutter={16}>
-
           <Col span={12}>
-
-            <RuleNameField value={this.state.name} onChange={this.onNameChange} />
-
+            <RuleNameField value={name} onChange={this.onNameChange} />
           </Col>
-
           <Col span={12}>
-
             <Fieldset title="Use Scale">
               <ScaleDenominator
-                minScaleDenom={this.state.minScale}
-                maxScaleDenom={this.state.maxScale}
+                minScaleDenom={minScale}
+                maxScaleDenom={maxScale}
                 onChange={this.onScaleDenomChange}
               />
             </Fieldset>
-
           </Col>
-
         </Row>
-
         <Row gutter={16}>
-
           <Col span={12}>
             <Preview
-              symbolizer={this.state.symbolizer}
+              symbolizer={symbolizer}
               features={gsData.exampleFeatures}
               onSymbolizerChange={this.onSymbolizerChange}
             />
           </Col>
-
           <Col span={12}>
-
             <Fieldset title="Use Filter">
               <ComparisonFilterUi
                 internalDataDef={this.props.internalDataDef}
@@ -177,17 +181,13 @@ class Rule extends React.Component<RuleProps, RuleState> {
                 onFilterChange={this.onFilterChange}
               />
             </Fieldset>
-
           </Col>
-
         </Row>
-
         <Row>
           <Col span={24} style={{ float: 'right' }} >
             <RuleRemoveButton ruleIdx={this.props.keyIndex} onClick={this.props.onRemove} />
           </Col>
         </Row>
-
       </div>
     );
   }

--- a/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
+++ b/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
@@ -11,7 +11,14 @@ import RadiusField from '../Field/RadiusField/RadiusField';
 import WidthField from '../Field/WidthField/WidthField';
 
 // default props
-interface DefaultCircleEditorProps {}
+interface DefaultCircleEditorProps {
+  radiusLabel: string;
+  fillOpacityLabel: string;
+  fillColorLabel: string;
+  strokeColorLabel: string;
+  strokeWidthLabel: string;
+  strokeOpacityLabel: string;
+}
 
 // non default props
 interface CircleEditorProps extends Partial<DefaultCircleEditorProps> {
@@ -19,22 +26,16 @@ interface CircleEditorProps extends Partial<DefaultCircleEditorProps> {
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
 }
 
-// state
-interface CircleEditorState {
-  symbolizer: CircleSymbolizer;
-}
-
-class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState> {
+class CircleEditor extends React.Component<CircleEditorProps, {}> {
 
   public static defaultProps: DefaultCircleEditorProps = {
+    radiusLabel: 'Radius',
+    fillOpacityLabel: 'Fill-Opacity',
+    fillColorLabel: 'Fill-Color',
+    strokeColorLabel: 'Stroke-Color',
+    strokeWidthLabel: 'Stroke-Width',
+    strokeOpacityLabel: 'Stroke-Opacity'
   };
-
-  static getDerivedStateFromProps(nextProps: CircleEditorProps, prevState: CircleEditorState): CircleEditorState {
-    return {
-      symbolizer: nextProps.symbolizer,
-      ...prevState
-    };
-  }
 
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
@@ -42,21 +43,28 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
 
   render() {
     const {
-      symbolizer
-    } = this.state;
+      symbolizer,
+      radiusLabel,
+      fillOpacityLabel,
+      fillColorLabel,
+      strokeColorLabel,
+      strokeWidthLabel,
+      strokeOpacityLabel
+    } = this.props;
 
     const {
-    radius,
-    opacity,
-    color,
-    strokeOpacity,
-    strokeColor,
-    strokeWidth
-    } = this.props.symbolizer;
+      radius,
+      opacity,
+      color,
+      strokeOpacity,
+      strokeColor,
+      strokeWidth
+    } = symbolizer;
 
     return (
       <div className="gs-circle-symbolizer-editor" >
         <RadiusField
+          label={radiusLabel}
           radius={radius}
           onChange={(value: number) => {
             symbolizer.radius = value;
@@ -65,7 +73,7 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
         />
         <ColorField
           color={color}
-          label="Fill-Color"
+          label={fillColorLabel}
           onChange={(value: string) => {
             symbolizer.color = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -73,7 +81,7 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
         />
         <OpacityField
           opacity={opacity}
-          label="Fill-Opacity"
+          label={fillOpacityLabel}
           onChange={(value: number) => {
             symbolizer.opacity = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -81,7 +89,7 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
         />
         <ColorField
           color={strokeColor}
-          label="Stroke-Color"
+          label={strokeColorLabel}
           onChange={(value: string) => {
             symbolizer.strokeColor = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -89,7 +97,7 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
         />
         <WidthField
           width={strokeWidth}
-          label="Stroke-Width"
+          label={strokeWidthLabel}
           onChange={(value: number) => {
             symbolizer.strokeWidth = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -97,7 +105,7 @@ class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState>
         />
         <OpacityField
           opacity={strokeOpacity}
-          label="Stroke-Opacity"
+          label={strokeOpacityLabel}
           onChange={(value: number) => {
             symbolizer.strokeOpacity = value;
             this.props.onSymbolizerChange(symbolizer);

--- a/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
+++ b/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  CircleSymbolizer
+} from 'geostyler-style';
+
+import ColorField from '../Field/ColorField/ColorField';
+import OpacityField from '../Field/OpacityField/OpacityField';
+import RadiusField from '../Field/RadiusField/RadiusField';
+import WidthField from '../Field/WidthField/WidthField';
+
+// default props
+interface DefaultCircleEditorProps {}
+
+// non default props
+interface CircleEditorProps extends Partial<DefaultCircleEditorProps> {
+  symbolizer: CircleSymbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+}
+
+// state
+interface CircleEditorState {
+  symbolizer: CircleSymbolizer;
+}
+
+class CircleEditor extends React.Component<CircleEditorProps, CircleEditorState> {
+
+  public static defaultProps: DefaultCircleEditorProps = {
+  };
+
+  static getDerivedStateFromProps(nextProps: CircleEditorProps, prevState: CircleEditorState): CircleEditorState {
+    return {
+      symbolizer: nextProps.symbolizer,
+      ...prevState
+    };
+  }
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  render() {
+    const {
+      symbolizer
+    } = this.state;
+
+    const {
+    radius,
+    opacity,
+    color,
+    strokeOpacity,
+    strokeColor,
+    strokeWidth
+    } = this.props.symbolizer;
+
+    return (
+      <div className="gs-circle-symbolizer-editor" >
+        <RadiusField
+          radius={radius}
+          onChange={(value: number) => {
+            symbolizer.radius = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <ColorField
+          color={color}
+          label="Fill-Color"
+          onChange={(value: string) => {
+            symbolizer.color = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={opacity}
+          label="Fill-Opacity"
+          onChange={(value: number) => {
+            symbolizer.opacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <ColorField
+          color={strokeColor}
+          label="Stroke-Color"
+          onChange={(value: string) => {
+            symbolizer.strokeColor = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <WidthField
+          width={strokeWidth}
+          label="Stroke-Width"
+          onChange={(value: number) => {
+            symbolizer.strokeWidth = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={strokeOpacity}
+          label="Stroke-Opacity"
+          onChange={(value: number) => {
+            symbolizer.strokeOpacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default CircleEditor;

--- a/src/Component/Symbolizer/Editor/Editor.css
+++ b/src/Component/Symbolizer/Editor/Editor.css
@@ -1,0 +1,18 @@
+.gs-symbolizer-editor {
+  background-color: white;
+  border: 1px solid lightgrey;
+  padding: 5px;
+}
+
+.editor-field {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 5px;
+}
+
+.editor-field > .label {
+  margin-right: 10px;
+  width: 140px;
+  text-align: right;
+}

--- a/src/Component/Symbolizer/Editor/Editor.spec.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.spec.tsx
@@ -1,0 +1,9 @@
+import Editor from './Editor';
+
+describe('SymbolizerEditor', () => {
+
+  it('is defined', () => {
+    expect(Editor).toBeDefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+
+import * as ol from 'openlayers';
+
+import {
+  Symbolizer
+} from 'geostyler-style';
+
+import CircleEditor from '../CircleEditor/CircleEditor';
+
+import './Editor.css';
+
+import 'openlayers/css/ol.css';
+
+// default props
+interface DefaultEditorProps {}
+
+// non default props
+interface EditorProps extends Partial<DefaultEditorProps> {
+  symbolizer: Symbolizer;
+  onSymbolizerChange: (symbolizer: Symbolizer) => void;
+}
+
+// state
+interface EditorState {
+  symbolizer: Symbolizer;
+  colorPickerVisible: boolean;
+}
+
+class Editor extends React.Component<EditorProps, EditorState> {
+
+  /** reference to the underlying OpenLayers map */
+  map: ol.Map;
+
+  /** refrence to the vector layer for the passed in features  */
+  dataLayer: ol.layer.Vector;
+
+  public static defaultProps: DefaultEditorProps = {
+  };
+
+  static getDerivedStateFromProps(nextProps: EditorProps, prevState: EditorState): EditorState {
+    return {
+      symbolizer: nextProps.symbolizer,
+      colorPickerVisible: false
+    };
+  }
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  getUiFromSymbolizer = (symbolizer: Symbolizer): React.ReactNode => {
+    const {
+      // colorPickerVisible
+    } = this.state;
+    switch (symbolizer.kind) {
+      case 'Circle':
+        return (
+          <CircleEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
+          />
+        );
+      default:
+        return `Symbolizer kind ${symbolizer.kind} not yet supported!`;
+    }
+  }
+
+  render() {
+    return (
+      <div className="gs-symbolizer-editor" >
+        {this.getUiFromSymbolizer(this.props.symbolizer)}
+      </div>
+    );
+  }
+}
+
+export default Editor;

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.css
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.css
@@ -1,0 +1,8 @@
+.sketch-picker {
+  position: absolute;
+  z-index: 200;
+}
+
+.color-preview {
+  width: 90px;
+}

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import * as Color from 'color';
+import {
+  SketchPicker,
+  ColorResult
+} from 'react-color';
+
+import {
+  Button
+} from 'antd';
+
+import './ColorField.css';
+
+// default props
+interface ColorFieldDefaultProps {
+  color: string;
+  closeText: string;
+  editText: string;
+  label: string;
+}
+
+// non default props
+interface ColorFieldProps extends Partial<ColorFieldDefaultProps> {
+  onChange: ((color: string) => void);
+}
+
+// state
+interface ColorFieldState {
+  colorPickerVisible: boolean;
+}
+
+/**
+ * ColorField
+ */
+class ColorField extends React.Component<ColorFieldProps, ColorFieldState> {
+
+  public static defaultProps: ColorFieldDefaultProps = {
+    color: '#AA1337',
+    closeText: 'Close',
+    editText: 'Change',
+    label: 'Color'
+  };
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      colorPickerVisible: false
+    };
+  }
+
+  onColorPreviewClick = () => {
+    this.setState({
+      colorPickerVisible: !this.state.colorPickerVisible
+    });
+  }
+
+  render() {
+    const {
+      colorPickerVisible = false
+    } = this.state;
+
+    const {
+      color,
+      closeText,
+      editText,
+      label
+    } = this.props;
+
+    const textColor = Color(color).negate().grayscale().string();
+
+    return (
+      <div className="editor-field color-field">
+        <span className="label">{`${label}:`}</span>
+        <div className="color-preview-wrapper">
+          <Button
+            className="color-preview"
+            style={{
+              backgroundColor: color,
+              color: textColor
+            }}
+            onClick={this.onColorPreviewClick}
+          >
+            {colorPickerVisible ? closeText : editText}
+          </Button>
+          {
+            colorPickerVisible ?
+            <SketchPicker
+              color={color}
+              disableAlpha={true}
+              onChangeComplete={(colorResult: ColorResult) => {
+                this.props.onChange(colorResult.hex);
+              }}
+            /> : null
+          }
+          </div>
+      </div>
+    );
+  }
+}
+
+export default ColorField;

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface OpacityFieldDefaultProps {
+  opacity: number;
+  label: string;
+}
+
+// non default props
+interface OpacityFieldProps extends Partial<OpacityFieldDefaultProps> {
+  onChange: ((opacity: number) => void);
+}
+
+/**
+ * OpacityField
+ */
+class OpacityField extends React.Component<OpacityFieldProps, {}> {
+
+  public static defaultProps: OpacityFieldDefaultProps = {
+    opacity: 1,
+    label: 'Opacity'
+  };
+
+  render() {
+    const {
+      opacity,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field opacity-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          min={0}
+          max={1}
+          step={0.01}
+          defaultValue={opacity}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default OpacityField;

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface RadiusFieldDefaultProps {
+  radius: number;
+  label: string;
+}
+
+// non default props
+interface RadiusFieldProps extends Partial<RadiusFieldDefaultProps> {
+  onChange: ((radius: number) => void);
+}
+
+/**
+ * RadiusField
+ */
+class RadiusField extends React.Component<RadiusFieldProps, {}> {
+
+  public static defaultProps: RadiusFieldDefaultProps = {
+    radius: 10,
+    label: 'Radius'
+  };
+
+  render() {
+    const {
+      radius,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field radius-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          min={0}
+          defaultValue={radius}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default RadiusField;

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface WidthFieldDefaultProps {
+  width: number;
+  label: string;
+}
+
+// non default props
+interface WidthFieldProps extends Partial<WidthFieldDefaultProps> {
+  onChange: ((radius: number) => void);
+}
+
+/**
+ * WidthField
+ */
+class WidthField extends React.Component<WidthFieldProps, {}> {
+
+  public static defaultProps: WidthFieldDefaultProps = {
+    width: 2,
+    label: 'Width'
+  };
+
+  render() {
+    const {
+      width,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field width-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          min={0}
+          defaultValue={width}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default WidthField;

--- a/src/Component/Symbolizer/Preview/Preview.css
+++ b/src/Component/Symbolizer/Preview/Preview.css
@@ -6,3 +6,10 @@
 .gs-symbolizer-preview .map {
   border: 1px solid lightgrey;
 }
+
+.gs-edit-preview-button {
+  position: absolute;
+  right: 10px;
+  bottom: 2px;
+  z-index: 1;
+}

--- a/src/app/Demo/Rule/RuleDemo.tsx
+++ b/src/app/Demo/Rule/RuleDemo.tsx
@@ -154,14 +154,11 @@ class RuleDemo extends React.Component<FilterDemoProps, FilterDemoState> {
 
     return (
       <div className="filter-demo-ui">
-
           <h2>Rule Demo</h2>
-
           <UploadButton
             style={{'marginBottom': '20px'}}
             onUpload={this.parseGeoJson}
           />
-
           {
             this.state.ruleUis.length > 0 ?
             <Button
@@ -173,7 +170,6 @@ class RuleDemo extends React.Component<FilterDemoProps, FilterDemoState> {
             /> :
             null
           }
-
           {
             this.state.ruleUis.map((ruleUi: any) => (
               <RuleUi
@@ -185,11 +181,14 @@ class RuleDemo extends React.Component<FilterDemoProps, FilterDemoState> {
               />
             ))
           }
-
           {
             this.state.ruleUis.length > 0 ?
             <Button
-              style={{'marginBottom': '20px', 'marginTop': '20px'}}
+              style={{
+                marginBottom: '20px',
+                marginTop: '20px',
+                position: 'inherit'
+              }}
               icon="enter"
               size="large"
               onClick={this.createStyle}
@@ -197,19 +196,21 @@ class RuleDemo extends React.Component<FilterDemoProps, FilterDemoState> {
             </Button> :
             null
           }
-
           {
             this.state.ruleUis.length > 0 ?
             <TextArea
               rows={16}
               value={this.state.gsStyleString}
-              style={{width: '99%', margin: '5px'}}
+              style={{
+                width: '99%',
+                margin: '5px',
+                position: 'inherit'
+              }}
               name="filter-style-ta"
               className="filter-style-ta"
             /> :
             null
           }
-
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,11 @@ import Rule from './Component/Rule/Rule';
 import MaxScaleDenominator from './Component/ScaleDenominator/MaxScaleDenominator';
 import MinScaleDenominator from './Component/ScaleDenominator/MinScaleDenominator';
 import Preview from './Component/Symbolizer/Preview/Preview';
+import Editor from './Component/Symbolizer/Editor/Editor';
+import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
+import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
+import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
+import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
 import UploadButton from './Component/UploadButton/UploadButton'
 
 export {
@@ -29,5 +34,10 @@ export {
   MaxScaleDenominator,
   MinScaleDenominator,
   Preview,
+  Editor,
+  ColorField,
+  OpacityField,
+  RadiusField,
+  WidthField,
   UploadButton
 };

--- a/tslint.json
+++ b/tslint.json
@@ -48,7 +48,7 @@
     ],
     "no-consecutive-blank-lines": true,
     "no-construct": true,
-    "no-debugger": true,
+    "no-debugger": false,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,


### PR DESCRIPTION
This introduces a basic Symoblizer Editor. It adds support for editing `CircleSymbolizer`s.
It includes some Field Components which can be reused with other Symbolizer-Editors.

It also adds some minor changes to the RuleDemo.
![symbolizer_editor](https://user-images.githubusercontent.com/1849416/40542331-15b4a170-6020-11e8-9d55-63524f2b9886.png)


Closes #74 
Closes #82 