### PR TITLE
ComparisonFilter GUI: Form validation and label improvements

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -10,6 +10,8 @@ interface DefaultAttributeComboProps {
   placeholder: string;
   value: string | undefined;
   attributeNameFilter: (attrName: string) => boolean;
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  help?: React.ReactNode;
 }
 // non default props
 interface AttributeComboProps extends Partial<DefaultAttributeComboProps> {
@@ -30,7 +32,9 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
     label: 'Attribute',
     placeholder: 'Select Attribute',
     value: undefined,
-    attributeNameFilter: () => true
+    attributeNameFilter: () => true,
+    validateStatus: 'success',
+    help: 'Please select an attribute.'
   };
 
   constructor(props: AttributeComboProps) {
@@ -83,9 +87,16 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
       });
     }
 
+    const helpTxt = this.props.validateStatus !== 'success' ? this.props.help : null;
+
     return (
       <div className="gs-attr-combo">
-        <Form.Item label={label} colon={false} >
+        <Form.Item
+          label={label}
+          colon={false}
+          validateStatus={this.props.validateStatus}
+          help={helpTxt}
+        >
           {
             internalDataDef ?
               <Select

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.css
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.css
@@ -1,4 +1,4 @@
 
 .gs-comparison-filter-ui {
-  padding: 5px;
+  padding-left: 5px;
 }

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -329,14 +329,14 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   }
 
   /**
-   *
+   * Function that validates passed attribute name
    */
   validateAttribute = (attributeName: string) => {
     return !_isEmpty(attributeName);
   }
 
   /**
-   *
+   * Function that validates passed attribute value
    */
   validateValue = (value: string | number | boolean | null) => {
     if (!value) {
@@ -353,14 +353,14 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   }
 
   /**
-   *
+   * Function that validates passed operator
    */
   validateOperator = (operator: string) => {
     return !_isEmpty(operator);
   }
 
   /**
-   *
+   * Function that validates given filter in props
    */
   validateFilter = () => {
     const { filter } = this.props;

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -39,10 +39,13 @@ interface DefaultComparisonFilterProps {
   attributeNameFilter: (attributeName: string) => boolean;
   attributeLabel: string | undefined;
   attributePlaceholderString: string | undefined;
-  comperatorLabel: string | undefined;
-  comperatorPlaceholderString: string | undefined;
+  attributeValidationHelpString: string | undefined;
+  operatorLabel: string | undefined;
+  operatorPlaceholderString: string | undefined;
+  operatorValidationHelpString: string | undefined;
   valueLabel: string | undefined;
   valuePlaceholder: string | undefined;
+  valueValidationHelpString: string | undefined;
   onValidationChanged: (status: ValidationStatus) => void;
 }
 // non default props
@@ -93,10 +96,13 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
     attributeNameFilter: () => true,
     attributeLabel: undefined,
     attributePlaceholderString: undefined,
-    comperatorLabel: undefined,
-    comperatorPlaceholderString: undefined,
+    attributeValidationHelpString: undefined,
+    operatorLabel: undefined,
+    operatorPlaceholderString: undefined,
+    operatorValidationHelpString: undefined,
     valueLabel: undefined,
     valuePlaceholder: undefined,
+    valueValidationHelpString: undefined,
     onValidationChanged: () => false
   };
 
@@ -389,6 +395,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 label={this.props.attributeLabel}
                 placeholder={this.props.attributePlaceholderString}
                 validateStatus={this.state.validateStatus.attribute}
+                help={this.props.attributeValidationHelpString}
               />
             </Col>
             <Col span={4}>
@@ -396,10 +403,11 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 value={this.state && this.state.filter ? this.state.filter[0] : undefined}
                 internalDataDef={this.props.internalDataDef}
                 onOperatorChange={this.onOperatorChange}
-                label={this.props.comperatorLabel}
                 operators={this.state.allowedOperators}
-                placeholder={this.props.comperatorPlaceholderString}
+                placeholder={this.props.operatorPlaceholderString}
+                label={this.props.operatorLabel}
                 validateStatus={this.state.validateStatus.operator}
+                help={this.props.operatorValidationHelpString}
               />
             </Col>
             {
@@ -412,6 +420,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                     label={this.props.valueLabel}
                     placeholder={this.props.valuePlaceholder}
                     validateStatus={this.state.validateStatus.value}
+                    help={this.props.valueValidationHelpString}
                   />
                 </Col> :
                 null
@@ -427,6 +436,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                     label={this.props.valueLabel}
                     placeholder={this.props.valuePlaceholder}
                     validateStatus={this.state.validateStatus.value}
+                    help={this.props.valueValidationHelpString}
                   />
                 </Col> :
                 null

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -28,6 +28,13 @@ import {
 interface DefaultComparisonFilterProps {
   filter: GsComparisonFilter;
   attributeNameFilter: (attributeName: string) => boolean;
+  attributeLabel: string | undefined;
+  attributePlaceholderString: string | undefined;
+  comperatorLabel: string | undefined;
+  comperatorPlaceholderString: string | undefined;
+  valueLabel: string | undefined;
+  valuePlaceholder: string | undefined;
+  onValidationChanged: (status: ValidationStatus) => void;
 }
 // non default props
 interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
@@ -66,7 +73,14 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
 
   public static defaultProps: DefaultComparisonFilterProps = {
     filter: ['==', '', null],
-    attributeNameFilter: () => true
+    attributeNameFilter: () => true,
+    attributeLabel: undefined,
+    attributePlaceholderString: undefined,
+    comperatorLabel: undefined,
+    comperatorPlaceholderString: undefined,
+    valueLabel: undefined,
+    valuePlaceholder: undefined,
+    onValidationChanged: () => false
   };
 
   private operatorsMap: Object = {
@@ -241,6 +255,9 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
               internalDataDef={this.props.internalDataDef}
               onAttributeChange={this.onAttributeChange}
               attributeNameFilter={this.props.attributeNameFilter}
+                label={this.props.attributeLabel}
+                placeholder={this.props.attributePlaceholderString}
+                validateStatus={this.state.validateStatus.attribute}
             />
           </Col>
           <Col span={4}>
@@ -249,6 +266,9 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
               internalDataDef={this.props.internalDataDef}
               onOperatorChange={this.onOperatorChange}
               operators={this.state.allowedOperators}
+                label={this.props.comperatorLabel}
+                placeholder={this.props.comperatorPlaceholderString}
+                validateStatus={this.state.validateStatus.operator}
             />
           </Col>
           {
@@ -258,6 +278,9 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                   value={this.state && this.state.filter ? this.state.filter[2] as string : undefined}
                   internalDataDef={this.props.internalDataDef}
                   onValueChange={this.onValueChange}
+                    label={this.props.valueLabel}
+                    placeholder={this.props.valuePlaceholder}
+                    validateStatus={this.state.validateStatus.value}
                 />
               </Col> :
               null
@@ -270,6 +293,9 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                   internalDataDef={this.props.internalDataDef}
                   selectedAttribute={this.state.attribute}
                   onValueChange={this.onValueChange}
+                    label={this.props.valueLabel}
+                    placeholder={this.props.valuePlaceholder}
+                    validateStatus={this.state.validateStatus.value}
                 />
               </Col> :
               null
@@ -281,11 +307,11 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                   value={this.state && this.state.filter ? this.state.filter[2] as boolean : undefined}
                   internalDataDef={this.props.internalDataDef}
                   onValueChange={this.onValueChange}
+                    label={this.props.valueLabel}
                 />
               </Col> :
               null
           }
-
         </Row>
 
       </div>

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -131,7 +131,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         filter: this.props.filter,
         validateStatus: {
           attribute: 'error',
-          operator: 'error',
+          operator: 'success',
           value: 'error'
         }
       };
@@ -170,7 +170,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         allowedOperators: ['==', '*=', '!=', '<', '<=', '>', '>='],
         validateStatus: {
           attribute: 'error',
-          operator: 'error',
+          operator: 'success',
           value: 'error'
         }
       };
@@ -365,19 +365,24 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   validateFilter = () => {
     const { filter } = this.props;
     if (!filter || !Array.isArray(filter)) {
-      return {
-        attribute: 'error',
-        operator: 'error',
-        value: 'error'
-      };
+      this.setState({
+        validateStatus: {
+          attribute: 'error',
+          operator: 'error',
+          value: 'error'
+        }
+      });
     }
 
-    const validationStatus: ValidationStatus = {
-      attribute: this.validateAttribute(filter[0]) ? 'success' : 'error',
-      operator: this.validateOperator(filter[1]) ? 'success' : 'error',
-      value: this.validateValue(filter[2]) ? 'success' : 'error'
+    const validateStatus: ValidationStatus = {
+      attribute: this.validateAttribute(filter![1]) ? 'success' : 'error',
+      operator: this.validateOperator(filter![0]) ? 'success' : 'error',
+      value: this.validateValue(filter![2]) ? 'success' : 'error'
     };
-    return validationStatus;
+
+    this.setState({
+      validateStatus
+    });
   }
 
   render() {

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
-import { Row, Col } from 'antd';
+import {
+  Row,
+  Col,
+  Form
+} from 'antd';
 
 import AttributeCombo from '../AttributeCombo/AttributeCombo';
 import OperatorCombo from '../OperatorCombo/OperatorCombo';
@@ -21,7 +25,12 @@ import {
 
 import {
   get as _get,
-  cloneDeep as _cloneDeep
+  cloneDeep as _cloneDeep,
+  isEqual as _isEqual,
+  isNaN as _isNaN,
+  isNumber as _isNumber,
+  isEmpty as _isEmpty,
+  isFunction as _isFunction
 } from 'lodash';
 
 // default props
@@ -41,6 +50,13 @@ interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
   internalDataDef: Data;
   onFilterChange: ((compFilter: GsComparisonFilter) => void);
 }
+
+interface ValidationStatus {
+  attribute: 'success' | 'warning' | 'error' | 'validating';
+  operator: 'success' | 'warning' | 'error' | 'validating';
+  value: 'success' | 'warning' | 'error' | 'validating';
+}
+
 // state
 interface ComparisonFilterState {
   textFieldVisible: boolean;
@@ -52,6 +68,7 @@ interface ComparisonFilterState {
   value: string | number | boolean | null;
   filter: GsComparisonFilter;
   allowedOperators: string[];
+  validateStatus: ValidationStatus;
 }
 
 /**
@@ -105,7 +122,12 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         attribute: attrName,
         operator: filter[0],
         value: filter[2],
-        filter: this.props.filter
+        filter: this.props.filter,
+        validateStatus: {
+          attribute: 'error',
+          operator: 'error',
+          value: 'error'
+        }
       };
 
       this.state = stateParts;
@@ -139,10 +161,24 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
         operator: undefined,
         value: null,
         filter: ComparisonFilterUi.defaultProps.filter,
-        allowedOperators: ['==', '*=', '!=', '<', '<=', '>', '>=']
+        allowedOperators: ['==', '*=', '!=', '<', '<=', '>', '>='],
+        validateStatus: {
+          attribute: 'error',
+          operator: 'error',
+          value: 'error'
+        }
       };
     }
+  }
 
+  /**
+   *
+   * @param previousProps
+   */
+  componentDidUpdate(previousProps: ComparisonFilterProps) {
+    if (!_isEqual(previousProps.filter, this.props.filter)) {
+      this.validateFilter();
+    }
   }
 
   /**
@@ -186,7 +222,8 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   onAttributeChange = (newAttrName: string) => {
     const {
       internalDataDef,
-      onFilterChange
+      onFilterChange,
+      onValidationChanged
     } = this.props;
 
     let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
@@ -213,9 +250,20 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
       }
     }
 
+    const isValid = this.validateAttribute(newAttrName);
+    const validationStateNew: ValidationStatus = {
+      ...this.state.validateStatus,
+      attribute: isValid ? 'success' : 'error'
+    };
+
+    if (_isFunction(onValidationChanged)) {
+      onValidationChanged(validationStateNew);
+    }
+
     onFilterChange(filter);
     this.setState({
-      filter
+      filter,
+      validateStatus: validationStateNew
     });
   }
 
@@ -229,7 +277,21 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
     filter[0] = newOperator;
     this.setState({filter});
     this.props.onFilterChange(filter);
-    this.setState({operator: newOperator});
+
+    const isValid = this.validateOperator(newOperator);
+    const validationStateNew: ValidationStatus = {
+      ...this.state.validateStatus,
+      operator: isValid ? 'success' : 'error'
+    };
+
+    this.setState({
+      validateStatus: validationStateNew,
+      operator: newOperator
+    });
+
+    if (_isFunction(this.props.onValidationChanged)) {
+      this.props.onValidationChanged(validationStateNew);
+    }
   }
 
   /**
@@ -240,80 +302,149 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
   onValueChange = (newValue: string | number | boolean) => {
     let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[2] = newValue;
-    this.setState({filter});
+
+    // validate value fields
+    let isValid = this.validateValue(newValue);
+    const validationStateNew: ValidationStatus = {
+      ...this.state.validateStatus,
+      value: isValid ? 'success' : 'error'
+    };
+
+    this.setState({
+      validateStatus: validationStateNew,
+      filter
+    });
+
+    if (_isFunction(this.props.onValidationChanged)) {
+      this.props.onValidationChanged(validationStateNew);
+    }
+
     this.props.onFilterChange(filter);
+  }
+
+  /**
+   *
+   */
+  validateAttribute = (attributeName: string) => {
+    return !_isEmpty(attributeName);
+  }
+
+  /**
+   *
+   */
+  validateValue = (value: string | number | boolean | null) => {
+    if (!value) {
+      return false;
+    }
+    switch (this.state.attributeType) {
+      case 'number':
+        return _isNumber(Number(value)) && !_isNaN(Number(value));
+      case 'boolean':
+        return true;
+      default:
+        return !_isEmpty(value);
+    }
+  }
+
+  /**
+   *
+   */
+  validateOperator = (operator: string) => {
+    return !_isEmpty(operator);
+  }
+
+  /**
+   *
+   */
+  validateFilter = () => {
+    const { filter } = this.props;
+    if (!filter || !Array.isArray(filter)) {
+      return {
+        attribute: 'error',
+        operator: 'error',
+        value: 'error'
+      };
+    }
+
+    const validationStatus: ValidationStatus = {
+      attribute: this.validateAttribute(filter[0]) ? 'success' : 'error',
+      operator: this.validateOperator(filter[1]) ? 'success' : 'error',
+      value: this.validateValue(filter[2]) ? 'success' : 'error'
+    };
+    return validationStatus;
   }
 
   render() {
 
     return (
       <div className="gs-comparison-filter-ui">
-         <Row gutter={16}>
-          <Col span={10}>
-            <AttributeCombo
-              value={this.state && this.state.filter ? this.state.filter[1] : undefined}
-              internalDataDef={this.props.internalDataDef}
-              onAttributeChange={this.onAttributeChange}
-              attributeNameFilter={this.props.attributeNameFilter}
+        <Form>
+          <Row gutter={16} justify="center">
+            <Col span={10}>
+              <AttributeCombo
+                value={this.state && this.state.filter ? this.state.filter[1] : undefined}
+                internalDataDef={this.props.internalDataDef}
+                onAttributeChange={this.onAttributeChange}
+                attributeNameFilter={this.props.attributeNameFilter}
                 label={this.props.attributeLabel}
                 placeholder={this.props.attributePlaceholderString}
                 validateStatus={this.state.validateStatus.attribute}
-            />
-          </Col>
-          <Col span={4}>
-            <OperatorCombo
-              value={this.state && this.state.filter ? this.state.filter[0] : undefined}
-              internalDataDef={this.props.internalDataDef}
-              onOperatorChange={this.onOperatorChange}
-              operators={this.state.allowedOperators}
+              />
+            </Col>
+            <Col span={4}>
+              <OperatorCombo
+                value={this.state && this.state.filter ? this.state.filter[0] : undefined}
+                internalDataDef={this.props.internalDataDef}
+                onOperatorChange={this.onOperatorChange}
                 label={this.props.comperatorLabel}
+                operators={this.state.allowedOperators}
                 placeholder={this.props.comperatorPlaceholderString}
                 validateStatus={this.state.validateStatus.operator}
-            />
-          </Col>
-          {
-            this.state.textFieldVisible ?
-              <Col span={10}>
-                <TextFilterField
-                  value={this.state && this.state.filter ? this.state.filter[2] as string : undefined}
-                  internalDataDef={this.props.internalDataDef}
-                  onValueChange={this.onValueChange}
+              />
+            </Col>
+            {
+              this.state.textFieldVisible ?
+                <Col span={10}>
+                  <TextFilterField
+                    value={this.state && this.state.filter ? this.state.filter[2] as string : undefined}
+                    internalDataDef={this.props.internalDataDef}
+                    onValueChange={this.onValueChange}
                     label={this.props.valueLabel}
                     placeholder={this.props.valuePlaceholder}
                     validateStatus={this.state.validateStatus.value}
-                />
-              </Col> :
-              null
-          }
-          {
-            this.state.numberFieldVisible ?
-              <Col span={10}>
-                <NumberFilterField
-                  value={this.state && this.state.filter ? this.state.filter[2] as number : undefined}
-                  internalDataDef={this.props.internalDataDef}
-                  selectedAttribute={this.state.attribute}
-                  onValueChange={this.onValueChange}
+                  />
+                </Col> :
+                null
+            }
+            {
+              this.state.numberFieldVisible ?
+                <Col span={10}>
+                  <NumberFilterField
+                    value={this.state && this.state.filter ? this.state.filter[2] as number : undefined}
+                    internalDataDef={this.props.internalDataDef}
+                    selectedAttribute={this.state.attribute}
+                    onValueChange={this.onValueChange}
                     label={this.props.valueLabel}
                     placeholder={this.props.valuePlaceholder}
                     validateStatus={this.state.validateStatus.value}
-                />
-              </Col> :
-              null
-          }
-          {
-            this.state.boolFieldVisible ?
-              <Col span={10}>
-                <BoolFilterField
-                  value={this.state && this.state.filter ? this.state.filter[2] as boolean : undefined}
-                  internalDataDef={this.props.internalDataDef}
-                  onValueChange={this.onValueChange}
+                  />
+                </Col> :
+                null
+            }
+            {
+              this.state.boolFieldVisible ?
+                <Col span={10}>
+                  <BoolFilterField
+                    value={this.state && this.state.filter ? this.state.filter[2] as boolean : undefined}
+                    internalDataDef={this.props.internalDataDef}
+                    onValueChange={this.onValueChange}
                     label={this.props.valueLabel}
-                />
-              </Col> :
-              null
-          }
-        </Row>
-
+                  />
+                </Col> :
+                null
+            }
+          </Row>
+        </Form>
       </div>
     );
   }

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -37,16 +37,16 @@ import {
 interface DefaultComparisonFilterProps {
   filter: GsComparisonFilter;
   attributeNameFilter: (attributeName: string) => boolean;
-  attributeLabel: string | undefined;
-  attributePlaceholderString: string | undefined;
-  attributeValidationHelpString: string | undefined;
-  operatorLabel: string | undefined;
-  operatorPlaceholderString: string | undefined;
-  operatorValidationHelpString: string | undefined;
-  valueLabel: string | undefined;
-  valuePlaceholder: string | undefined;
-  valueValidationHelpString: string | undefined;
-  onValidationChanged: (status: ValidationStatus) => void;
+  attributeLabel?: string;
+  attributePlaceholderString?: string;
+  attributeValidationHelpString?: string;
+  operatorLabel?: string;
+  operatorPlaceholderString?: string;
+  operatorValidationHelpString?: string;
+  valueLabel?: string;
+  valuePlaceholder?: string;
+  valueValidationHelpString?: string;
+  onValidationChanged?: (status: ValidationStatus) => void;
 }
 // non default props
 interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -32,7 +32,7 @@ class NumberFilterField extends React.Component<NumberFilterFieldProps, NumberFi
     placeholder: 'Enter Numeric Value',
     value: undefined,
     validateStatus: 'success',
-    help: 'Please enter a text.'
+    help: 'Please enter a number.'
   };
 
   constructor(props: NumberFilterFieldProps) {

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -8,6 +8,8 @@ interface DefaultNumberFilterFieldProps {
   label: string;
   placeholder: string;
   value: number | undefined;
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  help?: React.ReactNode;
 }
 // non default props
 interface NumberFilterFieldProps extends Partial<DefaultNumberFilterFieldProps> {
@@ -28,7 +30,9 @@ class NumberFilterField extends React.Component<NumberFilterFieldProps, NumberFi
   public static defaultProps: DefaultNumberFilterFieldProps = {
     label: 'Value',
     placeholder: 'Enter Numeric Value',
-    value: undefined
+    value: undefined,
+    validateStatus: 'success',
+    help: 'Please enter a text.'
   };
 
   constructor(props: NumberFilterFieldProps) {
@@ -63,10 +67,18 @@ class NumberFilterField extends React.Component<NumberFilterFieldProps, NumberFi
     const minVal = attrDefs[this.props.selectedAttribute].minimum;
     const maxVal = attrDefs[this.props.selectedAttribute].maximum;
 
+    const helpTxt = this.props.validateStatus !== 'success' ? this.props.help : null;
+
     return (
       <div className="gs-text-filter-fld">
 
-        <FormItem label={this.props.label} colon={false} >
+        <FormItem
+          label={this.props.label}
+          colon={false}
+          validateStatus={this.props.validateStatus}
+          help={helpTxt}
+          hasFeedback={true}
+        >
 
           <InputNumber
             value={this.state.value}

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -14,6 +14,8 @@ interface DefaultOperatorComboProps {
   placeholder: string;
   value: ComparisonOperator | undefined;
   operators: string[];
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  help?: React.ReactNode;
 }
 // non default props
 interface OperatorComboProps extends Partial<DefaultOperatorComboProps> {
@@ -34,7 +36,9 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
     label: 'Operator',
     placeholder: 'Select Operator',
     value: undefined,
-    operators: ['==', '*=', '!=', '<', '<=', '>', '>=']
+    operators: ['==', '*=', '!=', '<', '<=', '>', '>='],
+    validateStatus: 'error',
+    help: 'Please select an operator.'
   };
 
   constructor(props: OperatorComboProps) {
@@ -80,11 +84,16 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
       );
     });
 
+    const helpTxt = this.props.validateStatus !== 'success' ? this.props.help : null;
+
     return (
       <div className="gs-operator-combo">
-
-        <Form.Item label={this.props.label} colon={false} >
-
+        <Form.Item
+          label={this.props.label}
+          colon={false}
+          validateStatus={this.props.validateStatus}
+          help={helpTxt}
+        >
           <Select
             value={this.state.value}
             style={{ width: '100%' }}

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -8,6 +8,8 @@ interface DefaultTextFilterFieldProps {
   label: string;
   placeholder: string;
   value: string | undefined;
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  help?: React.ReactNode;
 }
 // non default props
 interface TextFilterFieldProps extends Partial<DefaultTextFilterFieldProps> {
@@ -27,7 +29,9 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
   public static defaultProps: DefaultTextFilterFieldProps = {
     label: 'Value',
     placeholder: 'Enter Text Value',
-    value: undefined
+    value: undefined,
+    validateStatus: 'success',
+    help: 'Please enter a text.'
   };
 
   constructor(props: TextFilterFieldProps) {
@@ -57,10 +61,18 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
 
   render() {
 
+    const helpTxt = this.props.validateStatus !== 'success' ? this.props.help : null;
+
     return (
       <div className="gs-text-filter-fld">
 
-        <Form.Item label={this.props.label} colon={false} >
+        <Form.Item
+          label={this.props.label}
+          colon={false}
+          validateStatus={this.props.validateStatus}
+          help={helpTxt}
+          hasFeedback={true}
+        >
 
           <Input
             value={this.state.value}


### PR DESCRIPTION
This PR adds form validation to ComparisonFilter GUI and adds some props in order to pass custom placeholder strings to e.g. AttributeCombo (needed esp. for i18n).
`ComparisonFilter` got a new prop `onValidationChanged` (function) that obtains the current validation status of the child elements.

GUI examples:
![image](https://user-images.githubusercontent.com/10559603/41292207-2df85e80-6e52-11e8-8c59-7a11b642937f.png)

![image](https://user-images.githubusercontent.com/10559603/41291700-b59f6240-6e50-11e8-95df-a209539880a6.png)

![image](https://user-images.githubusercontent.com/10559603/41291721-c3e8c86e-6e50-11e8-8404-a57346380c9e.png)
