### PR TITLE
Introduces sample values for ComparisonFilter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "port": 9230,
+      "runtimeArgs": [
+        "--inspect-brk=9230",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--watch"
+      ],
+      "runtimeExecutable": null,
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Tests Windows",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest",
+      "args": [
+        "-i",
+        "--watch"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "console": "integratedTerminal",
+      "outFiles": [
+        "${workspaceRoot}/build/dist/**/*"
+      ]
+    }
+  ]
+}

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -422,6 +422,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                   <TextFilterField
                     value={this.state && this.state.filter ? this.state.filter[2] as string : undefined}
                     internalDataDef={this.props.internalDataDef}
+                    selectedAttribute={this.state.attribute}
                     onValueChange={this.onValueChange}
                     label={this.props.valueLabel}
                     placeholder={this.props.valuePlaceholder}

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -22,9 +22,9 @@ describe('TextFilterField', () => {
     expect(wrapper).not.toBeUndefined();
   });
 
-  describe('#onChange', () => {
+  describe('#onInputChange', () => {
     it('is defined', () => {
-      expect(wrapper.instance().onChange).toBeDefined();
+      expect(wrapper.instance().onInputChange).toBeDefined();
     });
 
     it('calls onValueChange of props', () => {
@@ -33,9 +33,14 @@ describe('TextFilterField', () => {
           value: 'Test'
         }
       };
-
-      wrapper.instance().onChange(evtMock);
+      wrapper.instance().onInputChange(evtMock);
       expect(dummyFn.mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe('#onAutoCompleteChange', () => {
+    it('is defined', () => {
+      expect(wrapper.instance().onAutoCompleteChange).toBeDefined();
     });
   });
 

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 
-import { Input, Form } from 'antd';
+import { Input, Form, AutoComplete } from 'antd';
 import { Data } from 'geostyler-data';
+
+import {
+  get as _get
+} from 'lodash';
+import { Feature } from 'geojson';
 
 // default props
 interface DefaultTextFilterFieldProps {
@@ -15,6 +20,7 @@ interface DefaultTextFilterFieldProps {
 interface TextFilterFieldProps extends Partial<DefaultTextFilterFieldProps> {
   internalDataDef: Data;
   onValueChange: ((newValue: string) => void);
+  selectedAttribute: string;
 }
 // state
 interface TextFilterFieldState {
@@ -53,19 +59,39 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
    * Extracts the text value of the event object of 'onChange'
    * and passes it to the passed in 'onValueChange' handler.
    */
-  onChange = (e: any) => {
+  onInputChange = (e: any) => {
     this.props.onValueChange(e.target.value);
-
     this.setState({value: e.target.value});
   }
 
-  render() {
+  onAutoCompleteChange = (value: string) => {
+    this.props.onValueChange(value);
+    this.setState({value: value});
+  }
 
+  getSampleValuesFromFeatures = (): string[] => {
+    const {
+      selectedAttribute,
+      internalDataDef
+    } = this.props;
+    let sampleValues: string[] = [];
+    const features = _get(internalDataDef, 'exampleFeatures.features') || [];
+
+    features.forEach((feature: Feature) => {
+      const value = _get(feature, `properties[${selectedAttribute}]`);
+      if (value && sampleValues.indexOf(value) === -1) {
+        sampleValues.push(value);
+      }
+    });
+    return sampleValues.sort();
+  }
+
+  render() {
     const helpTxt = this.props.validateStatus !== 'success' ? this.props.help : null;
+    const sampleValues: string[] = this.getSampleValuesFromFeatures();
 
     return (
       <div className="gs-text-filter-fld">
-
         <Form.Item
           label={this.props.label}
           colon={false}
@@ -73,16 +99,25 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
           help={helpTxt}
           hasFeedback={true}
         >
-
+        {
+          sampleValues.length > 0 ?
+          <AutoComplete
+            value={this.state.value}
+            style={{ width: '100%' }}
+            onChange={this.onAutoCompleteChange}
+            placeholder={this.props.placeholder}
+            dataSource={sampleValues}
+            filterOption={(value: string , option: any) => option.key.includes(value)}
+          />
+          :
           <Input
             value={this.state.value}
             style={{ width: '100%' }}
-            onChange={this.onChange}
+            onChange={this.onInputChange}
             placeholder={this.props.placeholder}
           />
-
+        }
         </Form.Item>
-
       </div>
     );
   }

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -107,7 +107,9 @@ class TextFilterField extends React.Component<TextFilterFieldProps, TextFilterFi
             onChange={this.onAutoCompleteChange}
             placeholder={this.props.placeholder}
             dataSource={sampleValues}
-            filterOption={(value: string , option: any) => option.key.includes(value)}
+            filterOption={(value: string , option: any) => {
+              return option.key.toLowerCase().includes(value.toLowerCase());
+            }}
           />
           :
           <Input


### PR DESCRIPTION
This introduces sample values for the `ComparisonFilter`.

When a datasource is imported the standard input field is replaced with an `Autocomplete` field with the (unique) values of the selected Attribute.

The shown options are filtered by the current value. (lowercase & includes)

![sample_values](https://user-images.githubusercontent.com/1849416/41418885-08e54496-6ff1-11e8-9cb2-10731b3088a3.png)
