### PR TITLE
Filter operators due to changed attribute type

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -44,6 +44,7 @@ interface ComparisonFilterState {
   operator: ComparisonOperator | undefined;
   value: string | number | boolean | null;
   filter: GsComparisonFilter;
+  allowedOperators: string[];
 }
 
 /**
@@ -66,6 +67,12 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   public static defaultProps: DefaultComparisonFilterProps = {
     filter: ['==', '', null],
     attributeNameFilter: () => true
+  };
+
+  private operatorsMap: Object = {
+    string: ['==', '*=', '!='],
+    number: ['==', '!=', '<', '<=', '>', '>='],
+    boolean: ['==', '!=']
   };
 
   constructor(props: ComparisonFilterProps) {
@@ -96,6 +103,8 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         if (attribute) {
           const attrType = attrDefs[attrName].type;
           stateParts.attributeType = attrType;
+
+          stateParts.allowedOperators = this.operatorsMap[attrType];
         }
       }
 
@@ -115,7 +124,8 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         attribute: '',
         operator: undefined,
         value: null,
-        filter: ComparisonFilterUi.defaultProps.filter
+        filter: ComparisonFilterUi.defaultProps.filter,
+        allowedOperators: ['==', '*=', '!=', '<', '<=', '>', '>=']
       };
     }
 
@@ -179,10 +189,12 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
 
       // reset the filter value when the attribute type changed
       if (attrType !== this.state.attributeType) {
+
         this.setState({
           value: null,
           // preserve the attribute type to compare with new one
-          attributeType: attrType
+          attributeType: attrType,
+          allowedOperators: this.operatorsMap[attrType]
         });
       }
     }
@@ -236,6 +248,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
               value={this.state && this.state.filter ? this.state.filter[0] : undefined}
               internalDataDef={this.props.internalDataDef}
               onOperatorChange={this.onOperatorChange}
+              operators={this.state.allowedOperators}
             />
           </Col>
           {

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -3,6 +3,9 @@ import * as React from 'react';
 import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
 import { Data } from 'geostyler-data';
+import {
+  indexOf as _indexOf,
+} from 'lodash';
 const Option = Select.Option;
 
 // default props
@@ -10,6 +13,7 @@ interface DefaultOperatorComboProps {
   label: string;
   placeholder: string;
   value: ComparisonOperator | undefined;
+  operators: string[];
 }
 // non default props
 interface OperatorComboProps extends Partial<DefaultOperatorComboProps> {
@@ -29,11 +33,9 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
   public static defaultProps: DefaultOperatorComboProps = {
     label: 'Operator',
     placeholder: 'Select Operator',
-    value: undefined
+    value: undefined,
+    operators: ['==', '*=', '!=', '<', '<=', '>', '>=']
   };
-
-  /** Available filter operators shown in the combobox  */
-  operators: string[] = ['==', '*=', '!=', '<', '<=', '>', '>='];
 
   constructor(props: OperatorComboProps) {
     super(props);
@@ -45,17 +47,29 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
   static getDerivedStateFromProps(
       nextProps: OperatorComboProps,
       prevState: OperatorState): Partial<OperatorState> {
+
+    let value: ComparisonOperator | undefined = nextProps.value;
+
+    // check if we have to change value according to new allowed operators
+    if (nextProps.operators) {
+      if (_indexOf(nextProps.operators, nextProps.value) === -1) {
+        // current operator is not in allowed list, so we use an allowed one
+        value = nextProps.operators[0] as ComparisonOperator;
+      }
+    }
+
     return {
-      value: nextProps.value
+      value: value
     };
   }
 
   render() {
 
     let options: Object[] = [];
+    const operators = this.props.operators || ['==', '*=', '!=', '<', '<=', '>', '>='];
 
     // create an option per attribute
-    options = this.operators.map(operator => {
+    options = operators.map(operator => {
       return (
         <Option
           key={operator}


### PR DESCRIPTION
This filters the available select options in the OperatorCombo due to a changed attribute type.

Fixes #71.