### PR TITLE
Introduces the (live) CodeEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,6 @@
       "version": "16.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.12.tgz",
       "integrity": "sha512-FfBhLC3QeXXEtjoGGLixS7cB305vzBOM1dZKtbUuXeTfjY0quzRRMxpqylC4QyUaLqdhNLdER0ZdHUGAVlGSCA==",
-      "dev": true,
       "requires": {
         "csstype": "2.5.1"
       }
@@ -3372,8 +3371,7 @@
     "csstype": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.1.tgz",
-      "integrity": "sha512-qfG5lXkiUKz3kAuABSlpRxL9QL/U8ViJiXC6hvk/7tEJaCj7a2ZOW2kVtSFGpETOfQR7MicXjf/q1bmO1iShiA==",
-      "dev": true
+      "integrity": "sha512-qfG5lXkiUKz3kAuABSlpRxL9QL/U8ViJiXC6hvk/7tEJaCj7a2ZOW2kVtSFGpETOfQR7MicXjf/q1bmO1iShiA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -10123,6 +10121,11 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
+    "monaco-editor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.13.1.tgz",
+      "integrity": "sha512-0Kssg/O3cl1tXP0qAIxhrtMbRnzusFUEvFyt5/fpUbmuVeY3z+TnUx13+3kW16pgacFPXGUTEO/hOPlDeFU/dw=="
+    },
     "mout": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
@@ -13698,6 +13701,28 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-monaco-editor": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.17.1.tgz",
+      "integrity": "sha512-YI7PQWAgJfZh33hnALe6GpoflWYhWouZFozxHnMNPMaVn9g6WaFaUD7mY/QTslfVQbqwl9vNVVnWIjLFMMNv4w==",
+      "requires": {
+        "@types/react": "16.3.12",
+        "monaco-editor": "0.13.1",
+        "prop-types": "15.6.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "react-reconciler": {
       "version": "0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,11 @@
       "integrity": "sha512-+T9qBbqe/jXtTjzVddArZExahoPPmt8eq3O1ZuCKZXjBVxf/ciUYNXrIDZJEVgYvpELnv6VlPRCfLzufRxpAag==",
       "dev": true
     },
+    "@types/codemirror": {
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.56.tgz",
+      "integrity": "sha512-OMtPqg2wFOEcNeVga+m+UXpYJw8ugISPCQOtShdFUho/k91Ms1oWOozoDT1I87Phv6IdwLfMLtIOahh1tO1cJQ=="
+    },
     "@types/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
@@ -122,6 +127,7 @@
       "version": "16.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.12.tgz",
       "integrity": "sha512-FfBhLC3QeXXEtjoGGLixS7cB305vzBOM1dZKtbUuXeTfjY0quzRRMxpqylC4QyUaLqdhNLdER0ZdHUGAVlGSCA==",
+      "dev": true,
       "requires": {
         "csstype": "2.5.1"
       }
@@ -2522,8 +2528,7 @@
     "codemirror": {
       "version": "5.38.0",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.38.0.tgz",
-      "integrity": "sha512-PEPnDg8U3DTGFB/Dn2T/INiRNC9CB5k2vLAQJidYCsHvAgtXbklqnuidEwx7yGrMrdGhl0L0P3iNKW9I07J6tQ==",
-      "dev": true
+      "integrity": "sha512-PEPnDg8U3DTGFB/Dn2T/INiRNC9CB5k2vLAQJidYCsHvAgtXbklqnuidEwx7yGrMrdGhl0L0P3iNKW9I07J6tQ=="
     },
     "collapse-white-space": {
       "version": "1.0.4",
@@ -3371,7 +3376,8 @@
     "csstype": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.1.tgz",
-      "integrity": "sha512-qfG5lXkiUKz3kAuABSlpRxL9QL/U8ViJiXC6hvk/7tEJaCj7a2ZOW2kVtSFGpETOfQR7MicXjf/q1bmO1iShiA=="
+      "integrity": "sha512-qfG5lXkiUKz3kAuABSlpRxL9QL/U8ViJiXC6hvk/7tEJaCj7a2ZOW2kVtSFGpETOfQR7MicXjf/q1bmO1iShiA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -10121,11 +10127,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
-    "monaco-editor": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.13.1.tgz",
-      "integrity": "sha512-0Kssg/O3cl1tXP0qAIxhrtMbRnzusFUEvFyt5/fpUbmuVeY3z+TnUx13+3kW16pgacFPXGUTEO/hOPlDeFU/dw=="
-    },
     "mout": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
@@ -13521,10 +13522,9 @@
       }
     },
     "react-codemirror2": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-4.3.0.tgz",
-      "integrity": "sha512-tC0n9CHgrQYc976pUlKOaVJYEHAAYTVMers04gNy6jbkFf4rbPlw72y7bbOAfkHHvu6COG5S629Fek30bvHe8w==",
-      "dev": true
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-5.0.4.tgz",
+      "integrity": "sha512-qopJLZQDPI8zd901th7z5UCGukd3iOoSkdjtF9lpTxpTmG7U+hdF/FO9FgNoQTHLc9+kR/taZN23LDuJnQOOvw=="
     },
     "react-color": {
       "version": "2.14.1",
@@ -13701,28 +13701,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-monaco-editor": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.17.1.tgz",
-      "integrity": "sha512-YI7PQWAgJfZh33hnALe6GpoflWYhWouZFozxHnMNPMaVn9g6WaFaUD7mY/QTslfVQbqwl9vNVVnWIjLFMMNv4w==",
-      "requires": {
-        "@types/react": "16.3.12",
-        "monaco-editor": "0.13.1",
-        "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        }
-      }
     },
     "react-reconciler": {
       "version": "0.7.0",
@@ -14286,6 +14264,12 @@
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1"
           }
+        },
+        "react-codemirror2": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-4.3.0.tgz",
+          "integrity": "sha512-tC0n9CHgrQYc976pUlKOaVJYEHAAYTVMers04gNy6jbkFf4rbPlw72y7bbOAfkHHvu6COG5S629Fek30bvHe8w==",
+          "dev": true
         },
         "schema-utils": {
           "version": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/terrestris/geostyler#readme",
   "dependencies": {
     "antd": "3.5.4",
+    "codemirror": "5.38.0",
     "color": "3.0.0",
     "geostyler-data": "0.3.0",
     "geostyler-geojson-parser": "0.1.4",
@@ -31,6 +32,7 @@
     "geostyler-style": "0.5.0",
     "openlayers": "4.6.5",
     "react": "16.4.0",
+    "react-codemirror2": "5.0.4",
     "react-color": "2.14.1",
     "react-dom": "16.4.0",
     "react-scripts-ts": "2.16.0"
@@ -50,6 +52,7 @@
     "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags"
   },
   "devDependencies": {
+    "@types/codemirror": "0.0.56",
     "@types/color": "3.0.0",
     "@types/enzyme": "3.1.10",
     "@types/geojson": "7946.0.3",

--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -1,3 +1,8 @@
-textarea.ant-input.gs-code-editor{
+.gs-code-editor{
   height: 100%;
+  text-align: left;
+}
+
+.gs-code-editor .CodeMirror {
+  height: inherit;
 }

--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -6,3 +6,8 @@
 .gs-code-editor .CodeMirror {
   height: inherit;
 }
+
+.gs-code-editor-errormessage {
+  color: red;
+  background-color: lightgray;
+}

--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -1,10 +1,20 @@
 .gs-code-editor{
   height: 100%;
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.gs-code-editor .CodeMirror {
-  height: inherit;
+.gs-code-editor-codemirror {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+}
+
+.CodeMirror {
+  flex: 1;
 }
 
 .gs-code-editor-errormessage {

--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -1,0 +1,3 @@
+textarea.ant-input.gs-code-editor{
+  height: 100%;
+}

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import 'codemirror/lib/codemirror.css';
 
 import './CodeEditor.css';
 
@@ -7,9 +8,14 @@ import {
   StyleParserConstructable as GsStyleParserConstructable
 } from 'geostyler-style';
 
-// TODO Replace with monaco code editor
-import { Input } from 'antd';
-const { TextArea } = Input;
+// Favourite Editor should be Monaco Editor but its React Wrapper is currently
+// not very stable
+import {
+  UnControlled as CodeMirror
+} from 'react-codemirror2';
+
+require('codemirror/mode/xml/xml');
+require('codemirror/mode/javascript/javascript');
 
 // default props
 interface DefaultCodeEditorProps {
@@ -25,6 +31,7 @@ interface CodeEditorProps extends Partial<DefaultCodeEditorProps> {
 // state
 interface CodeEditorState {
   style: GsStyle;
+  invalid: boolean;
 }
 
 /**
@@ -39,7 +46,8 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
         name: 'Circle',
         type: 'Point',
         rules: []
-      }
+      },
+      invalid: false
     };
   }
 
@@ -59,9 +67,17 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
   /**
    *
    */
-  onChange = (evt: any) => {
-    const value = evt.target.value;
-    const style = JSON.parse(value);
+  onChange = (editor: any, data: any, value: string) => {
+    let style = this.state.style;
+    try {
+      style = JSON.parse(value);
+    } catch (error) {
+      // TODO improve this
+      this.setState({
+        invalid: true
+      });
+    }
+
     this.setState({
       style
     });
@@ -72,10 +88,16 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
 
   render() {
     const value = JSON.stringify(this.state.style, null, 2);
+
     return (
-      <TextArea
+      <CodeMirror
         className="gs-code-editor"
         value={value}
+        autoCursor={false}
+        options={{
+          mode: 'application/json',
+          lineNumbers: true
+        }}
         onChange={this.onChange}
       />
     );

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -167,8 +167,8 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
   render() {
     const value = this.state.value;
     return (
-      <div>
-        <div>
+      <div className="gs-code-editor">
+        <div className="gs-code-editor-format-select">
           Format: <Select
             style={{ width: 300 }}
             onSelect={this.onSelect}
@@ -178,7 +178,7 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
           </Select>
         </div>
         <CodeMirror
-          className="gs-code-editor"
+          className="gs-code-editor-codemirror"
           value={value}
           autoCursor={false}
           options={{

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -42,7 +42,7 @@ interface CodeEditorState {
 }
 
 /**
- * Button to upload / import geodata file.
+ * The CodeEditor.
  */
 class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
 

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+import './CodeEditor.css';
+
+import {
+  Style as GsStyle,
+  StyleParserConstructable as GsStyleParserConstructable
+} from 'geostyler-style';
+
+// TODO Replace with monaco code editor
+import { Input } from 'antd';
+const { TextArea } = Input;
+
+// default props
+interface DefaultCodeEditorProps {
+}
+
+// non default props
+interface CodeEditorProps extends Partial<DefaultCodeEditorProps> {
+  style?: GsStyle;
+  parsers: GsStyleParserConstructable[];
+  onStyleChange?: (rule: GsStyle) => void;
+}
+
+// state
+interface CodeEditorState {
+  style: GsStyle;
+}
+
+/**
+ * Button to upload / import geodata file.
+ */
+class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
+
+  constructor(props: CodeEditorProps) {
+    super(props);
+    this.state = {
+      style: {
+        name: 'Circle',
+        type: 'Point',
+        rules: []
+      }
+    };
+  }
+
+  static getDerivedStateFromProps(
+      nextProps: CodeEditorProps,
+      prevState: CodeEditorState): Partial<CodeEditorState> {
+    const newState: Partial<CodeEditorState> = {};
+    if (nextProps.style) {
+      newState.style = nextProps.style;
+    }
+    return newState;
+  }
+
+  public static defaultProps: DefaultCodeEditorProps = {
+  };
+
+  /**
+   *
+   */
+  onChange = (evt: any) => {
+    const value = evt.target.value;
+    const style = JSON.parse(value);
+    this.setState({
+      style
+    });
+    if (this.props.onStyleChange) {
+      this.props.onStyleChange(style);
+    }
+  }
+
+  render() {
+    const value = JSON.stringify(this.state.style, null, 2);
+    return (
+      <TextArea
+        className="gs-code-editor"
+        value={value}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+export default CodeEditor;

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
+
+// Favourite Editor should be Monaco Editor but its React Wrapper is currently
+// not very stable
+import {
+  UnControlled as CodeMirror
+} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/xml/xml';
+import 'codemirror/mode/javascript/javascript';
 
 import './CodeEditor.css';
 
@@ -8,14 +16,9 @@ import {
   StyleParserConstructable as GsStyleParserConstructable
 } from 'geostyler-style';
 
-// Favourite Editor should be Monaco Editor but its React Wrapper is currently
-// not very stable
 import {
-  UnControlled as CodeMirror
-} from 'react-codemirror2';
-
-require('codemirror/mode/xml/xml');
-require('codemirror/mode/javascript/javascript');
+  isEqual as _isEqual
+} from 'lodash';
 
 // default props
 interface DefaultCodeEditorProps {
@@ -24,14 +27,15 @@ interface DefaultCodeEditorProps {
 // non default props
 interface CodeEditorProps extends Partial<DefaultCodeEditorProps> {
   style?: GsStyle;
-  parsers: GsStyleParserConstructable[];
+  parser?: GsStyleParserConstructable;
   onStyleChange?: (rule: GsStyle) => void;
 }
 
 // state
 interface CodeEditorState {
-  style: GsStyle;
-  invalid: boolean;
+  value: string;
+  style?: GsStyle;
+  invalidMessage?: string;
 }
 
 /**
@@ -39,64 +43,111 @@ interface CodeEditorState {
  */
 class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
 
+  public static defaultProps: DefaultCodeEditorProps = {
+  };
+
   constructor(props: CodeEditorProps) {
     super(props);
     this.state = {
-      style: {
-        name: 'Circle',
-        type: 'Point',
-        rules: []
-      },
-      invalid: false
+      value: ''
     };
   }
 
-  static getDerivedStateFromProps(
-      nextProps: CodeEditorProps,
-      prevState: CodeEditorState): Partial<CodeEditorState> {
-    const newState: Partial<CodeEditorState> = {};
-    if (nextProps.style) {
-      newState.style = nextProps.style;
-    }
-    return newState;
+  static getDerivedStateFromProps(nextProps: CodeEditorProps) {
+    return {
+      style: nextProps.style
+    };
   }
 
-  public static defaultProps: DefaultCodeEditorProps = {
-  };
+  componentDidMount() {
+    if (this.props.style) {
+      this.updateValueFromStyle(this.props.style);
+    }
+  }
+
+  componentDidUpdate(prevProps: CodeEditorProps, prevState: CodeEditorState) {
+    if (this.props.style && !_isEqual(this.props.style, prevProps.style)) {
+      this.updateValueFromStyle(this.props.style);
+    }
+  }
+
+  updateValueFromStyle (style: GsStyle) {
+    this.valueFromStyleInput(style)
+      .then((parsedStyle: string) => {
+        this.setState({
+          value: parsedStyle
+        });
+      });
+  }
+
+  getModeByParser(): string {
+    if (this.props.parser && this.props.parser.name === 'SldStyleParser') {
+      return 'application/xml';
+    }
+    return 'application/json';
+  }
+
+  valueFromStyleInput(style: GsStyle) {
+    return new Promise((resolve, reject) => {
+      if (this.props.parser) {
+        const StyleParser = this.props.parser;
+        const parserInstance = new StyleParser();
+        resolve(parserInstance.writeStyle(style));
+      } else {
+        resolve(JSON.stringify(style, null, 2));
+      }
+    });
+  }
+
+  styleFromValue(value: string) {
+    return new Promise((resolve, reject) => {
+      if (this.props.parser) {
+        const StyleParser = this.props.parser;
+        const parserInstance = new StyleParser();
+        resolve(parserInstance.readStyle(value));
+      } else {
+        resolve(JSON.parse(value));
+      }
+    });
+  }
 
   /**
    *
    */
   onChange = (editor: any, data: any, value: string) => {
-    let style = this.state.style;
-    try {
-      style = JSON.parse(value);
-    } catch (error) {
-      // TODO improve this
-      this.setState({
-        invalid: true
-      });
-    }
-
+    let invalidMessage;
     this.setState({
-      style
+      value
     });
-    if (this.props.onStyleChange) {
-      this.props.onStyleChange(style);
+    try {
+      this.styleFromValue(value)
+        .then((style: GsStyle) => {
+          if (this.props.onStyleChange) {
+            this.props.onStyleChange(style);
+          }
+        }).catch(err => {debugger; });
+    } catch (error) {
+      invalidMessage = 'Error';
+    } finally {
+      this.setState({
+          invalidMessage
+      });
     }
   }
 
   render() {
-    const value = JSON.stringify(this.state.style, null, 2);
-
+    const value = this.state.value;
     return (
       <CodeMirror
         className="gs-code-editor"
         value={value}
         autoCursor={false}
         options={{
-          mode: 'application/json',
-          lineNumbers: true
+          gutters: ['CodeMirror-lint-markers'],
+          lint: true,
+          mode: this.getModeByParser(),
+          lineNumbers: true,
+          lineWrapping: true
         }}
         onChange={this.onChange}
       />

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { Select } from 'antd';
 const Option = Select.Option;
-import 'antd/dist/antd.css';
 
 import {
   Data as GsData,

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -32,9 +32,16 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
 
   constructor(props: AttributeComboProps) {
     super(props);
-
     this.state = {
       value: this.props.value
+    };
+  }
+
+  static getDerivedStateFromProps(
+     nextProps: AttributeComboProps,
+     prevState: AttributeComboState): Partial<AttributeComboState> {
+    return {
+      value: nextProps.value
     };
   }
 
@@ -78,7 +85,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
           {
             internalDataDef ?
               <Select
-                defaultValue={this.state.value}
+                value={this.state.value}
                 style={{ width: '100%' }}
                 onChange={onAttributeChange}
                 placeholder={placeholder}
@@ -87,7 +94,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
               </Select>
               :
               <Input
-                defaultValue={this.state.value}
+                value={this.state.value}
                 placeholder={placeholder}
                 style={{ width: '100%' }}
                 onChange={(event) => {

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -30,9 +30,16 @@ class BoolFilterField extends React.Component<BoolFilterFieldProps, BoolFilterFi
 
   constructor(props: BoolFilterFieldProps) {
     super(props);
-
     this.state = {
       value: this.props.value ? true : false
+    };
+  }
+
+  static getDerivedStateFromProps(
+      nextProps: BoolFilterFieldProps,
+      prevState: BoolFilterFieldState): Partial<BoolFilterFieldState> {
+    return {
+      value: nextProps.value
     };
   }
 

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -38,7 +38,7 @@ interface ComparisonFilterState {
   attributeType?: string;
   operator: ComparisonOperator | undefined;
   value: string | number | boolean | null;
-  filter: ComparisonFilter | undefined;
+  filter: ComparisonFilter;
 }
 
 /**
@@ -57,6 +57,10 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
       filter: nextProps.filter
     };
   }
+
+  public static defaultProps: DefaultComparisonFilterProps = {
+    filter: ['==', '', null]
+  };
 
   constructor(props: ComparisonFilterProps) {
     super(props);
@@ -105,7 +109,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         attribute: '',
         operator: undefined,
         value: null,
-        filter: undefined
+        filter: ComparisonFilterUi.defaultProps.filter
       };
     }
 
@@ -155,7 +159,8 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
       onFilterChange
     } = this.props;
 
-    let attrType;
+    let filter = this.state.filter;
+    filter[1] = newAttrName;
 
     const valueFieldVis = this.getValueFieldVis(newAttrName);
     this.setState(valueFieldVis);
@@ -163,32 +168,23 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
     if (internalDataDef) {
       // read out attribute type
       const attrDefs = internalDataDef.schema.properties;
-      attrType = attrDefs[newAttrName].type;
-
+      const attrType = attrDefs[newAttrName].type;
       this.setState({attribute: newAttrName});
-    }
 
-    // (re)create the ComparisonFilter object if all info are collected
-    if (this.state.operator && newAttrName && this.state.value) {
-      const compFilter: ComparisonFilter = [
-        this.state.operator, newAttrName, this.state.value
-      ];
-
-      if (internalDataDef) {
-        // reset the filter value when the attribute type changed
-        if (attrType !== this.state.attributeType) {
-          compFilter[2] = null;
-          this.setState({
-            value: null,
-            // preserve the attribute type to compare with new one
-            attributeType: attrType
-          });
-        }
+      // reset the filter value when the attribute type changed
+      if (attrType !== this.state.attributeType) {
+        this.setState({
+          value: null,
+          // preserve the attribute type to compare with new one
+          attributeType: attrType
+        });
       }
-
-      this.setState({filter: compFilter});
-      onFilterChange(compFilter);
     }
+
+    onFilterChange(filter);
+    this.setState({
+      filter
+    });
   }
 
   /**
@@ -197,18 +193,11 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
    * Stores the appropriate operator as member.
    */
   onOperatorChange = (newOperator: ComparisonOperator) => {
-
+    let filter = this.state.filter;
+    filter[0] = newOperator;
+    this.setState({filter});
+    this.props.onFilterChange(filter);
     this.setState({operator: newOperator});
-
-    // (re)create the ComparisonFilter object if all info are collected
-    if (newOperator && this.state.attribute && this.state.value) {
-      const compFilter: ComparisonFilter = [
-        newOperator, this.state.attribute, this.state.value
-      ];
-      this.setState({filter: compFilter});
-
-      this.props.onFilterChange(compFilter);
-    }
   }
 
   /**
@@ -217,27 +206,17 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
    * Stores the appropriate filter value as member.
    */
   onValueChange = (newValue: string | number | boolean) => {
-
-    this.setState({value: newValue});
-
-    // (re)create the ComparisonFilter object if all info are collected
-    if (this.state.operator && this.state.attribute && newValue) {
-      const compFilter: ComparisonFilter = [
-        this.state.operator, this.state.attribute, newValue
-      ];
-      this.setState({filter: compFilter});
-
-      this.props.onFilterChange(compFilter);
-    }
+    let filter = this.state.filter;
+    filter[2] = newValue;
+    this.setState({filter});
+    this.props.onFilterChange(filter);
   }
 
   render() {
 
     return (
       <div className="gs-comparison-filter-ui">
-
          <Row gutter={16}>
-
           <Col span={10}>
             <AttributeCombo
               value={this.state && this.state.filter ? this.state.filter[1] : undefined}

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -7,7 +7,10 @@ import OperatorCombo from '../OperatorCombo/OperatorCombo';
 import TextFilterField from '../TextFilterField/TextFilterField';
 import NumberFilterField from '../NumberFilterField/NumberFilterField';
 
-import { ComparisonFilter, ComparisonOperator } from 'geostyler-style';
+import {
+  ComparisonFilter as GsComparisonFilter,
+  ComparisonOperator
+} from 'geostyler-style';
 
 import './ComparisonFilter.css';
 import BoolFilterField from '../BoolFilterField/BoolFilterField';
@@ -17,17 +20,18 @@ import {
 } from 'geostyler-data';
 
 import {
-  get as _get
+  get as _get,
+  cloneDeep as _cloneDeep
 } from 'lodash';
 
 // default props
 interface DefaultComparisonFilterProps {
-  filter: ComparisonFilter;
+  filter: GsComparisonFilter;
 }
 // non default props
 interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
   internalDataDef: GsData;
-  onFilterChange: ((compFilter: ComparisonFilter) => void);
+  onFilterChange: ((compFilter: GsComparisonFilter) => void);
 }
 // state
 interface ComparisonFilterState {
@@ -38,7 +42,7 @@ interface ComparisonFilterState {
   attributeType?: string;
   operator: ComparisonOperator | undefined;
   value: string | number | boolean | null;
-  filter: ComparisonFilter;
+  filter: GsComparisonFilter;
 }
 
 /**
@@ -159,7 +163,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
       onFilterChange
     } = this.props;
 
-    let filter = this.state.filter;
+    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[1] = newAttrName;
 
     const valueFieldVis = this.getValueFieldVis(newAttrName);
@@ -193,7 +197,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
    * Stores the appropriate operator as member.
    */
   onOperatorChange = (newOperator: ComparisonOperator) => {
-    let filter = this.state.filter;
+    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[0] = newOperator;
     this.setState({filter});
     this.props.onFilterChange(filter);
@@ -206,7 +210,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
    * Stores the appropriate filter value as member.
    */
   onValueChange = (newValue: string | number | boolean) => {
-    let filter = this.state.filter;
+    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[2] = newValue;
     this.setState({filter});
     this.props.onFilterChange(filter);

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -32,9 +32,16 @@ class NumberFilterField extends React.Component<NumberFilterFieldProps, NumberFi
 
   constructor(props: NumberFilterFieldProps) {
     super(props);
-
     this.state = {
       value: this.props.value
+    };
+  }
+
+  static getDerivedStateFromProps(
+      nextProps: NumberFilterFieldProps,
+      prevState: NumberFilterFieldState): Partial<NumberFilterFieldState> {
+    return {
+      value: nextProps.value
     };
   }
 

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -36,9 +36,16 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
 
   constructor(props: OperatorComboProps) {
     super(props);
-
     this.state = {
       value: this.props.value
+    };
+  }
+
+  static getDerivedStateFromProps(
+      nextProps: OperatorComboProps,
+      prevState: OperatorState): Partial<OperatorState> {
+    return {
+      value: nextProps.value
     };
   }
 
@@ -64,12 +71,12 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
         <Form.Item label={this.props.label} colon={false} >
 
           <Select
-            defaultValue={this.state.value}
+            value={this.state.value}
             style={{ width: '100%' }}
             onChange={this.props.onOperatorChange}
             placeholder={this.props.placeholder}
           >
-              {options}
+            {options}
           </Select>
 
         </Form.Item>

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -31,9 +31,16 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
 
   constructor(props: TextFilterFieldProps) {
     super(props);
-
     this.state = {
       value: this.props.value
+    };
+  }
+
+  static getDerivedStateFromProps(
+      nextProps: TextFilterFieldProps,
+      prevState: TextFilterFieldState): Partial<TextFilterFieldState> {
+    return {
+      value: nextProps.value
     };
   }
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -18,6 +18,10 @@ import Preview from '../Symbolizer/Preview/Preview';
 
 import './Rule.css';
 
+import {
+  cloneDeep as _cloneDeep
+} from 'lodash';
+
 // default props
 interface DefaultRuleProps {
   rule: GsRule;
@@ -26,7 +30,7 @@ interface DefaultRuleProps {
 // non default props
 interface RuleProps extends Partial<DefaultRuleProps> {
   internalDataDef?: GsData | null;
-  onRuleChange?: (rule: GsRule) => void;
+  onRuleChange?: (rule: GsRule, ruleBefore?: GsRule) => void;
   onRemove?: (rule: GsRule) => void;
 }
 
@@ -70,11 +74,11 @@ class Rule extends React.Component<RuleProps, RuleState> {
    * Handles changing rule name
    */
   onNameChange = (name: string) => {
-    const rule = this.state.rule;
+    const rule: GsRule = _cloneDeep(this.state.rule);
     rule.name = name;
     this.setState({rule});
     if (this.props.onRuleChange) {
-      this.props.onRuleChange(rule);
+      this.props.onRuleChange(rule, this.state.rule);
     }
   }
 
@@ -82,11 +86,11 @@ class Rule extends React.Component<RuleProps, RuleState> {
    * Handles changing rule name
    */
   onScaleDenominatorChange = (scaleDenominator: any) => {
-    const rule = this.state.rule;
+    const rule: GsRule = _cloneDeep(this.state.rule);
     rule.scaleDenominator = scaleDenominator;
     this.setState({rule});
     if (this.props.onRuleChange) {
-      this.props.onRuleChange(rule);
+      this.props.onRuleChange(rule, this.state.rule);
     }
   }
 
@@ -94,11 +98,11 @@ class Rule extends React.Component<RuleProps, RuleState> {
    * Handles changing rule filter
    */
   onFilterChange = (filter: GsComparisonFilter) => {
-    const rule = this.state.rule;
+    const rule: GsRule = _cloneDeep(this.state.rule);
     rule.filter = filter;
     this.setState({rule});
     if (this.props.onRuleChange) {
-      this.props.onRuleChange(rule);
+      this.props.onRuleChange(rule, this.state.rule);
     }
   }
 
@@ -106,11 +110,11 @@ class Rule extends React.Component<RuleProps, RuleState> {
    * Handles changing rule symbolizer
    */
   onSymbolizerChange = (symbolizer: GsSymbolizer) => {
-    const rule = this.state.rule;
+    const rule: GsRule = _cloneDeep(this.state.rule);
     rule.symbolizer = symbolizer;
     this.setState({rule});
     if (this.props.onRuleChange) {
-      this.props.onRuleChange(rule);
+      this.props.onRuleChange(rule, this.state.rule);
     }
   }
 

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -4,7 +4,8 @@ import MinScaleDenominator from './MinScaleDenominator';
 import MaxScaleDenominator from './MaxScaleDenominator';
 
 import {
-  get as _get
+  get as _get,
+  cloneDeep as _cloneDeep
 } from 'lodash';
 
 import {
@@ -45,7 +46,7 @@ class ScaleDenominator extends React.Component<ScaleDenominatorProps, ScaleDenom
    * Reacts on changing min scale and pushes the current state to the 'onChange' function
    */
   onMinScaleDenomChange = (minScaleDenominator: number) => {
-    let scaleDenominator = this.state.scaleDenominator;
+    let scaleDenominator = _cloneDeep(this.state.scaleDenominator);
     if (!scaleDenominator) {
       scaleDenominator = {};
     }
@@ -58,7 +59,7 @@ class ScaleDenominator extends React.Component<ScaleDenominatorProps, ScaleDenom
    * Reacts on changing max scale and pushes the current state to the 'onChange' function
    */
   onMaxScaleDenomChange = (maxScaleDenominator: number) => {
-    let scaleDenominator = this.state.scaleDenominator;
+    let scaleDenominator = _cloneDeep(this.state.scaleDenominator);
     if (!scaleDenominator) {
       scaleDenominator = {};
     }

--- a/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
+++ b/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
@@ -10,6 +10,10 @@ import OpacityField from '../Field/OpacityField/OpacityField';
 import RadiusField from '../Field/RadiusField/RadiusField';
 import WidthField from '../Field/WidthField/WidthField';
 
+import {
+  cloneDeep as _cloneDeep
+} from 'lodash';
+
 // default props
 interface DefaultCircleEditorProps {
   radiusLabel: string;
@@ -43,7 +47,6 @@ class CircleEditor extends React.Component<CircleEditorProps, {}> {
 
   render() {
     const {
-      symbolizer,
       radiusLabel,
       fillOpacityLabel,
       fillColorLabel,
@@ -51,6 +54,8 @@ class CircleEditor extends React.Component<CircleEditorProps, {}> {
       strokeWidthLabel,
       strokeOpacityLabel
     } = this.props;
+
+    const symbolizer = _cloneDeep(this.props.symbolizer);
 
     const {
       radius,

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -146,7 +146,7 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     } else {
       // use passed in OL map and bind it to this preview DIV
       map = this.props.map;
-      map.setTarget('map');
+      map.setTarget(this.state.mapTargetId);
     }
 
     // show an OSM background layer if configured and no map was passed in

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -1,3 +1,25 @@
+#root {
+  height: 100%;
+}
+
 .App {
   text-align: center;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-content {
+  display: flex;
+  flex: 1;
+}
+
+.gui-wrapper {
+  flex: 2;
+}
+
+.editor-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -21,6 +21,8 @@ import StyleLoader from '../Component/DataInput/StyleLoader/StyleLoader';
 import DataLoader from '../Component/DataInput/DataLoader/DataLoader';
 import CodeEditor from '../Component/CodeEditor/CodeEditor';
 
+import GeoStylerTemplateStyle from './data/TemplateStyle';
+
 // default props
 interface DefaultAppProps {
   styleParsers: GsStyleParser[];
@@ -39,7 +41,9 @@ class App extends React.Component<AppProps, AppState> {
 
   constructor(props: any) {
     super(props);
-    this.state = {};
+    this.state = {
+      style: GeoStylerTemplateStyle
+    };
   }
 
   render() {
@@ -82,10 +86,7 @@ class App extends React.Component<AppProps, AppState> {
             <h2>Code Editor</h2>
             <CodeEditor
               style={this.state.style}
-              parsers={[
-                OlStyleParser,
-                SldStyleParser
-              ]}
+              parser={SldStyleParser}
               onStyleChange={(style: GsStyle) => {
                 this.setState({style});
               }}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import './App.css';
 import Style from '../Component/Style/Style';
 import StyleLoader from '../Component/DataInput/StyleLoader/StyleLoader';
 import DataLoader from '../Component/DataInput/DataLoader/DataLoader';
+import CodeEditor from '../Component/CodeEditor/CodeEditor';
 
 // default props
 interface DefaultAppProps {
@@ -44,28 +45,53 @@ class App extends React.Component<AppProps, AppState> {
   render() {
     return (
       <div className="App">
-        <h1 className="App-title">GeoStyler</h1>
-        <StyleLoader
-          parsers={[
-            OlStyleParser,
-            SldStyleParser
-          ]}
-          onStyleRead={(style: GsStyle) => {
-            this.setState({style});
-          }}
-        />
-        <DataLoader
-          parsers={[
-            GeoJsonParser
-          ]}
-          onDataRead={(data: GsData) => {
-            this.setState({data});
-          }}
-        />
-        <Style
-          style={this.state.style}
-          data={this.state.data}
-        />
+        <header>
+          <h1 className="App-title">GeoStyler</h1>
+        </header>
+        <div className="settings">
+          <StyleLoader
+            parsers={[
+              OlStyleParser,
+              SldStyleParser
+            ]}
+            onStyleRead={(style: GsStyle) => {
+              this.setState({style});
+            }}
+          />
+          <DataLoader
+            parsers={[
+              GeoJsonParser
+            ]}
+            onDataRead={(data: GsData) => {
+              this.setState({data});
+            }}
+          />
+        </div>
+        <div className="main-content">
+          <div className="gui-wrapper">
+            <h2>Graphical Editor</h2>
+            <Style
+              style={this.state.style}
+              data={this.state.data}
+              onStyleChange={(style: GsStyle) => {
+                this.setState({style});
+              }}
+            />
+          </div>
+          <div className="editor-wrapper">
+            <h2>Code Editor</h2>
+            <CodeEditor
+              style={this.state.style}
+              parsers={[
+                OlStyleParser,
+                SldStyleParser
+              ]}
+              onStyleChange={(style: GsStyle) => {
+                this.setState({style});
+              }}
+            />
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -86,7 +86,9 @@ class App extends React.Component<AppProps, AppState> {
             <h2>Code Editor</h2>
             <CodeEditor
               style={this.state.style}
-              parser={SldStyleParser}
+              parsers={[
+                SldStyleParser
+              ]}
               onStyleChange={(style: GsStyle) => {
                 this.setState({style});
               }}

--- a/src/app/data/TemplateStyle.ts
+++ b/src/app/data/TemplateStyle.ts
@@ -1,0 +1,23 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  name: 'GeoStyler Template Style',
+  type: 'Point',
+  rules: [{
+    name: 'City of Bonn',
+    filter: ['==', 'Name', 'Bonn'],
+    scaleDenominator: {
+      min: 10000,
+      max: 20000
+    },
+    symbolizer: {
+      kind: 'Circle',
+      color: '#FF0000',
+      radius: 6,
+      strokeColor: '#000000',
+      strokeWidth: 2
+    }
+  }]
+};
+
+export default pointSimplePoint;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,28 @@
+/* tslint:disable */
 import { configure } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
+
+global.Range = function Range() {};
+
+const createContextualFragment = (html) => {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.children[0]; // so hokey it's not even funny
+};
+
+Range.prototype.createContextualFragment = (html) => createContextualFragment(html);
+
+// HACK: Polyfil that allows codemirror to render in a JSDOM env.
+global.window.document.createRange = function createRange() {
+  return {
+    setEnd: () => {},
+    setStart: () => {},
+    getBoundingClientRect: () => {
+      return { right: 0 };
+    },
+    getClientRects: () => [],
+    createContextualFragment,
+  };
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,10 @@ import * as Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
+
+// Range poylfill comes from:
+// https://stackoverflow.com/questions/42213522/mocking-document-createrange-for-jest
+
 global.Range = function Range() {};
 
 const createContextualFragment = (html) => {


### PR DESCRIPTION
This introduces the live CodeEditor.

It displays the current style representation and allows cross side editing of the style.
It includes a Format SelectField which allows the input of GeoStyler Style Parsers to edit the Style in the format you like (how awesome is that? :open_mouth:   ).


**GeoStyler Style:**
![codeeditor_geostyler_style](https://user-images.githubusercontent.com/1849416/40721728-b064f6ae-641a-11e8-944e-fb104cab685d.png)

**SLD:**
![codeeditor_sld_style](https://user-images.githubusercontent.com/1849416/40721733-b1ef7058-641a-11e8-8798-100330a3178f.png)


According to testing the bidirectional synchronization some bugs regarding the manipulation of the immutable state object occurred. A fix is included that uses `cloneDeep` before setting new value on state properties.

This also includes a TemplateStyle that is loaded initially.
 