### PR TITLE
Validate minimum / maximum values in NumberField

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
@@ -8,7 +8,16 @@ describe('ComparisonFilter', () => {
   const onFilterChange = jest.fn();
   const attrValidator = jest.fn();
   const operatorValidator = jest.fn();
-  const valueValidator = jest.fn();
+  // TODO check why jest.fn() / mockReturnValue does not work here
+  // use native function and counter as fallback
+  let valueValidatorCalled = 0;
+  const valueValidator = () => {
+    valueValidatorCalled++;
+    return {
+      isValid: false,
+      errorMsg: 'Please enter valid input'
+    };
+  };
 
   let wrapper: any;
 
@@ -34,7 +43,7 @@ describe('ComparisonFilter', () => {
     onFilterChange.mockReset();
     attrValidator.mockReset();
     operatorValidator.mockReset();
-    valueValidator.mockReset();
+    valueValidatorCalled = 0;
   });
 
   it('is defined', () => {
@@ -119,7 +128,7 @@ describe('ComparisonFilter', () => {
       wrapper.instance().validateFilter();
       expect(attrValidator.mock.calls).toHaveLength(1);
       expect(operatorValidator.mock.calls).toHaveLength(1);
-      expect(valueValidator.mock.calls).toHaveLength(1);
+      expect(valueValidatorCalled).toBe(1);
     });
   });
 });

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -63,7 +63,8 @@ interface ValidationStatus {
 interface Validators {
   attribute: (attrName: string) => boolean;
   operator: (operator: string) => boolean;
-  value: (value: string | number | boolean | null, internalDataDef?: Data, attrType?: string) => ValidationResult;
+  value: (value: string | number | boolean | null, internalDataDef?: Data, selectedAttribute?: string)
+    => ValidationResult;
 }
 
 // state
@@ -105,14 +106,14 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
 
   /**
    * Default validation function for filter values.
-   * 
+   *
    * @param {string | number | boolean | null} newValue The new filter value
    * @param {Data} internalDataDef The internal data object
    * @param {string} selectedAttribute The currently seledted attribute field
    */
   static validateValue = (
-      newValue: string | number | boolean | null, 
-      internalDataDef: Data, 
+      newValue: string | number | boolean | null,
+      internalDataDef: Data,
       selectedAttribute: string): ValidationResult => {
 
     let isValid = true;


### PR DESCRIPTION
This adds a default validation function to validate the values of a `ComparisonFilter`. At the moment numeric values are validated whether

  - the value type is numeric and
  - a numeric value is inside the min/max-range

This reworks the validation function signature to

`value: (value: string | number | boolean| null, internalDataDef?: Data, selectedAttribute?: string) => ValidationResult;`

whereas `ValidationResult` is an object like

```
{
      isValid: false,
      erorMsg: 'Please enter a number'
}
```

This is a kind of an API break for existing validation functions. Maybe important for @ahennr.
