### PR TITLE
Introduces IconEditor

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.css
+++ b/src/Component/Symbolizer/Editor/Editor.css
@@ -16,3 +16,10 @@
   width: 140px;
   text-align: right;
 }
+
+.editor-field .ant-input-number,
+.editor-field .ant-select-selection,
+.editor-field .ant-input,
+.editor-field .color-preview {
+  width: 200px;
+}

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -21,9 +21,12 @@ import {
   cloneDeep as _cloneDeep
 } from 'lodash';
 import KindField from '../Field/KindField/KindField';
+import IconEditor from '../IconEditor/IconEditor';
 
 // default props
-interface DefaultEditorProps {}
+interface DefaultEditorProps {
+  defaultIconSource: string;
+}
 
 // non default props
 interface EditorProps extends Partial<DefaultEditorProps> {
@@ -54,6 +57,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
   dataLayer: ol.layer.Vector;
 
   public static defaultProps: DefaultEditorProps = {
+    defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
   };
 
   static getDerivedStateFromProps(
@@ -73,6 +77,17 @@ class Editor extends React.Component<EditorProps, EditorState> {
       case 'Circle':
         return (
           <CircleEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
+          />
+        );
+      case 'Icon':
+        if (!symbolizer.image) {
+          symbolizer.image = this.props.defaultIconSource;
+        }
+        return (
+          <IconEditor
+            defaultIconSource={this.props.defaultIconSource}
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
           />
@@ -100,7 +115,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
           />
         );
       default:
-        return `Symbolizer kind ${symbolizer.kind} not yet supported!`;
+        return `Unknown Symbolizer!`;
     }
   }
 

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -52,7 +52,6 @@ class FontPicker extends React.Component<FontPickerProps, {}> {
         <Select
           mode="tags"
           value={font}
-          style={{ width: 90 }}
           onChange={this.props.onChange}
         >
           {children}

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import {
+  Input
+} from 'antd';
+
+// default props
+interface ImageFieldDefaultProps {
+  image: string;
+  label: string;
+  placeholder: string;
+}
+
+// non default props
+interface ImageFieldProps extends Partial<ImageFieldDefaultProps> {
+  onChange: ((image: string) => void);
+}
+
+/**
+ * ImageField
+ */
+class ImageField extends React.Component<ImageFieldProps, {}> {
+
+  public static defaultProps: ImageFieldDefaultProps = {
+    image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+    label: 'Image',
+    placeholder: 'URL to image'
+  };
+
+  render() {
+    const {
+      image,
+      label,
+      placeholder,
+      onChange
+    } = this.props;
+
+    return (
+      <div className="editor-field image-field">
+        <span className="label">{`${label}:`}</span>
+        <Input
+          value={image}
+          placeholder={placeholder}
+          defaultValue={image}
+          onChange={(evt: any) => {
+            const value = evt.target.value;
+            onChange(value);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default ImageField;

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface RotateFieldDefaultProps {
+  rotate: number;
+  label: string;
+}
+
+// non default props
+interface RotateFieldProps extends Partial<RotateFieldDefaultProps> {
+  onChange: ((radius: number) => void);
+}
+
+/**
+ * RotateField
+ */
+class RotateField extends React.Component<RotateFieldProps, {}> {
+
+  public static defaultProps: RotateFieldDefaultProps = {
+    rotate: 2,
+    label: 'Rotate'
+  };
+
+  render() {
+    const {
+      rotate,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field rotate-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          min={-360}
+          max={360}
+          defaultValue={rotate}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default RotateField;

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// default props
+interface SizeFieldDefaultProps {
+  size: number;
+  label: string;
+}
+
+// non default props
+interface SizeFieldProps extends Partial<SizeFieldDefaultProps> {
+  onChange: ((radius: number) => void);
+}
+
+/**
+ * SizeField
+ */
+class SizeField extends React.Component<SizeFieldProps, {}> {
+
+  public static defaultProps: SizeFieldDefaultProps = {
+    size: 2,
+    label: 'Size'
+  };
+
+  render() {
+    const {
+      size,
+      label
+    } = this.props;
+
+    return (
+      <div className="editor-field size-field">
+        <span className="label">{`${label}:`}</span>
+        <InputNumber
+          step={0.1}
+          defaultValue={size}
+          onChange={this.props.onChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default SizeField;

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  IconSymbolizer
+} from 'geostyler-style';
+
+import OpacityField from '../Field/OpacityField/OpacityField';
+import ImageField from '../Field/ImageField/ImageField';
+
+import {
+  cloneDeep as _cloneDeep,
+  isEmpty as _isEmpty
+} from 'lodash';
+import RotateField from '../Field/RotateField/RotateField';
+import SizeField from '../Field/SizeField/SizeField';
+
+// default props
+interface DefaultIconEditorProps {
+  imageLabel: string;
+  opacityLabel: string;
+  rotateLabel: string;
+  sizeLabel: string;
+  defaultIconSource: string;
+}
+
+// non default props
+interface IconEditorProps extends Partial<DefaultIconEditorProps> {
+  symbolizer: IconSymbolizer;
+  onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+}
+
+class IconEditor extends React.Component<IconEditorProps, {}> {
+
+  public static defaultProps: DefaultIconEditorProps = {
+    imageLabel: 'Source',
+    opacityLabel: 'Opacity',
+    rotateLabel: 'Rotation',
+    sizeLabel: 'Size',
+    defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+  };
+
+  onSymbolizerChange = (symbolizer: Symbolizer) => {
+    this.props.onSymbolizerChange(symbolizer);
+  }
+
+  render() {
+    const {
+      defaultIconSource,
+      imageLabel,
+      opacityLabel,
+      rotateLabel,
+      sizeLabel
+    } = this.props;
+
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+
+    const {
+      opacity,
+      image,
+      size,
+      rotate
+    } = symbolizer;
+
+    const imageSrc = !_isEmpty(image) ? image : defaultIconSource;
+
+    return (
+      <div className="gs-icon-symbolizer-editor" >
+        <ImageField
+          image={imageSrc}
+          label={imageLabel}
+          onChange={(value: string) => {
+            symbolizer.image = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <SizeField
+          size={size}
+          label={sizeLabel}
+          onChange={(value: number) => {
+            symbolizer.size = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <RotateField
+          rotate={rotate}
+          label={rotateLabel}
+          onChange={(value: number) => {
+            symbolizer.rotate = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <OpacityField
+          opacity={opacity}
+          label={opacityLabel}
+          onChange={(value: number) => {
+            symbolizer.opacity = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default IconEditor;

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -255,7 +255,7 @@ class Preview extends React.Component<PreviewProps, PreviewState> {
         // apply new OL style to vector layer
         this.dataLayer.setStyle(olStyles[0]);
         return olStyles[0];
-    });
+      });
   }
 
   render() {

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -22,4 +22,5 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  max-width: 34%;
 }


### PR DESCRIPTION
This introduces the `IconEditor` to edit `IconSymbolizer`.

![image](https://user-images.githubusercontent.com/1849416/41413897-d0cac04c-6fe4-11e8-805d-38636a7fc3dc.png)

It includes some new Fields: `ImageField`, `RotateField`, `SizeField`

It also removes the inline style from the `FontPicker` due to changes in the `Editor.css`.

Closes #160 