### PR TITLE
Fix only partially visible colorpicker

### DIFF
--- a/src/Component/Symbolizer/Preview/Preview.css
+++ b/src/Component/Symbolizer/Preview/Preview.css
@@ -21,4 +21,5 @@
   border: 1px solid lightgrey;
   padding: 5px;
   z-index: 2;
+  overflow: visible;
 }


### PR DESCRIPTION
By setting overflow of Tab to visible, issue of only partially visible colorpickers is resolved.

resolves #333 

![image](https://user-images.githubusercontent.com/12186477/44099683-75c75abe-9fe3-11e8-986e-fe7aeec8e1bf.png)
