### PR TITLE
Add a simple editor for text symbolizer

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -7,12 +7,13 @@ import {
 } from 'geostyler-style';
 
 import CircleEditor from '../CircleEditor/CircleEditor';
+import LineEditor from '../LineEditor/LineEditor';
+import FillEditor from '../FillEditor/FillEditor';
+import TextEditor from '../TextEditor/TextEditor';
 
 import './Editor.css';
 
 import 'openlayers/css/ol.css';
-import LineEditor from '../LineEditor/LineEditor';
-import FillEditor from '../FillEditor/FillEditor';
 
 // default props
 interface DefaultEditorProps {}
@@ -84,6 +85,13 @@ class Editor extends React.Component<EditorProps, EditorState> {
       case 'Fill':
         return (
           <FillEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
+          />
+        );
+      case 'Text':
+        return (
+          <TextEditor
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
           />

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.spec.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.spec.tsx
@@ -1,0 +1,19 @@
+import FontPicker from './FontPicker';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('FontPicker', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(FontPicker, {});
+  });
+
+  it('is defined', () => {
+    expect(FontPicker).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import {
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+// default props
+interface FontPickerDefaultProps {
+  font: string[];
+  label: string;
+  fontOptions: string[];
+}
+
+// non default props
+interface FontPickerProps extends Partial<FontPickerDefaultProps> {
+  onChange: ((font: string[]) => void);
+}
+
+/**
+ * FontPicker to select font types / families
+ */
+class FontPicker extends React.Component<FontPickerProps, {}> {
+
+  public static defaultProps: FontPickerDefaultProps = {
+    font: ['Arial'],
+    label: 'Font',
+    fontOptions: ['Arial', 'Verdana', 'Courier New', 'Lucida Console', 'Times New Roman', 'Georgia']
+  };
+
+  render() {
+    const {
+      font,
+      label,
+      fontOptions
+    } = this.props;
+
+    const children: JSX.Element[] = [];
+    if (fontOptions) {
+      fontOptions.forEach(fontOpt => {
+        children.push(<Option key={fontOpt}>{fontOpt}</Option>);
+      });
+    }
+
+    return (
+      <div className="editor-field font-picker">
+        <span className="label">{`${label}:`}</span>
+        <Select mode="tags" value={font} style={{ width: 90 }} onChange={this.props.onChange}>
+          {children}
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default FontPicker;

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -14,7 +14,7 @@ interface FontPickerDefaultProps {
 
 // non default props
 interface FontPickerProps extends Partial<FontPickerDefaultProps> {
-  onChange: ((font: string[]) => void);
+  onChange: ((fonts: string[]) => void);
 }
 
 /**
@@ -25,7 +25,11 @@ class FontPicker extends React.Component<FontPickerProps, {}> {
   public static defaultProps: FontPickerDefaultProps = {
     font: ['Arial'],
     label: 'Font',
-    fontOptions: ['Arial', 'Verdana', 'Courier New', 'Lucida Console', 'Times New Roman', 'Georgia']
+    fontOptions: [
+      'Arial', 'Verdana', 'Sans-serif',
+      'Courier New', 'Lucida Console', 'Monospace',
+      'Times New Roman', 'Georgia', 'Serif'
+    ]
   };
 
   render() {
@@ -45,7 +49,12 @@ class FontPicker extends React.Component<FontPickerProps, {}> {
     return (
       <div className="editor-field font-picker">
         <span className="label">{`${label}:`}</span>
-        <Select mode="tags" value={font} style={{ width: 90 }} onChange={this.props.onChange}>
+        <Select
+          mode="tags"
+          value={font}
+          style={{ width: 90 }}
+          onChange={this.props.onChange}
+        >
           {children}
         </Select>
       </div>

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.spec.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.spec.tsx
@@ -1,0 +1,19 @@
+import OffsetField from './OffsetField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('OffsetField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(OffsetField, {});
+  });
+
+  it('is defined', () => {
+    expect(OffsetField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface OffsetFieldDefaultProps {
+  offset: number;
+  label: string;
+}
+
+// non default props
+interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps> {
+  onChange: ((radius: number) => void);
+}
+
+/**
+ * OffsetField for map labels
+ */
+class OffsetField extends React.Component<OffsetFieldProps, {}> {
+
+  public static defaultProps: OffsetFieldDefaultProps = {
+    offset: 0,
+    label: ''
+  };
+
+  render() {
+    const {
+      offset,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field offset-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          defaultValue={offset}
+          step={1}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default OffsetField;

--- a/src/Component/Symbolizer/TextEditor/TextEditor.spec.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.spec.tsx
@@ -1,0 +1,22 @@
+import TextEditor from './TextEditor';
+import TestUtil from '../../../Util/TestUtil';
+
+describe('TextEditor', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const labelStyle = TestUtil.getLabeledPointStyle();
+    wrapper = TestUtil.shallowRenderComponent(TextEditor, {
+      symbolizer: labelStyle.rules[0].symbolizer
+    });
+  });
+
+  it('is defined', () => {
+    expect(TextEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  TextSymbolizer
+} from 'geostyler-style';
+
+import ColorField from '../Field/ColorField/ColorField';
+import OpacityField from '../Field/OpacityField/OpacityField';
+import WidthField from '../Field/WidthField/WidthField';
+
+import {
+  cloneDeep as _cloneDeep
+} from 'lodash';
+import FontPicker from '../Field/FontPicker/FontPicker';
+import OffsetField from '../Field/OffsetField/OffsetField';
+
+// default props
+interface DefaultTextEditorProps {
+  opacityLabel: string;
+  colorLabel: string;
+  sizeLabel: string;
+  offsetXLabel: string;
+  offsetYLabel: string;
+}
+
+// non default props
+interface TextEditorProps extends Partial<DefaultTextEditorProps> {
+  symbolizer: TextSymbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+}
+
+class TextEditor extends React.Component<TextEditorProps, {}> {
+
+  public static defaultProps: DefaultTextEditorProps = {
+    opacityLabel: 'Text-Opacity',
+    colorLabel: 'Text-Color',
+    sizeLabel: 'Text-Size',
+    offsetXLabel: 'Offset X',
+    offsetYLabel: 'Offset Y'
+  };
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  render() {
+    const {
+      opacityLabel,
+      colorLabel,
+      sizeLabel,
+      offsetXLabel,
+      offsetYLabel
+    } = this.props;
+
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+
+    const {
+      opacity,
+      color,
+      font,
+      offset,
+      size,
+    } = symbolizer;
+
+    // split the current offset
+    let offsetX = 0;
+    let offsetY = 0;
+    if (offset) {
+      offsetX = offset[0];
+      offsetY = offset[0];
+    }
+
+    return (
+      <div className="gs-text-symbolizer-editor" >
+        <ColorField
+          color={color}
+          label={colorLabel}
+          onChange={(value: string) => {
+            symbolizer.color = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <FontPicker
+          font={font}
+          onChange={(value: string[]) => {
+            symbolizer.font = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={opacity}
+          label={opacityLabel}
+          onChange={(value: number) => {
+            symbolizer.opacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <WidthField
+          width={size}
+          label={sizeLabel}
+          onChange={(value: number) => {
+            symbolizer.size = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OffsetField
+          offset={offsetX}
+          label={offsetXLabel}
+          onChange={(value: number) => {
+            let newOffset: [number, number] = [value, (symbolizer.offset ? symbolizer.offset[1] : 0)];
+            symbolizer.offset = newOffset;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OffsetField
+          offset={offsetY}
+          label={offsetYLabel}
+          onChange={(value: number) => {
+            let newOffset: [number, number] = [(symbolizer.offset ? symbolizer.offset[0] : 0), value];
+            symbolizer.offset = newOffset;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default TextEditor;

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -93,9 +93,9 @@ export class TestUtil {
   }
 
   /**
-   * Returns a simple polygon symbolizer object.
+   * Returns a simple polygon style object.
    *
-   * @returns {Style} The polgy style object
+   * @returns {Style} The polygon style object
    */
   static getPolygonStyle = () => {
     const polygonTransparentPolygon: Style = {
@@ -113,6 +113,31 @@ export class TestUtil {
     };
 
     return polygonTransparentPolygon;
+  }
+
+  /**
+   * Returns a simple labeled point style object.
+   * 
+   * @returns {Style} The labeled style object
+   */
+  static getLabeledPointStyle = () => {
+    const pointStyledLabel: Style = {
+      name: 'Styled Label',
+      type: 'Point',
+      rules: [{
+        name: '',
+        symbolizer: {
+          kind: 'Text',
+          color: '#000000',
+          field: 'name',
+          font: ['Arial'],
+          size: 12,
+          offset: [0, 5]
+        }
+      }]
+    };
+
+    return pointStyledLabel;
   }
 }
 


### PR DESCRIPTION
This adds a simple editor for ``TextSymbolizer``s, which allows to edit the

  - text color
  - font type
  - text opacity
  - text size
  - text offset

of the label / text:

![image](https://user-images.githubusercontent.com/1185547/41344965-aa822b92-6f02-11e8-8c0c-b503f2bce895.png)
