### PR TITLE
Mapping function for operator names

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -52,6 +52,8 @@ export interface DefaultComparisonFilterProps {
   operatorPlaceholderString?: string;
   /** Validation help text for the underlying OperatorCombo */
   operatorValidationHelpString?: string;
+  /** Mapping function for operator names of unterlying OperatorCombo */
+  operatorNameMappingFunction?: (originalOperatorName: string) => string;
   /** Label for the underlying value field */
   valueLabel?: string;
   /** Placeholder for the underlying value field */
@@ -178,6 +180,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
     operatorLabel: undefined,
     operatorPlaceholderString: undefined,
     operatorValidationHelpString: undefined,
+    operatorNameMappingFunction: n => n,
     valueLabel: undefined,
     valuePlaceholder: undefined,
     valueValidationHelpString: undefined,
@@ -486,6 +489,7 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 internalDataDef={this.props.internalDataDef}
                 onOperatorChange={this.onOperatorChange}
                 operators={this.state.allowedOperators}
+                operatorNameMappingFunction={this.props.operatorNameMappingFunction}
                 placeholder={this.props.operatorPlaceholderString}
                 label={this.props.operatorLabel}
                 validateStatus={this.state.validateStatus.operator}

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -16,6 +16,8 @@ interface DefaultOperatorComboProps {
   value: ComparisonOperator | undefined;
   /** List of operators to show in this combo */
   operators: string[];
+  /** Mapping function for operator names this combo */
+  operatorNameMappingFunction?: (originalOperatorName: string) => string;
   /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
@@ -43,6 +45,7 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
     placeholder: 'Select Operator',
     value: undefined,
     operators: ['==', '*=', '!=', '<', '<=', '>', '>='],
+    operatorNameMappingFunction: n => n,
     validateStatus: 'error',
     help: 'Please select an operator.'
   };
@@ -85,7 +88,7 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
           key={operator}
           value={operator}
         >
-        {operator}
+        {this.props.operatorNameMappingFunction(operator)}
         </Option>
       );
     });


### PR DESCRIPTION
This PR introduces a mapping function as prop for `OperatorCombo` and `ComparionFilter` to pass a function which maps operator names. By default, operator name is returned as is.

Possible scenario:

![image](https://user-images.githubusercontent.com/10559603/43763302-bafa3250-9a2a-11e8-977a-d8d2e7236023.png)
