### PR TITLE
Add select field for label attribute in TextEditor

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -13,7 +13,7 @@ interface DefaultAttributeComboProps {
 }
 // non default props
 interface AttributeComboProps extends Partial<DefaultAttributeComboProps> {
-  internalDataDef: Data;
+  internalDataDef?: Data;
   onAttributeChange: ((newAttrName: string) => void);
 }
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -151,7 +151,7 @@ class Rule extends React.Component<RuleProps, RuleState> {
             <RuleNameField value={rule.name} onChange={this.onNameChange} />
             <Preview
               symbolizer={rule.symbolizer}
-              features={gsData ? gsData.exampleFeatures : undefined}
+              internalDataDef={gsData}
               onSymbolizerChange={this.onSymbolizerChange}
             />
           </div>

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -14,6 +14,7 @@ import TextEditor from '../TextEditor/TextEditor';
 import './Editor.css';
 
 import 'openlayers/css/ol.css';
+import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultEditorProps {}
@@ -21,6 +22,7 @@ interface DefaultEditorProps {}
 // non default props
 interface EditorProps extends Partial<DefaultEditorProps> {
   symbolizer: Symbolizer;
+  internalDataDef?: Data;
   onSymbolizerChange: (symbolizer: Symbolizer) => void;
 }
 
@@ -93,6 +95,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
         return (
           <TextEditor
             symbolizer={symbolizer}
+            internalDataDef={this.props.internalDataDef}
             onSymbolizerChange={this.onSymbolizerChange}
           />
         );

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import * as ol from 'openlayers';
 
-import { FeatureCollection, GeometryObject } from 'geojson';
 import { Symbolizer, SymbolizerKind } from 'geostyler-style';
 
 import './Preview.css';
@@ -20,6 +19,7 @@ import {
   isEqual as _isEqual,
   get as _get
 } from 'lodash';
+import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultPreviewProps {
@@ -37,7 +37,7 @@ interface DefaultPreviewProps {
 
 // non default props
 interface PreviewProps extends Partial<DefaultPreviewProps> {
-  features?: FeatureCollection<GeometryObject>;
+  internalDataDef?: Data; 
   symbolizer: Symbolizer;
   onSymbolizerChange: (symbolizer: Symbolizer) => void;
 }
@@ -97,7 +97,10 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
     if (this.dataLayer) {
       this.applySymbolizerToMapFeatures(this.state.symbolizer);
     }
-    if (!_isEqual(this.props.features, prevProps.features)) {
+
+    const features = this.props.internalDataDef ? this.props.internalDataDef.exampleFeatures : undefined;
+    const prevFeatures = prevProps.internalDataDef ? prevProps.internalDataDef.exampleFeatures : undefined;
+    if (!_isEqual(features, prevFeatures)) {
       this.updateFeatures();
     }
   }
@@ -111,8 +114,8 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
       featureProjection: this.map.getView().getProjection()
     });
     // add data features to style according to symbolizer and zoom to them (when existing)
-    if (this.props.features) {
-      const olFeatures = format.readFeatures(this.props.features);
+    if (this.props.internalDataDef && this.props.internalDataDef.exampleFeatures) {
+      const olFeatures = format.readFeatures(this.props.internalDataDef.exampleFeatures);
       this.dataLayer.getSource().addFeatures(olFeatures);
     // create a simple feature to see the symbolizer anyway
     } else {
@@ -259,6 +262,7 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
       symbolizer,
       openEditorText,
       closeEditorText,
+      internalDataDef,
       onSymbolizerChange
     } = this.props;
 
@@ -280,6 +284,7 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
             this.state.editorVisible ?
             <Editor
               symbolizer={symbolizer}
+              internalDataDef={internalDataDef}
               onSymbolizerChange={onSymbolizerChange}
             /> : null
           }

--- a/src/Component/Symbolizer/TextEditor/TextEditor.css
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.css
@@ -1,0 +1,11 @@
+.gs-text-symbolizer-editor .ant-select-selection {
+  width: 90px;
+}
+
+.gs-text-symbolizer-editor .ant-row.ant-form-item.ant-form-item-no-colon {
+  margin-bottom: 0;
+}
+
+.gs-text-symbolizer-editor .ant-form-item-label {
+  display: none;
+}

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -21,6 +21,7 @@ import './TextEditor.css';
 
 // default props
 interface DefaultTextEditorProps {
+  fieldLabel: string;
   opacityLabel: string;
   colorLabel: string;
   sizeLabel: string;
@@ -38,6 +39,7 @@ interface TextEditorProps extends Partial<DefaultTextEditorProps> {
 class TextEditor extends React.Component<TextEditorProps, {}> {
 
   public static defaultProps: DefaultTextEditorProps = {
+    fieldLabel: 'Field',
     opacityLabel: 'Text-Opacity',
     colorLabel: 'Text-Color',
     sizeLabel: 'Text-Size',
@@ -51,6 +53,7 @@ class TextEditor extends React.Component<TextEditorProps, {}> {
 
   render() {
     const {
+      fieldLabel,
       opacityLabel,
       colorLabel,
       sizeLabel,
@@ -80,8 +83,8 @@ class TextEditor extends React.Component<TextEditorProps, {}> {
     return (
 
       <div className="gs-text-symbolizer-editor" >
-         <div className="editor-field width-field">
-          <span className="label">Foo</span>
+         <div className="editor-field attribute-field">
+          <span className="label">{fieldLabel}</span>
           <AttributeCombo
             value={symbolizer.field}
             internalDataDef={internalDataDef}

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -14,6 +14,10 @@ import {
 } from 'lodash';
 import FontPicker from '../Field/FontPicker/FontPicker';
 import OffsetField from '../Field/OffsetField/OffsetField';
+import AttributeCombo from '../../Filter/AttributeCombo/AttributeCombo';
+import { Data } from 'geostyler-data';
+
+import './TextEditor.css';
 
 // default props
 interface DefaultTextEditorProps {
@@ -27,6 +31,7 @@ interface DefaultTextEditorProps {
 // non default props
 interface TextEditorProps extends Partial<DefaultTextEditorProps> {
   symbolizer: TextSymbolizer;
+  internalDataDef?: Data;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
 }
 
@@ -50,7 +55,8 @@ class TextEditor extends React.Component<TextEditorProps, {}> {
       colorLabel,
       sizeLabel,
       offsetXLabel,
-      offsetYLabel
+      offsetYLabel,
+      internalDataDef
     } = this.props;
 
     const symbolizer = _cloneDeep(this.props.symbolizer);
@@ -72,7 +78,19 @@ class TextEditor extends React.Component<TextEditorProps, {}> {
     }
 
     return (
+
       <div className="gs-text-symbolizer-editor" >
+         <div className="editor-field width-field">
+          <span className="label">Foo</span>
+          <AttributeCombo
+            value={symbolizer.field}
+            internalDataDef={internalDataDef}
+            onAttributeChange={(newAttrName: string) => {
+              symbolizer.field = newAttrName;
+              this.props.onSymbolizerChange(symbolizer);
+            }}
+          />
+        </div>
         <ColorField
           color={color}
           label={colorLabel}


### PR DESCRIPTION
This adds an `AttributeCombo` component to the `TextEditor` in order to let the user select the field / attribute which is used as label in the map.

Herewith the `SymbolizerPreview` is changed that it accepts the full internal data object (instead of just the features), so the schema can be forwarded to the new `AttributeCombo`.

At the moment the preview only works for string based fields. A separate issue will opened since this could be a problem in the [geostyler-openlayers-parser](https://github.com/terrestris/geostyler-openlayers-parser) .

![image](https://user-images.githubusercontent.com/1185547/41354560-99d115e8-6f1f-11e8-9868-0b7d6f1d6184.png)