### PR TITLE
FillSymbolizer GraphicFill

### DIFF
--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -1,22 +1,29 @@
 import * as React from 'react';
+import { Collapse } from 'antd';
 
 import {
   Symbolizer,
-  FillSymbolizer
+  FillSymbolizer,
+  PointSymbolizer
 } from 'geostyler-style';
 
 import ColorField from '../Field/ColorField/ColorField';
 import OpacityField from '../Field/OpacityField/OpacityField';
+import GraphicEditor from '../GraphicEditor/GraphicEditor';
 
 const _cloneDeep = require('lodash/cloneDeep');
+const _get = require('lodash/get');
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+
+const Panel = Collapse.Panel;
 
 // i18n
 export interface FillEditorLocale {
   fillOpacityLabel?: string;
   fillColorLabel?: string;
   outlineColorLabel?: string;
+  graphicFillTypeLabel?: string;
 }
 
 // non default props
@@ -40,7 +47,8 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
     const {
       color,
       opacity,
-      outlineColor
+      outlineColor,
+      graphicFill
     } = symbolizer;
 
     const {
@@ -49,30 +57,45 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
 
     return (
       <div className="gs-fill-symbolizer-editor" >
-        <ColorField
-          color={color}
-          label={locale.fillColorLabel}
-          onChange={(value: string) => {
-            symbolizer.color = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <OpacityField
-          opacity={opacity}
-          label={locale.fillOpacityLabel}
-          onChange={(value: number) => {
-            symbolizer.opacity = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
-        <ColorField
-          color={outlineColor}
-          label={locale.outlineColorLabel}
-          onChange={(value: string) => {
-            symbolizer.outlineColor = value;
-            this.props.onSymbolizerChange(symbolizer);
-          }}
-        />
+        <Collapse bordered={false} defaultActiveKey={['1']}>
+          <Panel header="General" key="1">
+            <ColorField
+              color={color}
+              label={locale.fillColorLabel}
+              onChange={(value: string) => {
+                symbolizer.color = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <OpacityField
+              opacity={opacity}
+              label={locale.fillOpacityLabel}
+              onChange={(value: number) => {
+                symbolizer.opacity = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <ColorField
+              color={outlineColor}
+              label={locale.outlineColorLabel}
+              onChange={(value: string) => {
+                symbolizer.outlineColor = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+          </Panel>
+          <Panel header="Graphic Fill" key="2">
+              <GraphicEditor
+                graphicTypeFieldLabel={locale.graphicFillTypeLabel}
+                graphic={graphicFill}
+                graphicType={_get(graphicFill, 'kind')}
+                onGraphicChange={(gFill: PointSymbolizer) => {
+                  symbolizer.graphicFill = gFill;
+                  this.props.onSymbolizerChange(symbolizer);
+                }}
+              />
+          </Panel>
+        </Collapse>
       </div>
     );
   }

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -53,7 +53,8 @@ export default {
     GsFillEditor: {
         fillOpacityLabel: 'Deckkraft Füllung',
         fillColorLabel: 'Füllfarbe',
-        outlineColorLabel: 'Randfarbe'
+        outlineColorLabel: 'Randfarbe',
+        graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {
         imageLabel: 'Quelle',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -42,7 +42,8 @@ export default {
     GsFillEditor: {
         fillOpacityLabel: 'Fill-Opacity',
         fillColorLabel: 'Fill-Color',
-        outlineColorLabel: 'Stroke-Color'
+        outlineColorLabel: 'Stroke-Color',
+        graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {
         imageLabel: 'Source',


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/48)
- [x] [this PR from geostyler-sld-parser](https://github.com/terrestris/geostyler-sld-parser/pull/71)
were merged.

With this PR, geostyler can handle graphicFill of a PolygonSymbolizer. This should allow defining styles as described in [this issue](https://github.com/terrestris/geostyler/issues/214). So far, two kinds of styles can be added to graphicFill: wellKnownSymbol or Icon.

To keep the FillEditor UI compact, antd's Collapse component was used to collapse/expand different sections within FillEditor. This is subject of change, with regard to [this comment](https://github.com/terrestris/geostyler/issues/355#issuecomment-414199717).

**Note:** Openlayers API does not natively support graphicFill for Polygons. Thus, geostyler-openlayers-parser was not updated and the Preview does not render changes in graphicFill. However, geostyler-sld-parser does parse graphicFill.

**Example 1:** FillEditor with Star GraphicFill
![image](https://user-images.githubusercontent.com/12186477/44408112-fd99ee80-a55f-11e8-923b-2162c73402bb.png)

**Example 2:** SLD excerpt from Example 1
```xml
          <PolygonSymbolizer>
            <Stroke>
              <CssParameter name="stroke">#b6b4c4</CssParameter>
            </Stroke>
            <Fill>
              <CssParameter name="fill">#4c2fdc</CssParameter>
              <CssParameter name="fill-opacity">1</CssParameter>
              <GraphicFill>
                <Graphic>
                  <Mark>
                    <WellKnownName>star</WellKnownName>
                    <Fill>
                      <CssParameter name="fill">#000000</CssParameter>
                    </Fill>
                    <Stroke>
                      <CssParameter name="stroke">#417505</CssParameter>
                      <CssParameter name="stroke-width">2</CssParameter>
                      <CssParameter name="stroke-opacity">1</CssParameter>
                    </Stroke>
                  </Mark>
                  <Size>5</Size>
                  <Opacity>1</Opacity>
                  <Rotation>45</Rotation>
                </Graphic>
              </GraphicFill>
            </Fill>
          </PolygonSymbolizer>
```

**Example 3:** FillEditor with external graphic as GraphicFill
![image](https://user-images.githubusercontent.com/12186477/44408192-2fab5080-a560-11e8-8e06-5392cf7a775c.png)

