### PR TITLE
Set correct type for internal data references

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Select, Form, Input } from 'antd';
+import { Data } from 'geostyler-data';
 const Option = Select.Option;
 
 // default props
@@ -12,7 +13,7 @@ interface DefaultAttributeComboProps {
 }
 // non default props
 interface AttributeComboProps extends Partial<DefaultAttributeComboProps> {
-  internalDataDef: any;
+  internalDataDef: Data;
   onAttributeChange: ((newAttrName: string) => void);
 }
 

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { Checkbox, Form } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox/Checkbox';
+import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultBoolFilterFieldProps {
@@ -10,7 +11,7 @@ interface DefaultBoolFilterFieldProps {
 }
 // non default props
 interface BoolFilterFieldProps extends Partial<DefaultBoolFilterFieldProps> {
-  internalDataDef: any;
+  internalDataDef: Data;
   onValueChange: ((newValue: boolean) => void);
 }
 // state

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -16,7 +16,7 @@ import './ComparisonFilter.css';
 import BoolFilterField from '../BoolFilterField/BoolFilterField';
 
 import {
-  Data as GsData
+  Data as Data
 } from 'geostyler-data';
 
 import {
@@ -31,7 +31,7 @@ interface DefaultComparisonFilterProps {
 }
 // non default props
 interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
-  internalDataDef: GsData;
+  internalDataDef: Data;
   onFilterChange: ((compFilter: GsComparisonFilter) => void);
 }
 // state

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { InputNumber } from 'antd';
 import FormItem from 'antd/lib/form/FormItem';
+import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultNumberFilterFieldProps {
@@ -10,7 +11,7 @@ interface DefaultNumberFilterFieldProps {
 }
 // non default props
 interface NumberFilterFieldProps extends Partial<DefaultNumberFilterFieldProps> {
-  internalDataDef: any;
+  internalDataDef: Data;
   onValueChange: ((newValue: number) => void);
   selectedAttribute: string;
 }

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
+import { Data } from 'geostyler-data';
 const Option = Select.Option;
 
 // default props
@@ -12,7 +13,7 @@ interface DefaultOperatorComboProps {
 }
 // non default props
 interface OperatorComboProps extends Partial<DefaultOperatorComboProps> {
-  internalDataDef: any;
+  internalDataDef: Data;
   onOperatorChange: ((newOperator: ComparisonOperator) => void);
 }
 

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Input, Form } from 'antd';
+import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultTextFilterFieldProps {
@@ -10,7 +11,7 @@ interface DefaultTextFilterFieldProps {
 }
 // non default props
 interface TextFilterFieldProps extends Partial<DefaultTextFilterFieldProps> {
-  internalDataDef: any;
+  internalDataDef: Data;
   onValueChange: ((newValue: string) => void);
 }
 // state


### PR DESCRIPTION
This changes the type declaration from any to ``Data`` (``import { Data } from 'geostyler-data'``) for the properties holding the internal data reference.

Fixes #158.