### PR TITLE
Add a simple editor for line symbolizer

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -11,6 +11,7 @@ import CircleEditor from '../CircleEditor/CircleEditor';
 import './Editor.css';
 
 import 'openlayers/css/ol.css';
+import LineEditor from '../LineEditor/LineEditor';
 
 // default props
 interface DefaultEditorProps {}
@@ -68,6 +69,13 @@ class Editor extends React.Component<EditorProps, EditorState> {
       case 'Circle':
         return (
           <CircleEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
+          />
+        );
+      case 'Line':
+        return (
+          <LineEditor
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
           />

--- a/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
@@ -1,0 +1,22 @@
+import LineEditor from './LineEditor';
+import TestUtil from '../../../Util/TestUtil';
+
+describe('LineEditor', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const linestyle = TestUtil.getLineStyle();
+    wrapper = TestUtil.shallowRenderComponent(LineEditor, {
+      symbolizer: linestyle.rules[0].symbolizer
+    });
+  });
+
+  it('is defined', () => {
+    expect(LineEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  LineSymbolizer
+} from 'geostyler-style';
+
+import ColorField from '../Field/ColorField/ColorField';
+import OpacityField from '../Field/OpacityField/OpacityField';
+import WidthField from '../Field/WidthField/WidthField';
+
+import {
+  cloneDeep as _cloneDeep
+} from 'lodash';
+
+// default props
+interface DefaultLineEditorProps {
+  colorLabel: string;
+  widthLabel: string;
+  opacityLabel: string;
+}
+
+// non default props
+interface LineEditorProps extends Partial<DefaultLineEditorProps> {
+  symbolizer: LineSymbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+}
+
+class LineEditor extends React.Component<LineEditorProps, {}> {
+
+  public static defaultProps: DefaultLineEditorProps = {
+    colorLabel: 'Color',
+    widthLabel: 'Width',
+    opacityLabel: 'Opacity'
+  };
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  render() {
+    const {
+      colorLabel,
+      widthLabel,
+      opacityLabel
+    } = this.props;
+
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+
+    const {
+      color,
+      width,
+      opacity,
+    } = symbolizer;
+
+    return (
+      <div className="gs-line-symbolizer-editor" >
+        <ColorField
+          color={color}
+          label={colorLabel}
+          onChange={(value: string) => {
+            symbolizer.color = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <WidthField
+          width={width}
+          label={widthLabel}
+          onChange={(value: number) => {
+            symbolizer.width = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={opacity}
+          label={opacityLabel}
+          onChange={(value: number) => {
+            symbolizer.opacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default LineEditor;

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
+import { Style } from 'geostyler-style';
 
 /**
  * A set of some useful static helper methods.
@@ -67,6 +68,28 @@ export class TestUtil {
         ]
       }
     };
+  }
+
+  /**
+   * Returns a simple line symbolizer object.
+   *
+   * @returns {Style}
+   */
+  static getLineStyle = () => {
+    const lineSimpleLine: Style = {
+      name: 'Simple Line',
+      type: 'Line',
+      rules: [{
+        name: '',
+        symbolizer: {
+          kind: 'Line',
+          color: '#000000',
+          width: 3
+        }
+      }]
+    };
+
+    return lineSimpleLine;
   }
 }
 


### PR DESCRIPTION
This adds a simple editor for ``LineSymbolizer``s, which allows to edit the 

  - color 
  - width and
  - opacity

of the line.