### PR TITLE
Optimize app layout for small screens

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -470,7 +470,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
       <div className="gs-comparison-filter-ui">
         <Form>
           <Row gutter={16} justify="center">
-            <Col span={10}>
+            <Col span={10} className="gs-small-col">
               <AttributeCombo
                 value={this.state && this.state.filter ? this.state.filter[1] : undefined}
                 internalDataDef={this.props.internalDataDef}
@@ -483,7 +483,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 hideAttributeType={this.props.hideAttributeType}
               />
             </Col>
-            <Col span={4}>
+            <Col span={4} className="gs-small-col">
               <OperatorCombo
                 value={this.state && this.state.filter ? this.state.filter[0] : undefined}
                 internalDataDef={this.props.internalDataDef}
@@ -497,7 +497,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
             </Col>
             {
               this.state.textFieldVisible ?
-                <Col span={10}>
+                <Col span={10} className="gs-small-col">
                   <TextFilterField
                     value={this.state && this.state.filter ? this.state.filter[2] as string : undefined}
                     internalDataDef={this.props.internalDataDef}
@@ -513,7 +513,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
             }
             {
               this.state.numberFieldVisible ?
-                <Col span={10}>
+                <Col span={10} className="gs-small-col">
                   <NumberFilterField
                     value={this.state && this.state.filter ? this.state.filter[2] as number : undefined}
                     internalDataDef={this.props.internalDataDef}
@@ -529,7 +529,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
             }
             {
               this.state.boolFieldVisible ?
-                <Col span={10}>
+                <Col span={10} className="gs-small-col">
                   <BoolFilterField
                     value={this.state && this.state.filter ? this.state.filter[2] as boolean : undefined}
                     internalDataDef={this.props.internalDataDef}

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -70,15 +70,15 @@ class ScaleDenominator extends React.Component<ScaleDenominatorProps, ScaleDenom
 
   render() {
     return (
-      <div className="gs-max-scaledenominator">
+      <div className="gs-scaledenominator">
         <Row gutter={16} >
-          <Col span={12}>
+          <Col span={12} className="gs-small-col">
             <MinScaleDenominator
               value={_get(this.state, 'scaleDenominator.min')}
               onChange={this.onMinScaleDenomChange}
             />
           </Col>
-          <Col span={12}>
+          <Col span={12} className="gs-small-col">
             <MaxScaleDenominator
               value={_get(this.state, 'scaleDenominator.max')}
               onChange={this.onMaxScaleDenomChange}

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -28,3 +28,26 @@
 .gs-dataloader-right {
   margin-left: 135px;
 }
+
+/* Small devices (landscape phones, less than 768px) */
+@media (max-width: 767.98px) {
+  .gs-small-col {
+    width: auto;
+  }
+
+  .main-content {
+    display: block;
+  }
+
+  .editor-wrapper {
+    max-width: 95%;
+  }
+
+  .gs-dataloader-right {
+    margin-left: auto;
+  }
+
+  header > a {
+    margin-right: 10px;
+  }
+}


### PR DESCRIPTION
This optimizes the layout for small screens (phones and tablets in portrait mode). Graphical Editor and Code editor are shown one below the other. Same is done for child elements of `ScaleDenominator` and
`ComparisonFilter` UI.

Before:
![image](https://user-images.githubusercontent.com/1185547/41835904-69689ae6-7859-11e8-973e-b2cf4d2db004.png)

After:
![image](https://user-images.githubusercontent.com/1185547/41835876-57d3bb30-7859-11e8-9c44-7b1e3f8d32fb.png)