### PR TITLE
Add more API-Docs for props

### DIFF
--- a/src/Component/FieldSet/FieldSet.tsx
+++ b/src/Component/FieldSet/FieldSet.tsx
@@ -7,7 +7,9 @@ import './FieldSet.css';
 interface DefaultFieldSetProps {}
 // non default props
 interface FieldSetProps extends Partial<DefaultFieldSetProps> {
+  /** Title to be rendered on top of the FieldSet */
   title: string;
+  /** Callback function for onChange of the checkbox  */
   onCheckChange?: (e: any) => void;
 }
 
@@ -17,7 +19,8 @@ interface FieldSetState {
 }
 
 /**
- * Input field for a numeric filter value.
+ * A container for grouping sets of fields similar to a HTML fieldset element.
+ * A title and a checkbox will be rendered on the top border of the component.
  */
 class FieldSet extends React.Component<FieldSetProps, FieldSetState> {
 

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -6,17 +6,29 @@ const Option = Select.Option;
 
 // default props
 interface DefaultAttributeComboProps {
+  /** Label for this field */
   label: string;
+  /** The default text to place into the empty field */
   placeholder: string;
+  /** Initial value set to the field */
   value: string | undefined;
+  /** Set true to hide the attribute's type in the select options */
   hideAttributeType: boolean;
+  /**
+   * A custom filter function which is passed each attribute.
+   * Should return true to accept each attribute or false to reject it.
+   */
   attributeNameFilter: (attrName: string) => boolean;
+  /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  /** Element to show a help text */
   help?: React.ReactNode;
 }
 // non default props
 interface AttributeComboProps extends Partial<DefaultAttributeComboProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef?: Data;
+  /** Callback function for onChange */
   onAttributeChange: ((newAttrName: string) => void);
 }
 

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -6,12 +6,16 @@ import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultBoolFilterFieldProps {
+  /** Label for this field */
   label: string;
+  /** Initial value set to the field */
   value: boolean;
 }
 // non default props
 interface BoolFilterFieldProps extends Partial<DefaultBoolFilterFieldProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
+  /** Callback function for onChange */
   onValueChange: ((newValue: boolean) => void);
 }
 // state

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -33,24 +33,43 @@ import {
 
 // default props
 interface DefaultComparisonFilterProps {
+  /** Initial comparison filter object */
   filter: GsComparisonFilter;
+  /** Set true to hide the attribute's type in the AttributeCombo select options */
   hideAttributeType: boolean;
+  /**
+   * A custom filter function which is passed each attribute.
+   * Should return true to accept each attribute or false to reject it.
+   */
   attributeNameFilter: (attributeName: string) => boolean;
+  /** Label for the underlying AttributeCombo */
   attributeLabel?: string;
+  /** Placeholder text for the underlying AttributeCombo */
   attributePlaceholderString?: string;
+  /** Validation help text for the underlying AttributeCombo */
   attributeValidationHelpString?: string;
+  /** Label for the underlying OperatorCombo */
   operatorLabel?: string;
+  /** Placeholder for the underlying OperatorCombo */
   operatorPlaceholderString?: string;
+  /** Validation help text for the underlying OperatorCombo */
   operatorValidationHelpString?: string;
+  /** Label for the underlying value field */
   valueLabel?: string;
+  /** Placeholder for the underlying value field */
   valuePlaceholder?: string;
+  /** Validation help text for the underlying value field */
   valueValidationHelpString?: string;
+  /** Callback for onValidationChanged */
   onValidationChanged?: (status: ValidationStatus) => void;
+  /** Object aggregating validation functions for attribute, operator and value */
   validators: Validators;
 }
 // non default props
 interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
+  /** Callback function for onFilterChange */
   onFilterChange: ((compFilter: GsComparisonFilter) => void);
 }
 

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -4,16 +4,24 @@ import { Data } from 'geostyler-data';
 
 // default props
 interface DefaultNumberFilterFieldProps {
+  /** Label for this field */
   label: string;
+  /** The default text to place into the empty field */
   placeholder: string;
+  /** Initial value set to the field */
   value: number | undefined;
+  /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  /** Element to show a help text */
   help?: React.ReactNode;
 }
 // non default props
 interface NumberFilterFieldProps extends Partial<DefaultNumberFilterFieldProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
+  /** Callback for onChange */
   onValueChange: ((newValue: number) => void);
+  /** The selected attribute name */
   selectedAttribute: string;
 }
 // state

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -10,16 +10,24 @@ const Option = Select.Option;
 
 // default props
 interface DefaultOperatorComboProps {
+  /** Label for this field */
   label: string;
+  /** The default text to place into the empty field */
   placeholder: string;
+  /** Initial value set to the field */
   value: ComparisonOperator | undefined;
+  /** List of operators to show in this combo */
   operators: string[];
+  /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  /** Element to show a help text */
   help?: React.ReactNode;
 }
 // non default props
 interface OperatorComboProps extends Partial<DefaultOperatorComboProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
+  /** Callback function for onChange */
   onOperatorChange: ((newOperator: ComparisonOperator) => void);
 }
 

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -10,16 +10,24 @@ import { Feature } from 'geojson';
 
 // default props
 interface DefaultTextFilterFieldProps {
+  /** Label for this field */
   label: string;
+  /** The default text to place into the empty field */
   placeholder: string;
+  /** Initial value set to the field */
   value: string | undefined;
+  /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  /** Element to show a help text */
   help?: React.ReactNode;
 }
 // non default props
 interface TextFilterFieldProps extends Partial<DefaultTextFilterFieldProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
+  /** Callback function for onChange */
   onValueChange: ((newValue: string) => void);
+  /** The selected attribute name */
   selectedAttribute: string;
 }
 // state

--- a/src/Component/Rule/RemoveButton/RemoveButton.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.tsx
@@ -5,11 +5,14 @@ import './RemoveButton.css';
 
 // default props
 interface DefaultRemoveButtonProps {
+  /** Button text */
   text: string;
 }
 // non default props
 interface RemoveButtonProps extends Partial<DefaultRemoveButtonProps> {
+  /** Index of the correspondig Rule object */
   ruleIdx: number;
+  /** Callback for onClick */
   onClick: ((ruleIdx: number) => void);
 }
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -30,13 +30,17 @@ import {
 
 // default props
 interface DefaultRuleProps {
+  /** Optional Rule object holding inital values for the component */
   rule: GsRule;
 }
 
 // non default props
 interface RuleProps extends Partial<DefaultRuleProps> {
+  /** Reference to internal data object (holding schema and example features) */
   internalDataDef?: GsData | null;
+  /** Callback for a changed Rule */
   onRuleChange?: (rule: GsRule, ruleBefore?: GsRule) => void;
+  /** Callback for onClick of the RemoveButton */
   onRemove?: (rule: GsRule) => void;
 }
 

--- a/src/Component/Rule/TitleField/TitleField.tsx
+++ b/src/Component/Rule/TitleField/TitleField.tsx
@@ -5,11 +5,14 @@ import './TitleField.css';
 
 // default props
 interface DefaultTitleFieldProps {
+  /** Label for this field */
   label: string;
+  /** The default text to place into the empty field */
   placeholder: string;
 }
 // non default props
 interface TitleFieldProps extends Partial<DefaultTitleFieldProps> {
+  /** Callback for onChange */
   onChange: ((newValue: string) => void);
 }
 


### PR DESCRIPTION
This adds the API-Docs for the props of the components in the packages

  - `Component/FieldSet`
  - `Component/Filter`
  - `Component/Rule`