### PR TITLE
Fixes tests on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags",
     "styleguide": "styleguidist server",
     "start": "react-scripts-ts start",
-    "test": "CI=true react-scripts-ts test --env=jsdom",
+    "test": "CI=true react-scripts-ts test --env=jsdom --runInBand",
     "test:watch": "react-scripts-ts test --env=jsdom"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds [`--runInBand`](http://jestjs.io/docs/en/cli#runinband) to the test script to avoid tests timing out on Travis CI.