### PR TITLE
Mapping function for titles in operator combo and disable titles

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -48,12 +48,16 @@ export interface DefaultComparisonFilterProps {
   attributeValidationHelpString?: string;
   /** Label for the underlying OperatorCombo */
   operatorLabel?: string;
+  /** Show title of selected item in underlying OperatorCombo */
+  showOperatorTitles: boolean;
   /** Placeholder for the underlying OperatorCombo */
   operatorPlaceholderString?: string;
   /** Validation help text for the underlying OperatorCombo */
   operatorValidationHelpString?: string;
   /** Mapping function for operator names of underlying OperatorCombo */
   operatorNameMappingFunction?: (originalOperatorName: string) => string;
+  /** Mapping function for operator title in underlying OperatorCombo */
+  operatorTitleMappingFunction?: (originalOperatorName: string) => string;
   /** Label for the underlying value field */
   valueLabel?: string;
   /** Placeholder for the underlying value field */
@@ -178,9 +182,11 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
     attributePlaceholderString: undefined,
     attributeValidationHelpString: undefined,
     operatorLabel: undefined,
+    showOperatorTitles: true,
     operatorPlaceholderString: undefined,
     operatorValidationHelpString: undefined,
     operatorNameMappingFunction: n => n,
+    operatorTitleMappingFunction: t => t,
     valueLabel: undefined,
     valuePlaceholder: undefined,
     valueValidationHelpString: undefined,
@@ -494,6 +500,8 @@ class ComparisonFilterUi extends React.Component<ComparisonFilterProps, Comparis
                 label={this.props.operatorLabel}
                 validateStatus={this.state.validateStatus.operator}
                 help={this.props.operatorValidationHelpString}
+                operatorTitleMappingFunction={this.props.operatorTitleMappingFunction}
+                showTitles={this.props.showOperatorTitles}
               />
             </Col>
             {

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -10,6 +10,8 @@ const Option = Select.Option;
 interface DefaultOperatorComboProps {
   /** Label for this field */
   label: string;
+  /** Show title of selected item */
+  showTitles: boolean;
   /** The default text to place into the empty field */
   placeholder: string;
   /** Initial value set to the field */
@@ -18,6 +20,8 @@ interface DefaultOperatorComboProps {
   operators: string[];
   /** Mapping function for operator names in this combo */
   operatorNameMappingFunction?: (originalOperatorName: string) => string;
+  /** Mapping function for operator title in this combo */
+  operatorTitleMappingFunction?: (originalOperatorName: string) => string;
   /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
@@ -42,10 +46,12 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
 
   public static defaultProps: DefaultOperatorComboProps = {
     label: 'Operator',
+    showTitles: true,
     placeholder: 'Select Operator',
     value: undefined,
     operators: ['==', '*=', '!=', '<', '<=', '>', '>='],
     operatorNameMappingFunction: n => n,
+    operatorTitleMappingFunction: t => t,
     validateStatus: 'error',
     help: 'Please select an operator.'
   };
@@ -83,10 +89,15 @@ class OperatorCombo extends React.Component<OperatorComboProps, OperatorState> {
 
     // create an option per attribute
     options = operators.map(operator => {
+      const title = this.props.showTitles
+        ? this.props.operatorTitleMappingFunction(operator)
+        : ' ';
+
       return (
         <Option
           key={operator}
           value={operator}
+          title={title}
         >
         {this.props.operatorNameMappingFunction(operator)}
         </Option>


### PR DESCRIPTION
This PR adds following props to `OperatorCombo`
* show title of selected item (when selected item hovered) -> `boolean`
* mapping function for operator titles