### PR TITLE
Add a simple editor for fill symbolizer 

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -12,6 +12,7 @@ import './Editor.css';
 
 import 'openlayers/css/ol.css';
 import LineEditor from '../LineEditor/LineEditor';
+import FillEditor from '../FillEditor/FillEditor';
 
 // default props
 interface DefaultEditorProps {}
@@ -76,6 +77,13 @@ class Editor extends React.Component<EditorProps, EditorState> {
       case 'Line':
         return (
           <LineEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
+          />
+        );
+      case 'Fill':
+        return (
+          <FillEditor
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
           />

--- a/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
@@ -1,0 +1,22 @@
+import FillEditor from './FillEditor';
+import TestUtil from '../../../Util/TestUtil';
+
+describe('FillEditor', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const polygonStyle = TestUtil.getPolygonStyle();
+    wrapper = TestUtil.shallowRenderComponent(FillEditor, {
+      symbolizer: polygonStyle.rules[0].symbolizer
+    });
+  });
+
+  it('is defined', () => {
+    expect(FillEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  FillSymbolizer
+} from 'geostyler-style';
+
+import ColorField from '../Field/ColorField/ColorField';
+import OpacityField from '../Field/OpacityField/OpacityField';
+
+import {
+  cloneDeep as _cloneDeep
+} from 'lodash';
+
+// default props
+interface DefaultFillEditorProps {
+  fillOpacityLabel: string;
+  fillColorLabel: string;
+  strokeColorLabel: string;
+}
+
+// non default props
+interface FillEditorProps extends Partial<DefaultFillEditorProps> {
+  symbolizer: FillSymbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+}
+
+class FillEditor extends React.Component<FillEditorProps, {}> {
+
+  public static defaultProps: DefaultFillEditorProps = {
+    fillOpacityLabel: 'Fill-Opacity',
+    fillColorLabel: 'Fill-Color',
+    strokeColorLabel: 'Stroke-Color'
+  };
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  render() {
+    const {
+      fillOpacityLabel,
+      fillColorLabel,
+      strokeColorLabel
+    } = this.props;
+
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+
+    const {
+      color,
+      opacity,
+      outlineColor
+    } = symbolizer;
+
+    return (
+      <div className="gs-fill-symbolizer-editor" >
+        <ColorField
+          color={color}
+          label={fillColorLabel}
+          onChange={(value: string) => {
+            symbolizer.color = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={opacity}
+          label={fillOpacityLabel}
+          onChange={(value: number) => {
+            symbolizer.opacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <ColorField
+          color={outlineColor}
+          label={strokeColorLabel}
+          onChange={(value: string) => {
+            symbolizer.outlineColor = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default FillEditor;

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -16,7 +16,7 @@ import {
 interface DefaultFillEditorProps {
   fillOpacityLabel: string;
   fillColorLabel: string;
-  strokeColorLabel: string;
+  outlineColorLabel: string;
 }
 
 // non default props
@@ -30,7 +30,7 @@ class FillEditor extends React.Component<FillEditorProps, {}> {
   public static defaultProps: DefaultFillEditorProps = {
     fillOpacityLabel: 'Fill-Opacity',
     fillColorLabel: 'Fill-Color',
-    strokeColorLabel: 'Stroke-Color'
+    outlineColorLabel: 'Stroke-Color'
   };
 
   onSymbolizerChange = (symbolizer: Symbolizer) => {
@@ -39,9 +39,9 @@ class FillEditor extends React.Component<FillEditorProps, {}> {
 
   render() {
     const {
-      fillOpacityLabel,
       fillColorLabel,
-      strokeColorLabel
+      fillOpacityLabel,
+      outlineColorLabel
     } = this.props;
 
     const symbolizer = _cloneDeep(this.props.symbolizer);
@@ -72,7 +72,7 @@ class FillEditor extends React.Component<FillEditorProps, {}> {
         />
         <ColorField
           color={outlineColor}
-          label={strokeColorLabel}
+          label={outlineColorLabel}
           onChange={(value: string) => {
             symbolizer.outlineColor = value;
             this.props.onSymbolizerChange(symbolizer);

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -91,6 +91,29 @@ export class TestUtil {
 
     return lineSimpleLine;
   }
+
+  /**
+   * Returns a simple polygon symbolizer object.
+   *
+   * @returns {Style} The polgy style object
+   */
+  static getPolygonStyle = () => {
+    const polygonTransparentPolygon: Style = {
+      name: 'Transparent Polygon',
+      type: 'Fill',
+      rules: [{
+        name: '',
+        symbolizer: {
+          kind: 'Fill',
+          color: '#000080',
+          opacity: 0.5,
+          outlineColor: '#FFFFFF'
+        }
+      }]
+    };
+
+    return polygonTransparentPolygon;
+  }
 }
 
 export default TestUtil;


### PR DESCRIPTION
This adds a simple editor for ``FillSymbolizer``s, which allows to edit the

 - fill color
 - fill opacity and
 - stroke color

of the polygon.