### PR TITLE
Updates packages and disable strictNullChecks

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
     "test:watch": "react-scripts-ts test --env=jsdom"
   },
   "devDependencies": {
-    "@types/codemirror": "0.0.56",
+    "@types/codemirror": "0.0.57",
     "@types/color": "3.0.0",
     "@types/enzyme": "3.1.11",
     "@types/file-saver": "1.3.0",
-    "@types/jest": "23.1.1",
+    "@types/jest": "23.1.3",
     "@types/geojson": "7946.0.4",
-    "@types/node": "10.3.5",
-    "@types/react": "16.4.1",
+    "@types/node": "10.5.1",
+    "@types/react": "16.4.5",
     "@types/ol": "4.6.2",
     "@types/react-color": "2.13.5",
     "@types/react-dom": "16.0.6",
@@ -77,7 +77,7 @@
     "rimraf": "2.6.2",
     "react-docgen-typescript": "1.6.1",
     "ts-jest": "22.4.6",
-    "typescript": "2.8.1"
+    "typescript": "2.9.2"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/Component/FieldSet/FieldSet.tsx
+++ b/src/Component/FieldSet/FieldSet.tsx
@@ -63,7 +63,7 @@ class FieldSet extends React.Component<FieldSetProps, FieldSetState> {
             if (this.state.visible) {
               return child;
             }
-            return;
+            return undefined;
           })}
         </fieldset>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
-    "strictNullChecks": true,
+    "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true
   },


### PR DESCRIPTION
This updates several pacakges.

It also sets `strictNullChecks:false` option to false in the `tsconfig.`

The option affected the use of `this.state` in many components. And it showed errors that this might be null... even the state was set in the constructor. To avoid this (falsy) warning the option was set to false.

Also `return;` has to be replaced with `return undefined;` :man_facepalming:.

Closes #259 
Closes #258
 Closes #257 
Closes #256 
Closes #255
 Closes #253 
Closes #252 
Closes #251