### PR TITLE
Replace name as key for Rule UI

### DIFF
--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -140,8 +140,8 @@ class Style extends React.Component<StyleProps, StyleState> {
       <div className="gs-style" >
         <NameField value={this.state.style.name} onChange={this.onNameChange} />
         {
-          rules.map((rule) => <Rule
-            key={rule.name}
+          rules.map((rule, idx) => <Rule
+            key={'rule_' + idx}
             rule={rule}
             onRemove={this.removeRule}
             internalDataDef={this.props.data}


### PR DESCRIPTION
This sets the key for the Rule UIs to somethings which is not related to the rule's name. Otherwise the Rule UI is re-created every time the user changes the rule name.

Fixes #234.