### PR TITLE
LineSymbolizer GraphicFill and GraphicStroke

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "geostyler-data": "0.5.0",
     "geostyler-geojson-parser": "0.3.0",
     "geostyler-openlayers-parser": "0.10.0",
-    "geostyler-sld-parser": "0.12.0",
+    "geostyler-sld-parser": "0.13.0",
     "geostyler-style": "0.11.0",
     "lodash": "4.17.10",
     "moment": "2.22.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags",
     "styleguide": "styleguidist server",
     "start": "react-scripts-ts start",
+    "start:styleguide": "styleguidist server",
     "test": "CI=true react-scripts-ts test --env=jsdom --runInBand --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\"",
     "test:watch": "react-scripts-ts test --env=jsdom --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\""
   },

--- a/public/img/openLayers_logo.svg
+++ b/public/img/openLayers_logo.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg3859"
+   height="100"
+   width="100"
+   version="1.1">
+  <defs
+     id="defs3861">
+    <clipPath
+       id="clipPath3849">
+      <rect
+         style="color:#000000;fill:none;stroke:#000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3851"
+         transform="matrix(-0.47673484,0.87904715,-0.95035547,-0.31116633,0,0)"
+         y="-1761.3143"
+         x="699.2251"
+         ry="89.573692"
+         height="396.80566"
+         width="394.26315" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata3864">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-952.36218)">
+    <rect
+       width="71.05851"
+       height="71.516754"
+       ry="16.143972"
+       x="-794.30432"
+       y="783.77881"
+       transform="matrix(0.76602036,-0.64281631,0.76990078,0.6381636,0,0)"
+       id="rect3017-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#005964;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.147975;marker:none;enable-background:accumulate" />
+    <rect
+       width="71.05851"
+       height="71.516754"
+       ry="16.143972"
+       x="-788.10034"
+       y="777.60608"
+       transform="matrix(0.76602036,-0.64281631,0.76990078,0.6381636,0,0)"
+       id="rect3017-7"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.147975;marker:none;enable-background:accumulate" />
+    <rect
+       width="71.05851"
+       height="71.516754"
+       ry="16.143972"
+       x="-781.23462"
+       y="770.77496"
+       transform="matrix(0.76602036,-0.64281631,0.76990078,0.6381636,0,0)"
+       id="rect3017"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#53c5d5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.147975;marker:none;enable-background:accumulate" />
+    <path
+       d="m 1233.8003,1119.4669 c -53.8878,178.2803 -220.6429,298.2666 -406.80645,292.7119 l -32.97308,-83.598 164.08844,-297.9751 z"
+       transform="matrix(-0.16766085,-0.06612953,0.06612953,-0.16766085,142.84327,1277.661)"
+       clip-path="url(#clipPath3849)"
+       id="path3812"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#35bcce;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate" />
+  </g>
+</svg>

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -70,7 +70,7 @@ class Style extends React.Component<StyleProps, StyleState> {
       name: 'My Style',
       rules: []
     },
-    defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+    defaultIconSource: 'img/openLayers_logo.svg'
   };
 
   componentDidUpdate(prevProps: any, prevState: any) {

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -61,7 +61,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
   dataLayer: OlLayerVector;
 
   public static defaultProps: DefaultEditorProps = {
-    defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+    defaultIconSource: 'img/openLayers_logo.svg',
     unknownSymbolizerText: `Unknown Symbolizer!`
   };
 

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.spec.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.spec.tsx
@@ -1,0 +1,29 @@
+import { GraphicTypeField } from './GraphicTypeField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('GraphicTypeField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(GraphicTypeField, {});
+  });
+
+  it('is defined', () => {
+    expect(GraphicTypeField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  it('gets the right default type select options', () => {
+    expect(wrapper.instance().getTypeSelectOptions()).toHaveLength(2);
+  });
+
+  it('gets the right non-default type select options', () => {
+    wrapper.setProps({
+      graphicTypes: ['Mark']
+    });
+    expect(wrapper.instance().getTypeSelectOptions()).toHaveLength(1);
+  });
+});

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { Select } from 'antd';
+
+import { GraphicType } from 'geostyler-style';
+
+import { localize } from '../../../LocaleWrapper/LocaleWrapper';
+
+const _get = require('lodash/get');
+
+const Option = Select.Option;
+
+interface GraphicTypeFieldLocale {
+  /** Rendered Text for Mark Option */
+  Mark: string;
+  /** Rendered Text for Icon Option */
+  Icon: string;
+}
+
+export interface DefaultGraphicTypeFieldProps {
+  /** List of selectable GraphicTypes for Select */
+  graphicTypes?: GraphicType[];
+  /** Label rendered next to Select */
+  label?: String;
+  /** Language package */
+  locale?: GraphicTypeFieldLocale;
+}
+
+interface GraphicTypeFieldProps extends DefaultGraphicTypeFieldProps {
+  /** Currently selected GraphicType */
+  graphicType?: GraphicType;
+  /** Callback when selection changes */
+  onChange: ((type: GraphicType) => void);
+}
+
+/** GraphicTypeField to select between different GraphicTypes */
+export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}> {
+
+  static componentName: string = 'GraphicTypeField';
+
+  public static defaultProps: DefaultGraphicTypeFieldProps = {
+    graphicTypes: ['Mark', 'Icon'],
+    label: 'Graphic'
+  };
+
+  /**
+   * Iterates over props.graphicTypes and returns an Option according to GraphicType
+   *
+   * @param {GraphicTypeFieldLocale} locale Language package used for the displayed text of an Option
+   * @return {React.ReactNode[]} List of Options
+   */
+  getTypeSelectOptions = (locale: GraphicTypeFieldLocale): React.ReactNode[] => {
+    return (this.props.graphicTypes.map((type: GraphicType) => {
+      const loc = _get(locale, 'graphicTypes[' + type + ']') || type;
+      return (
+        <Option
+          key={type}
+          value={type}
+        >
+          {loc}
+        </Option>
+      );
+    }));
+  }
+
+  render() {
+    const {
+      label,
+      locale,
+      graphicType,
+      graphicTypes,
+      onChange,
+      ...passThroughProps
+    } = this.props;
+
+    return (
+      <div className="editor-field graphictype-field">
+        <span className="label">{`${label}:`}</span>
+        <Select
+          value={graphicType}
+          onChange={onChange}
+          allowClear={true}
+          {...passThroughProps}
+        >
+          {this.getTypeSelectOptions(locale)}
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default localize(GraphicTypeField, GraphicTypeField.componentName);

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -22,7 +22,7 @@ interface ImageFieldProps extends Partial<ImageFieldDefaultProps> {
 class ImageField extends React.Component<ImageFieldProps, {}> {
 
   public static defaultProps: ImageFieldDefaultProps = {
-    image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+    image: 'img/openLayers_logo.svg',
     label: 'Image',
     placeholder: 'URL to image'
   };

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
@@ -56,7 +56,7 @@ describe('GraphicEditor', () => {
   it('returns IconSymbolizer as default IconGraphic', () => {
     const dummyIcon: IconSymbolizer = {
       kind: 'Icon',
-      image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+      image: 'img/openLayers_logo.svg'
     };
     expect(wrapper.instance().getDefaultIconGraphic()).toEqual(dummyIcon);
   });

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
@@ -1,0 +1,77 @@
+import GraphicEditor from './GraphicEditor';
+import TestUtil from '../../../Util/TestUtil';
+import {
+  PointSymbolizer,
+  GraphicType,
+  IconSymbolizer
+} from 'geostyler-style';
+// import MarkEditor from '../MarkEditor/MarkEditor';
+
+describe('GraphicEditor', () => {
+
+  const dummyGraphicType: GraphicType = 'Mark';
+  const dummyGraphic: PointSymbolizer = {
+    kind: 'Mark',
+    wellKnownName: 'Circle'
+  };
+
+  const dummyOnGraphicChange = (g: PointSymbolizer, gType: GraphicType): void => {
+    return;
+  };
+
+  let wrapper: any;
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(GraphicEditor, {
+      graphic: dummyGraphic,
+      graphicType: dummyGraphicType,
+      onGraphicChange: dummyOnGraphicChange
+    });
+  });
+
+  it('is defined', () => {
+    expect(GraphicEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  it('renders MarkEditor if graphicType is Mark', () => {
+    expect(wrapper.instance().getGraphicFields(dummyGraphicType).props.symbolizer.kind)
+      .toEqual('Mark');
+  });
+
+  it('renders IconEditor if graphicType is Icon', () => {
+    expect(wrapper.instance().getGraphicFields('Icon').props.symbolizer.kind).toEqual('Icon');
+  });
+
+  it('renders nothing if graphicType is not Mark or Icon', () => {
+    expect(wrapper.instance().getGraphicFields('Text')).toBeUndefined();
+  });
+
+  it('returns CircleSymbolizer as default MarkGraphic', () => {
+    expect(wrapper.instance().getDefaultMarkGraphic()).toEqual(dummyGraphic);
+  });
+
+  it('returns IconSymbolizer as default IconGraphic', () => {
+    const dummyIcon: IconSymbolizer = {
+      kind: 'Icon',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+    };
+    expect(wrapper.instance().getDefaultIconGraphic()).toEqual(dummyIcon);
+  });
+
+  // it('handles onGraphicTypeChange', () => {
+  //   const wrapperInstance = wrapper.instance();
+  //   console.log(wrapperInstance);
+  //   // const onGraphicChangeSpy = jest.spyOn(wrapperInstance.props, 'onGraphicChange');
+  //   wrapperInstance.onGraphicTypeChange('Mark');
+  //   wrapperInstance.onGraphicTypeChange('Icon');
+  //   wrapperInstance.onGraphicTypeChange('Wrong');
+  //   wrapperInstance.onGraphicTypeChange();
+  //   expect(wrapperInstance.props.onGraphicChange).toHaveBeenCalledTimes(4);
+
+  //   // onGraphicChangeSpy.mockReset();
+  //   // onGraphicChangeSpy.mockRestore();
+  // });
+});

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
@@ -5,27 +5,28 @@ import {
   GraphicType,
   IconSymbolizer
 } from 'geostyler-style';
-// import MarkEditor from '../MarkEditor/MarkEditor';
 
 describe('GraphicEditor', () => {
 
   const dummyGraphicType: GraphicType = 'Mark';
-  const dummyGraphic: PointSymbolizer = {
+  const dummyGraphicMark: PointSymbolizer = {
     kind: 'Mark',
     wellKnownName: 'Circle'
   };
-
-  const dummyOnGraphicChange = (g: PointSymbolizer, gType: GraphicType): void => {
-    return;
+  const dummyGraphicIcon: PointSymbolizer = {
+    kind: 'Icon',
+    image: 'img/openLayers_logo.svg'
   };
+  const onGraphicChangeSpy = jest.fn();
 
   let wrapper: any;
   beforeEach(() => {
     wrapper = TestUtil.shallowRenderComponent(GraphicEditor, {
-      graphic: dummyGraphic,
+      graphic: dummyGraphicMark,
       graphicType: dummyGraphicType,
-      onGraphicChange: dummyOnGraphicChange
+      onGraphicChange: onGraphicChangeSpy
     });
+    onGraphicChangeSpy.mockClear();
   });
 
   it('is defined', () => {
@@ -36,13 +37,13 @@ describe('GraphicEditor', () => {
     expect(wrapper).not.toBeUndefined();
   });
 
-  it('renders MarkEditor if graphicType is Mark', () => {
-    expect(wrapper.instance().getGraphicFields(dummyGraphicType).props.symbolizer.kind)
+  it('renders MarkEditor if graphic is Mark', () => {
+    expect(wrapper.instance().getGraphicFields(dummyGraphicMark).props.symbolizer.kind)
       .toEqual('Mark');
   });
 
-  it('renders IconEditor if graphicType is Icon', () => {
-    expect(wrapper.instance().getGraphicFields('Icon').props.symbolizer.kind).toEqual('Icon');
+  it('renders IconEditor if graphic is Icon', () => {
+    expect(wrapper.instance().getGraphicFields(dummyGraphicIcon).props.symbolizer.kind).toEqual('Icon');
   });
 
   it('renders nothing if graphicType is not Mark or Icon', () => {
@@ -50,7 +51,7 @@ describe('GraphicEditor', () => {
   });
 
   it('returns CircleSymbolizer as default MarkGraphic', () => {
-    expect(wrapper.instance().getDefaultMarkGraphic()).toEqual(dummyGraphic);
+    expect(wrapper.instance().getDefaultMarkGraphic()).toEqual(dummyGraphicMark);
   });
 
   it('returns IconSymbolizer as default IconGraphic', () => {
@@ -61,17 +62,25 @@ describe('GraphicEditor', () => {
     expect(wrapper.instance().getDefaultIconGraphic()).toEqual(dummyIcon);
   });
 
-  // it('handles onGraphicTypeChange', () => {
-  //   const wrapperInstance = wrapper.instance();
-  //   console.log(wrapperInstance);
-  //   // const onGraphicChangeSpy = jest.spyOn(wrapperInstance.props, 'onGraphicChange');
-  //   wrapperInstance.onGraphicTypeChange('Mark');
-  //   wrapperInstance.onGraphicTypeChange('Icon');
-  //   wrapperInstance.onGraphicTypeChange('Wrong');
-  //   wrapperInstance.onGraphicTypeChange();
-  //   expect(wrapperInstance.props.onGraphicChange).toHaveBeenCalledTimes(4);
+  it('handles onGraphicTypeChange', () => {
+    expect.assertions(9);
+    expect(onGraphicChangeSpy).not.toHaveBeenCalled();
+    const wrapperInstance = wrapper.instance();
 
-  //   // onGraphicChangeSpy.mockReset();
-  //   // onGraphicChangeSpy.mockRestore();
-  // });
+    wrapperInstance.onGraphicTypeChange('Mark');
+    expect(onGraphicChangeSpy).toHaveBeenCalled();
+    expect(onGraphicChangeSpy).toHaveBeenCalledWith(dummyGraphicMark);
+
+    wrapperInstance.onGraphicTypeChange('Icon');
+    expect(onGraphicChangeSpy).toHaveBeenCalled();
+    expect(onGraphicChangeSpy).toHaveBeenCalledWith(dummyGraphicIcon);
+
+    wrapperInstance.onGraphicTypeChange('Wrong');
+    expect(onGraphicChangeSpy).toHaveBeenCalled();
+    expect(onGraphicChangeSpy).toHaveBeenCalledWith(undefined);
+
+    wrapperInstance.onGraphicTypeChange();
+    expect(onGraphicChangeSpy).toHaveBeenCalled();
+    expect(onGraphicChangeSpy).toHaveBeenCalledWith(undefined);
+  });
 });

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -36,7 +36,7 @@ class GraphicEditor extends React.Component <GraphicEditorProps, {}> {
   public static defaultProps: DefaultGraphicEditorProps = {
     graphicTypeFieldLabel: 'Graphic-Type',
     iconEditorProps: {
-      defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+      defaultIconSource: 'img/openLayers_logo.svg'
     }
   };
 

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import {
+  PointSymbolizer,
+  GraphicType,
+  MarkSymbolizer,
+  IconSymbolizer
+} from 'geostyler-style';
+import MarkEditor from '../MarkEditor/MarkEditor';
+import IconEditor, { DefaultIconEditorProps } from '../IconEditor/IconEditor';
+import GraphicTypeField, { DefaultGraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
+
+const _get = require('lodash/get');
+
+export interface DefaultGraphicEditorProps {
+  /** Label being used on TypeField */
+  graphicTypeFieldLabel: string;
+  /** Default GraphicTypeFieldProps */
+  graphicTypeFieldProps?: DefaultGraphicTypeFieldProps;
+  /** Default IconEditorProps */
+  iconEditorProps?: DefaultIconEditorProps;
+}
+
+// non default props
+interface GraphicEditorProps extends Partial<DefaultGraphicEditorProps> {
+  /** PointSymbolizer that is being used as graphic */
+  graphic: PointSymbolizer;
+  /** Currently selected GraphicType */
+  graphicType: GraphicType;
+  /** Gets called when changing a graphic */
+  onGraphicChange: ((graphic: PointSymbolizer) => void);
+}
+
+/** GraphicEditor to select between different graphic options */
+class GraphicEditor extends React.Component <GraphicEditorProps, {}> {
+
+  public static defaultProps: DefaultGraphicEditorProps = {
+    graphicTypeFieldLabel: 'Graphic-Type',
+    iconEditorProps: {
+      defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+    }
+  };
+
+  /**
+   * Get the right Editor depending on kind of PointSymbolizer
+   *
+   * @param {PointSymbolizer} graphic Pointsymbolizer that should be editable
+   * @param {any} iconEditorProps PassTroughProps for IconEditor
+   * @return {React.ReactNode} MarkEditor or IconEditor or undefined
+   */
+  getGraphicFields = (graphic: PointSymbolizer, iconEditorProps?: any): React.ReactNode => {
+    if (_get(graphic, 'kind') === 'Mark') {
+      let markGraphic: MarkSymbolizer = graphic as MarkSymbolizer;
+      return (
+        <MarkEditor
+          symbolizer={markGraphic}
+          onSymbolizerChange={(symb: MarkSymbolizer) => {
+            this.props.onGraphicChange(symb);
+          }}
+        />
+      );
+    } else if (_get(graphic, 'kind') === 'Icon') {
+      return (
+        <IconEditor
+          symbolizer={graphic}
+          onSymbolizerChange={(symb: IconSymbolizer) => {
+            this.props.onGraphicChange(symb);
+          }}
+          {...iconEditorProps}
+        />
+      );
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
+   * Get a default MarkGraphic
+   *
+   * @return {MarkSymbolizer} WellKnownName Circle
+   */
+  getDefaultMarkGraphic = (): MarkSymbolizer => {
+    return ({
+      kind: 'Mark',
+      wellKnownName: 'Circle'
+    });
+  }
+
+  /**
+   * Get a default IconGraphic
+   *
+   * @return {IconSymbolizer} Icon
+   */
+  getDefaultIconGraphic = (): IconSymbolizer => {
+    return ({
+      kind: 'Icon',
+      image: this.props.iconEditorProps.defaultIconSource
+    });
+  }
+
+  /**
+   * If GraphicType changed, call props.onGraphicChange with default PointSymbolizers.
+   * If GraphicType was unselected, call props.onGraphicChange with undefined to reset values.
+   *
+   * @param {GraphicType} gType currently selected GraphicType
+   */
+  onGraphicTypeChange = (gType: GraphicType): void => {
+    if (gType === 'Mark') {
+      this.props.onGraphicChange(this.getDefaultMarkGraphic());
+    } else if (gType === 'Icon') {
+      this.props.onGraphicChange(this.getDefaultIconGraphic());
+    } else {
+      this.props.onGraphicChange(undefined);
+    }
+  }
+
+  render() {
+    const {
+      graphic,
+      graphicType,
+      graphicTypeFieldLabel,
+      graphicTypeFieldProps,
+      iconEditorProps
+    } = this.props;
+
+    return (
+      <div>
+      <GraphicTypeField
+        label={graphicTypeFieldLabel}
+        graphicType={graphicType}
+        onChange={(type: GraphicType) => {
+          this.onGraphicTypeChange(type);
+        }}
+        {...graphicTypeFieldProps}
+      />
+      {this.getGraphicFields(graphic, iconEditorProps)}
+    </div>
+    );
+  }
+}
+
+export default GraphicEditor;

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -38,7 +38,7 @@ interface IconEditorProps extends Partial<DefaultIconEditorProps> {
 class IconEditor extends React.Component<IconEditorProps, {}> {
 
   public static defaultProps: DefaultIconEditorProps = {
-    defaultIconSource: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg'
+    defaultIconSource: 'img/openLayers_logo.svg'
   };
 
   static componentName: string = 'IconEditor';

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
+import { Collapse } from 'antd';
+
 import {
   Symbolizer,
-  LineSymbolizer
+  LineSymbolizer,
+  PointSymbolizer
 } from 'geostyler-style';
 
 import ColorField from '../Field/ColorField/ColorField';
@@ -12,10 +15,14 @@ import LineDashField from '../Field/LineDashField/LineDashField';
 import LineCapField from '../Field/LineCapField/LineCapField';
 import LineJoinField from '../Field/LineJoinField/LineJoinField';
 import OffsetField from '../Field/OffsetField/OffsetField';
+import GraphicEditor from '../GraphicEditor/GraphicEditor';
 
 const _cloneDeep = require('lodash/cloneDeep');
+const _get = require('lodash/get');
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+
+const Panel = Collapse.Panel;
 
 // i18n
 export interface LineEditorLocale {
@@ -26,12 +33,17 @@ export interface LineEditorLocale {
   dashOffsetLabel?: string;
   capLabel?: string;
   joinLabel?: string;
+  graphicStrokeTypeLabel?: string;
+  graphicFillTypeLabel?: string;
 }
 
 // non default props
 interface LineEditorProps {
+  /** Symbolizer */
   symbolizer: LineSymbolizer;
+  /** Callback when symbolizer changes */
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
+  /** Language package */
   locale?: LineEditorLocale;
 }
 
@@ -53,7 +65,9 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
       dasharray,
       cap,
       join,
-      dashOffset
+      dashOffset,
+      graphicStroke,
+      graphicFill
     } = symbolizer;
 
     const {
@@ -62,63 +76,89 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
 
     return (
       <div className="gs-line-symbolizer-editor" >
-        <ColorField
-          color={color}
-          label={locale.colorLabel}
-          onChange={(value: string) => {
-            symbolizer.color = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <WidthField
-          width={width}
-          label={locale.widthLabel}
-          onChange={(value: number) => {
-            symbolizer.width = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <OpacityField
-          opacity={opacity}
-          label={locale.opacityLabel}
-          onChange={(value: number) => {
-            symbolizer.opacity = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <LineDashField
-          dashArray={dasharray}
-          label={locale.dashLabel}
-          onChange={(value: number[]) => {
-            symbolizer.dasharray = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <OffsetField
-          offset={dashOffset}
-          label={locale.dashOffsetLabel}
-          onChange={(value: LineSymbolizer['dashOffset']) => {
-            symbolizer.dashOffset = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-          disabled={symbolizer.dasharray === undefined || symbolizer.dasharray.length === 0}
-        />
-        <LineCapField
-          cap={cap}
-          label={locale.capLabel}
-          onChange={(value: LineSymbolizer['cap']) => {
-            symbolizer.cap = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <LineJoinField
-          join={join}
-          label={locale.joinLabel}
-          onChange={(value: LineSymbolizer['join']) => {
-            symbolizer.join = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
+        <Collapse bordered={false} defaultActiveKey={['1']} onChange={(key: string) => (null)}>
+          <Panel header="General" key="1">
+            <ColorField
+              color={color}
+              label={locale.colorLabel}
+              onChange={(value: string) => {
+                symbolizer.color = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <WidthField
+              width={width}
+              label={locale.widthLabel}
+              onChange={(value: number) => {
+                symbolizer.width = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <OpacityField
+              opacity={opacity}
+              label={locale.opacityLabel}
+              onChange={(value: number) => {
+                symbolizer.opacity = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <LineDashField
+              dashArray={dasharray}
+              label={locale.dashLabel}
+              onChange={(value: number[]) => {
+                symbolizer.dasharray = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <OffsetField
+              offset={dashOffset}
+              label={locale.dashOffsetLabel}
+              onChange={(value: LineSymbolizer['dashOffset']) => {
+                symbolizer.dashOffset = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+              disabled={symbolizer.dasharray === undefined || symbolizer.dasharray.length === 0}
+            />
+            <LineCapField
+              cap={cap}
+              label={locale.capLabel}
+              onChange={(value: LineSymbolizer['cap']) => {
+                symbolizer.cap = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <LineJoinField
+              join={join}
+              label={locale.joinLabel}
+              onChange={(value: LineSymbolizer['join']) => {
+                symbolizer.join = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+          </Panel>
+          <Panel header="Graphic Stroke" key="2">
+            <GraphicEditor
+              graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
+              graphic={graphicStroke}
+              graphicType={_get(graphicStroke, 'kind')}
+              onGraphicChange={(gStroke: PointSymbolizer) => {
+                symbolizer.graphicStroke = gStroke;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+          </Panel>
+          <Panel header="Graphic Fill" key="3">
+            <GraphicEditor
+              graphicTypeFieldLabel={locale.graphicFillTypeLabel}
+              graphic={graphicFill}
+              graphicType={_get(graphicFill, 'kind')}
+              onGraphicChange={(gFill: PointSymbolizer) => {
+                symbolizer.graphicFill = gFill;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+          </Panel>
+        </Collapse>
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,13 @@ import LineEditor from './Component/Symbolizer/LineEditor/LineEditor';
 import FillEditor from './Component/Symbolizer/FillEditor/FillEditor';
 import TextEditor from './Component/Symbolizer/TextEditor/TextEditor';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
+import GraphicEditor from './Component/Symbolizer/GraphicEditor/GraphicEditor';
 import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
 import OffsetField from './Component/Symbolizer/Field/OffsetField/OffsetField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
+import GraphicField from './Component/Symbolizer/Field/GraphicField/GraphicField';
 import LineCapField from './Component/Symbolizer/Field/LineCapField/LineCapField';
 import LineJoinField from './Component/Symbolizer/Field/LineJoinField/LineJoinField';
 import UploadButton from './Component/UploadButton/UploadButton';
@@ -44,11 +46,13 @@ export {
   MinScaleDenominator,
   Preview,
   Editor,
+  GraphicEditor,
   ColorField,
   OffsetField,
   OpacityField,
   RadiusField,
   WidthField,
+  GraphicField,
   LineCapField,
   LineJoinField,
   UploadButton,

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -66,7 +66,9 @@ export default {
         dashLabel: 'Strichmuster',
         dashOffsetLabel: 'Strichmuster Versatz',
         capLabel: 'Verschluss',
-        joinLabel: 'Verknüpfung'
+        joinLabel: 'Verknüpfung',
+        graphicStrokeTypeLabel: 'Graphic Stroke Type',
+        graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsTextEditor: {
         fieldLabel: 'Feld',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -57,7 +57,9 @@ export default {
         dashLabel: 'Dash Pattern',
         dashOffsetLabel: 'Dash Offset',
         capLabel: 'Cap',
-        joinLabel: 'Join'
+        joinLabel: 'Join',
+        graphicStrokeTypeLabel: 'Graphic Stroke Type',
+        graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsTextEditor: {
         fieldLabel: 'Field',


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/46)
- [x] [this PR from geostyler-sld-parser](https://github.com/terrestris/geostyler-sld-parser/pull/67)
were merged.

With this PR, geostyler can handle graphicFill and graphicStroke of a LineSymbolizer. This should allow defining styles as described in [this issue](https://github.com/terrestris/geostyler/issues/242). So far, two kinds of styles can be added to graphicFill and graphicStroke: wellKnownSymbol or Icon.

New Components for handling graphicFill and graphicStroke were added:
- **GraphicTypeField:** selecting between supported GraphicTypes (so far `Mark` and `Icon`)
- **GraphicEditor:** handling display of fields depending on GraphicTypeField selection (using `MarkEditor` or `IconEditor`)

Options in `GraphicTypeField` can be deselected. The property will then be removed from the style.

To keep the LineSymbolizer UI compact, antd's `Collapse` component was used to collapse/expand different sections within LineSymbolizer. This is subject of change, with regard to [this comment](https://github.com/terrestris/geostyler/issues/355#issuecomment-414199717).

**Note:** Openlayers API does not natively support graphicFill and graphicStroke. Thus, geostyler-openlayers-parser was not updated and the Preview does not render changes in graphicFill or graphicStroke. However, geostyler-sld-parser does parse graphicStroke and graphicFill.

**Example 1:** Expanded General section, Collapsed GraphicFill and GraphicStroke section
![image](https://user-images.githubusercontent.com/12186477/44332752-29887780-a46d-11e8-910f-afbc6c011492.png)

**Example 2:** Collapsed General, Expanded GraphicFill and GraphicStroke without anything selected
![image](https://user-images.githubusercontent.com/12186477/44332852-694f5f00-a46d-11e8-938d-c9c5342f3385.png)

**Example 3:** GraphicFill with WellKnownSymbol, GraphicStroke with Icon
![image](https://user-images.githubusercontent.com/12186477/44332929-a156a200-a46d-11e8-8e55-d1c42f3a2e87.png)

**Example 4:** Excerpt from CodeEditor with GraphicFill Icon
![image](https://user-images.githubusercontent.com/12186477/44333047-fc889480-a46d-11e8-8ae1-6d4f1dd4952f.png)
