### PR TITLE
Align DataInput UIs when upload button is shown

### DIFF
--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -78,7 +78,7 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
     } = this.state;
 
     return (
-      <div>
+      <div className={activeParser ? 'gs-dataloader-right' : ''}>
         {label}
         <Select
           style={{ width: 300 }}

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -78,7 +78,7 @@ class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderState> {
     } = this.state;
 
     return (
-      <div>
+      <div className={activeParser ? 'gs-dataloader-right' : ''}>
         {label}
         <Select
           style={{ width: 300 }}

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -24,3 +24,7 @@
   flex-direction: column;
   max-width: 34%;
 }
+
+.gs-dataloader-right {
+  margin-left: 135px;
+}


### PR DESCRIPTION
This prevents the shift of the select field due to the shown upload button. So the fields keep aligned, even one DataInput shows the upload button and one does not.

Before:

![image](https://user-images.githubusercontent.com/1185547/41455515-aeff0a4c-707d-11e8-9f2b-ce4345fe0b06.png)

After:

![image](https://user-images.githubusercontent.com/1185547/41455491-9a7ba80a-707d-11e8-99af-cf7e48222d77.png)
