### PR TITLE
Set download button below code editor

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -3,7 +3,7 @@
   text-align: left;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-end;
 }
 
 .gs-code-editor-codemirror {
@@ -28,6 +28,7 @@
 }
 
 .gs-code-editor-download-button {
-  float: right;
+  width: 150px;
+  margin-top: 10px;
 }
 

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -204,13 +204,6 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
           >
             {this.getParserOptions()}
           </Select>
-          <Button
-            className="gs-code-editor-download-button"
-            type="primary"
-            onClick={this.onDownloadButtonClick}
-          >
-            {downloadButtonLabel}
-          </Button>
         </div>
         <CodeMirror
           className="gs-code-editor-codemirror"
@@ -228,6 +221,13 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
         <div className="gs-code-editor-errormessage">
           {this.state.invalidMessage}
         </div>
+        <Button
+            className="gs-code-editor-download-button"
+            type="primary"
+            onClick={this.onDownloadButtonClick}
+        >
+            {downloadButtonLabel}
+        </Button>
       </div>
     );
   }


### PR DESCRIPTION
This PR suggests a UI adaption, so the download button is placed below the CodeEditor. This prevents an ugly line break on smaller screens:

Before:

![image](https://user-images.githubusercontent.com/1185547/41454240-f57bef8a-7078-11e8-8ab9-681ad397bdf4.png)

After:

![image](https://user-images.githubusercontent.com/1185547/41454255-0200af84-7079-11e8-8d5b-02b317bbb482.png)