### PR TITLE
Update UI to LineSymbolizer changes

### DIFF
--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.spec.tsx
@@ -1,0 +1,19 @@
+import LineCapField from './LineCapField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('LineCapField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(LineCapField, {});
+  });
+
+  it('is defined', () => {
+    expect(LineCapField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import {
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+import {
+    LineSymbolizer
+} from 'geostyler-style';
+
+// default props
+interface LineCapFieldDefaultProps {
+  label: string;
+  capOptions: LineSymbolizer['cap'][];
+}
+
+// non default props
+interface LineCapFieldProps extends Partial<LineCapFieldDefaultProps> {
+  onChange: ((caps: LineSymbolizer['cap']) => void);
+  cap?: LineSymbolizer['cap'];
+}
+
+/**
+ * LineCapField to select between different line-cap options
+ */
+class LineCapField extends React.Component<LineCapFieldProps, {}> {
+
+  public static defaultProps: LineCapFieldDefaultProps = {
+    label: 'Line-Cap',
+    capOptions: ['butt', 'round', 'square']
+  };
+
+  getCapSelectOptions = () => {
+    return this.props.capOptions.map(capOpt => {
+        return (
+            <Option
+                key={capOpt}
+                value={capOpt}
+            >
+            {capOpt}
+            </Option>
+        );
+    });
+  }
+
+  render() {
+    const {
+      cap,
+      label,
+      onChange
+    } = this.props;
+
+    return (
+      <div className="editor-field line-cap">
+        <span className="label">{`${label}:`}</span>
+        <Select
+          value={cap}
+          onChange={onChange}
+        >
+          {this.getCapSelectOptions()}
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default LineCapField;

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.spec.tsx
@@ -1,0 +1,19 @@
+import LineJoinField from './LineJoinField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('LineJoinField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(LineJoinField, {});
+  });
+
+  it('is defined', () => {
+    expect(LineJoinField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import {
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+import {
+    LineSymbolizer
+} from 'geostyler-style';
+
+// default props
+interface LineJoinFieldDefaultProps {
+  label: string;
+  joinOptions: LineSymbolizer['join'][];
+}
+
+// non default props
+interface LineJoinFieldProps extends Partial<LineJoinFieldDefaultProps> {
+  onChange: ((caps: LineSymbolizer['join']) => void);
+  join?: LineSymbolizer['join'];
+}
+
+/**
+ * LineJoinField to select between different line-join options
+ */
+class LineJoinField extends React.Component<LineJoinFieldProps, {}> {
+
+  public static defaultProps: LineJoinFieldDefaultProps = {
+    label: 'Line-Join',
+    joinOptions: ['bevel', 'round', 'miter']
+  };
+
+  getJoinSelectOptions = () => {
+    return this.props.joinOptions.map(joinOpt => {
+        return (
+            <Option
+                key={joinOpt}
+                value={joinOpt}
+            >
+            {joinOpt}
+            </Option>
+        );
+    });
+  }
+
+  render() {
+    const {
+      join,
+      label,
+      onChange
+    } = this.props;
+
+    return (
+      <div className="editor-field line-join">
+        <span className="label">{`${label}:`}</span>
+        <Select
+          value={join}
+          onChange={onChange}
+        >
+          {this.getJoinSelectOptions()}
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default LineJoinField;

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -7,6 +7,7 @@ import {
 // default props
 interface OffsetFieldDefaultProps {
   label: string;
+  disabled?: boolean;
 }
 
 // non default props
@@ -27,7 +28,8 @@ class OffsetField extends React.Component<OffsetFieldProps, {}> {
   render() {
     const {
       offset,
-      label
+      label,
+      ...inputProps
     } = this.props;
 
     return (
@@ -37,6 +39,7 @@ class OffsetField extends React.Component<OffsetFieldProps, {}> {
           value={offset}
           step={1}
           onChange={this.props.onChange}
+          {...inputProps}
         />
       </div>
     );

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -23,6 +23,9 @@ export interface LineEditorLocale {
   widthLabel?: string;
   opacityLabel?: string;
   dashLabel?: string;
+  dashOffsetLabel?: string;
+  capLabel?: string;
+  joinLabel?: string;
 }
 
 // non default props
@@ -93,7 +96,7 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
         />
         <OffsetField
           offset={dashOffset}
-          label={dashOffsetLabel}
+          label={locale.dashOffsetLabel}
           onChange={(value: LineSymbolizer['dashOffset']) => {
             symbolizer.dashOffset = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -102,7 +105,7 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
         />
         <LineCapField
           cap={cap}
-          label={capLabel}
+          label={locale.capLabel}
           onChange={(value: LineSymbolizer['cap']) => {
             symbolizer.cap = value;
             this.props.onSymbolizerChange(symbolizer);
@@ -110,7 +113,7 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
         />
         <LineJoinField
           join={join}
-          label={joinLabel}
+          label={locale.joinLabel}
           onChange={(value: LineSymbolizer['join']) => {
             symbolizer.join = value;
             this.props.onSymbolizerChange(symbolizer);

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -9,6 +9,8 @@ import ColorField from '../Field/ColorField/ColorField';
 import OpacityField from '../Field/OpacityField/OpacityField';
 import WidthField from '../Field/WidthField/WidthField';
 import LineDashField from '../Field/LineDashField/LineDashField';
+import LineCapField from '../Field/LineCapField/LineCapField';
+import LineJoinField from '../Field/LineJoinField/LineJoinField';
 
 const _cloneDeep = require('lodash/cloneDeep');
 
@@ -44,7 +46,9 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
       color,
       width,
       opacity,
-      dasharray
+      dasharray,
+      cap,
+      join
     } = symbolizer;
 
     const {
@@ -82,6 +86,22 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
           label={locale.dashLabel}
           onChange={(value: number[]) => {
             symbolizer.dasharray = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <LineCapField
+          cap={cap}
+          label={capLabel}
+          onChange={(value: LineSymbolizer['cap']) => {
+            symbolizer.cap = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+        />
+        <LineJoinField
+          join={join}
+          label={joinLabel}
+          onChange={(value: LineSymbolizer['join']) => {
+            symbolizer.join = value;
             this.props.onSymbolizerChange(symbolizer);
           }}
         />

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -11,6 +11,7 @@ import WidthField from '../Field/WidthField/WidthField';
 import LineDashField from '../Field/LineDashField/LineDashField';
 import LineCapField from '../Field/LineCapField/LineCapField';
 import LineJoinField from '../Field/LineJoinField/LineJoinField';
+import OffsetField from '../Field/OffsetField/OffsetField';
 
 const _cloneDeep = require('lodash/cloneDeep');
 
@@ -48,7 +49,8 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
       opacity,
       dasharray,
       cap,
-      join
+      join,
+      dashOffset
     } = symbolizer;
 
     const {
@@ -88,6 +90,15 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
             symbolizer.dasharray = value;
             this.props.onSymbolizerChange(symbolizer);
           }}
+        />
+        <OffsetField
+          offset={dashOffset}
+          label={dashOffsetLabel}
+          onChange={(value: LineSymbolizer['dashOffset']) => {
+            symbolizer.dashOffset = value;
+            this.props.onSymbolizerChange(symbolizer);
+          }}
+          disabled={symbolizer.dasharray === undefined || symbolizer.dasharray.length === 0}
         />
         <LineCapField
           cap={cap}

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -119,6 +119,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
 
   componentDidUpdate(prevProps: PreviewProps, prevState: PreviewState) {
     if (this.dataLayer) {
+      debugger;
       this.applySymbolizerToMapFeatures(this.state.symbolizer);
     }
 
@@ -281,6 +282,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
     styleParser.writeStyle(style)
       .then((olStyles: OlStyle[]) => {
         // apply new OL style to vector layer
+        debugger;
         this.dataLayer.setStyle(olStyles[0]);
         return olStyles[0];
       });

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -119,7 +119,6 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
 
   componentDidUpdate(prevProps: PreviewProps, prevState: PreviewState) {
     if (this.dataLayer) {
-      debugger;
       this.applySymbolizerToMapFeatures(this.state.symbolizer);
     }
 
@@ -277,12 +276,10 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
         symbolizer: symbolizer
       }]
     };
-
     // parser style to OL style
     styleParser.writeStyle(style)
       .then((olStyles: OlStyle[]) => {
         // apply new OL style to vector layer
-        debugger;
         this.dataLayer.setStyle(olStyles[0]);
         return olStyles[0];
       });

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
+import LineCapField from './Component/Symbolizer/Field/LineCapField/LineCapField';
+import LineJoinField from './Component/Symbolizer/Field/LineJoinField/LineJoinField';
 import UploadButton from './Component/UploadButton/UploadButton';
 import Style from './Component/Style/Style';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
@@ -46,6 +48,8 @@ export {
   OpacityField,
   RadiusField,
   WidthField,
+  LineCapField,
+  LineJoinField,
   UploadButton,
   CircleEditor,
   IconEditor,

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import FillEditor from './Component/Symbolizer/FillEditor/FillEditor';
 import TextEditor from './Component/Symbolizer/TextEditor/TextEditor';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
 import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
+import OffsetField from './Component/Symbolizer/Field/OffsetField/OffsetField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
@@ -45,6 +46,7 @@ export {
   Preview,
   Editor,
   ColorField,
+  OffsetField,
   OpacityField,
   RadiusField,
   WidthField,

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -62,7 +62,10 @@ export default {
         colorLabel: 'Farbe',
         widthLabel: 'Breite',
         opacityLabel: 'Deckkraft',
-        dashLabel: 'Strichmuster'
+        dashLabel: 'Strichmuster',
+        dashOffsetLabel: 'Strichmuster Versatz',
+        capLabel: 'Verschluss',
+        joinLabel: 'Verknüpfung'
     },
     GsTextEditor: {
         fieldLabel: 'Feld',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -53,7 +53,10 @@ export default {
         colorLabel: 'Color',
         widthLabel: 'Width',
         opacityLabel: 'Opacity',
-        dashLabel: 'Dash Pattern'
+        dashLabel: 'Dash Pattern',
+        dashOffsetLabel: 'Dash Offset',
+        capLabel: 'Cap',
+        joinLabel: 'Join'
     },
     GsTextEditor: {
         fieldLabel: 'Field',


### PR DESCRIPTION
**Important:** Please wait with merging this PR until 

- [x] [this PR in geostyler-openlayer-parser](https://github.com/terrestris/geostyler-openlayers-parser/pull/17)
- [x] [this PR in geostyler-sld-parser](https://github.com/terrestris/geostyler-sld-parser/pull/56)
- [x] [this PR in geostyler-style](https://github.com/terrestris/geostyler-style/pull/38)
- [x] [this PR in types/ol](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27892)
were merged.

Ui now also handles `lineCap`, `lineJoin` and `lineDashOffset` in LineSymbolizer. `lineDashOffset` field is only active, if a lineDash was specified.

In order to make it running without the PR of types/ol, you can add following lines to `node_modules/@types/openlayers/index.d.ts` (the other three PRs must be merged before, anyway):

line 10144:
```
/**
 * Get the line dash offset style for the stroke.
 * @return Line dash offset
 * @api
 */
getLineDashOffset(): number;

/**
 * Set the line dash offset.
 *
 * @param lineDashOffset Line dash offset.
 * @api
 */
 setLineDashOffset(lineDashOffset: number): void;

```
line 12366 (`Interface StrokeOptions`):
```
lineDashOffset?: number;
```