### PR TITLE
Fix internationalisation minify bug

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -63,6 +63,8 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
     };
   }
 
+  static componentName: string = 'CodeEditor';
+
   componentDidMount() {
     if (this.props.style) {
       this.updateValueFromStyle(this.props.style);
@@ -227,4 +229,4 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
   }
 }
 
-export default localize(CodeEditor);
+export default localize(CodeEditor, CodeEditor.componentName);

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -41,6 +41,8 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
     this.state = {};
   }
 
+  static componentName: string = 'DataLoader';
+
   public static defaultProps: DefaultDataLoaderProps = {
     onDataRead: (data: GsData) => {return; }
   };
@@ -107,4 +109,4 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
   }
 }
 
-export default localize(DataLoader);
+export default localize(DataLoader, DataLoader.componentName);

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -42,6 +42,8 @@ class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderState> {
     this.state = {};
   }
 
+  static componentName: string = 'StyleLoader';
+
   public static defaultProps: DefaultStyleLoaderProps = {
     onStyleRead: (style: GsStyle) => {return; },
   };
@@ -107,4 +109,4 @@ class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderState> {
   }
 }
 
-export default localize(StyleLoader);
+export default localize(StyleLoader, StyleLoader.componentName);

--- a/src/Component/LocaleWrapper/LocaleWrapper.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.tsx
@@ -5,7 +5,7 @@ export interface LocaleProps {
     locale?: object;
 }
 
-export const localize = <P extends {}>(Component: React.ComponentType<P & LocaleProps>) => {
+export const localize = <P extends {}>(Component: React.ComponentType<P & LocaleProps>, componentName: string) => {
     class Wrap extends React.Component<P & LocaleProps> {
         static contextTypes = {
             antLocale: PropTypes.object
@@ -15,7 +15,7 @@ export const localize = <P extends {}>(Component: React.ComponentType<P & Locale
             const { antLocale } = this.context;
             return (
                 <Component 
-                    locale={antLocale['Gs' + Component.name]}
+                    locale={antLocale['Gs' + componentName]}
                     {...this.props}
                 />
             );

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -88,6 +88,8 @@ export class Rule extends React.Component<RuleProps, RuleState> {
     };
   }
 
+  static componentName: string = 'Rule';
+
   public static defaultProps: DefaultRuleProps = {
     rule: {
       name: 'My Style',
@@ -279,4 +281,4 @@ export class Rule extends React.Component<RuleProps, RuleState> {
   }
 }
 
-export default localize(Rule);
+export default localize(Rule, Rule.componentName);

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -48,6 +48,8 @@ export class ScaleDenominator extends React.Component<ScaleDenominatorProps, Sca
     };
   }
 
+  static componentName: string = 'ScaleDenominator';
+
   /**
    * Reacts on changing min scale and pushes the current state to the 'onChange' function
    */
@@ -104,4 +106,4 @@ export class ScaleDenominator extends React.Component<ScaleDenominatorProps, Sca
   }
 }
 
-export default localize(ScaleDenominator);
+export default localize(ScaleDenominator, ScaleDenominator.componentName);

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -58,6 +58,8 @@ class Style extends React.Component<StyleProps, StyleState> {
     };
   }
 
+  static componentName: string = 'Style';
+
   public static defaultProps: DefaultStyleProps = {
     style: {
       name: 'My Style',
@@ -191,4 +193,4 @@ class Style extends React.Component<StyleProps, StyleState> {
   }
 }
 
-export default localize(Style);
+export default localize(Style, Style.componentName);

--- a/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
+++ b/src/Component/Symbolizer/CircleEditor/CircleEditor.tsx
@@ -33,6 +33,8 @@ interface CircleEditorProps {
 
 class CircleEditor extends React.Component<CircleEditorProps, {}> {
 
+  static componentName: string = 'CircleEditor';
+
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
   }
@@ -108,4 +110,4 @@ class CircleEditor extends React.Component<CircleEditorProps, {}> {
   }
 }
 
-export default localize(CircleEditor);
+export default localize(CircleEditor, CircleEditor.componentName);

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -53,6 +53,8 @@ class ColorField extends React.Component<ColorFieldProps, ColorFieldState> {
     };
   }
 
+  static componentName: string = 'ColorField';
+
   onColorPreviewClick = () => {
     this.setState({
       colorPickerVisible: !this.state.colorPickerVisible
@@ -110,4 +112,4 @@ class ColorField extends React.Component<ColorFieldProps, ColorFieldState> {
   }
 }
 
-export default localize(ColorField);
+export default localize(ColorField, ColorField.componentName);

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -43,6 +43,8 @@ class KindField extends React.Component<KindFieldProps, {}> {
     symbolizerKinds: ['Circle', 'Fill', 'Icon', 'Line', 'Text']
   };
 
+  static componentName: string = 'KindField';
+
   getKindSelectOptions = (locale: KindFieldLocale) => {
     return this.props.symbolizerKinds!.map(kind => {
       return (
@@ -77,4 +79,4 @@ class KindField extends React.Component<KindFieldProps, {}> {
   }
 }
 
-export default localize(KindField);
+export default localize(KindField, KindField.componentName);

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -28,6 +28,8 @@ interface FillEditorProps {
 
 export class FillEditor extends React.Component<FillEditorProps, {}> {
   
+  static componentName: string = 'FillEditor';
+
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
   }
@@ -76,4 +78,4 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
   }
 }
 
-export default localize(FillEditor);
+export default localize(FillEditor, FillEditor.componentName);

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -41,6 +41,8 @@ class IconEditor extends React.Component<IconEditorProps, {}> {
     defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
   };
 
+  static componentName: string = 'IconEditor';
+
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
   }
@@ -101,4 +103,4 @@ class IconEditor extends React.Component<IconEditorProps, {}> {
   }
 }
 
-export default localize(IconEditor);
+export default localize(IconEditor, IconEditor.componentName);

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -31,6 +31,8 @@ interface LineEditorProps {
 
 export class LineEditor extends React.Component<LineEditorProps, {}> {
 
+  static componentName: string = 'LineEditor';
+
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
   }
@@ -88,4 +90,4 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
   }
 }
 
-export default localize(LineEditor);
+export default localize(LineEditor, LineEditor.componentName);

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -106,6 +106,8 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
     };
   }
 
+  static componentName: string = 'Preview';
+
   static getDerivedStateFromProps(
       nextProps: PreviewProps,
       prevState: PreviewState): Partial<PreviewState> {
@@ -323,4 +325,4 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
   }
 }
 
-export default localize(Preview);
+export default localize(Preview, Preview.componentName);

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -41,6 +41,8 @@ interface TextEditorProps {
 
 export class TextEditor extends React.Component<TextEditorProps, {}> {
 
+  static componentName: string = 'TextEditor';
+  
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);
   }
@@ -138,4 +140,4 @@ export class TextEditor extends React.Component<TextEditorProps, {}> {
   }
 }
 
-export default localize(TextEditor);
+export default localize(TextEditor, TextEditor.componentName);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,6 +55,8 @@ class App extends React.Component<AppProps, AppState> {
     };
   }
 
+  static componentName: string = 'App';
+
   render() {
     const { locale } = this.props;
     return (
@@ -109,4 +111,4 @@ class App extends React.Component<AppProps, AppState> {
   }
 }
 
-export default localize(App);
+export default localize(App, App.componentName);

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
 import UploadButton from './Component/UploadButton/UploadButton';
 import Style from './Component/Style/Style';
+import { localize } from './Component/LocaleWrapper/LocaleWrapper';
 
 export {
   FieldSet,
@@ -51,5 +52,6 @@ export {
   LineEditor,
   FillEditor,
   TextEditor,
-  Style
+  Style,
+  localize
 };


### PR DESCRIPTION
localize from LocaleWrapper.ts did not work properly when minified. Due to renaming of class names, localize could not find the matching properties in the language packs. Bug was fixed through adding the original class name of a component as additional parameter in localize.

Every class that is wrapped in localize now has a static property componentName. This property will then be added as parameter to localize.