### PR TITLE
Hide attribute type in AttributeCombo

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -9,6 +9,7 @@ interface DefaultAttributeComboProps {
   label: string;
   placeholder: string;
   value: string | undefined;
+  hideAttributeType: boolean;
   attributeNameFilter: (attrName: string) => boolean;
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
   help?: React.ReactNode;
@@ -32,6 +33,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
     label: 'Attribute',
     placeholder: 'Select Attribute',
     value: undefined,
+    hideAttributeType: false,
     attributeNameFilter: () => true,
     validateStatus: 'success',
     help: 'Please select an attribute.'
@@ -58,7 +60,8 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
       onAttributeChange,
       label,
       placeholder,
-      attributeNameFilter
+      attributeNameFilter,
+      hideAttributeType
     } = this.props;
 
     let options: Object[] = [];
@@ -81,7 +84,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
             key={attrName}
             value={attrName}
           >
-          {attrName} ({attrDefs[attrName].type})
+            {!hideAttributeType ? `${attrName} (${attrDefs[attrName].type})` : attrName}
           </Option>
         );
       });
@@ -105,7 +108,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
                 onChange={onAttributeChange}
                 placeholder={placeholder}
               >
-                  {options}
+                {options}
               </Select>
               :
               <Input

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -84,7 +84,7 @@ class AttributeCombo extends React.Component<AttributeComboProps, AttributeCombo
             key={attrName}
             value={attrName}
           >
-            {!hideAttributeType ? `${attrName} (${attrDefs[attrName].type})` : attrName}
+            {hideAttributeType ? attrName : `${attrName} (${attrDefs[attrName].type})`}
           </Option>
         );
       });

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -34,6 +34,7 @@ import {
 // default props
 interface DefaultComparisonFilterProps {
   filter: GsComparisonFilter;
+  hideAttributeType: boolean;
   attributeNameFilter: (attributeName: string) => boolean;
   attributeLabel?: string;
   attributePlaceholderString?: string;
@@ -98,6 +99,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
 
   public static defaultProps: DefaultComparisonFilterProps = {
     filter: ['==', '', null],
+    hideAttributeType: false,
     attributeNameFilter: () => true,
     attributeLabel: undefined,
     attributePlaceholderString: undefined,
@@ -399,6 +401,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 placeholder={this.props.attributePlaceholderString}
                 validateStatus={this.state.validateStatus.attribute}
                 help={this.props.attributeValidationHelpString}
+                hideAttributeType={this.props.hideAttributeType}
               />
             </Col>
             <Col span={4}>


### PR DESCRIPTION
This PR introduces a further prop (`boolean`) to hide attribute type in `AttributeCombo`