### PR TITLE
[WIP] Handle format of IconSymbolizer

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -5,7 +5,8 @@ import OlLayerVector from 'ol/layer/vector';
 
 import {
   Symbolizer,
-  SymbolizerKind
+  SymbolizerKind,
+  IconMime
 } from 'geostyler-style';
 
 import MarkEditor from '../MarkEditor/MarkEditor';
@@ -77,6 +78,27 @@ class Editor extends React.Component<EditorProps, EditorState> {
     this.props.onSymbolizerChange(symbolizer);
   }
 
+  /**
+   * Extract image mime-type from filename. Supported mime-types are
+   * image/png, image/jpeg, image/gif and image/svg+xml
+   *
+   * @param {String} path The image filepath
+   * @return {IconMime} The mime-type of the image or undefined if mime-type not supported
+   */
+  getImageFormat = (path: string): IconMime => {
+    const imgExt = path.split('.').pop();
+    switch (imgExt) {
+      case 'png':
+      case 'jpeg':
+      case 'gif':
+        return `image/${imgExt}` as IconMime;
+      case 'svg':
+        return `image/${imgExt}+xml` as IconMime;
+      default:
+        return undefined;
+    }
+  }
+
   getUiFromSymbolizer = (symbolizer: Symbolizer): React.ReactNode => {
     switch (symbolizer.kind) {
       case 'Mark':
@@ -89,6 +111,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       case 'Icon':
         if (!symbolizer.image) {
           symbolizer.image = this.props.defaultIconSource;
+          symbolizer.format = this.getImageFormat(symbolizer.image);
         }
         return (
           <IconEditor

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   Input
 } from 'antd';
+import { IconMime } from 'geostyler-style';
 
 // default props
 interface ImageFieldDefaultProps {
@@ -13,7 +14,7 @@ interface ImageFieldDefaultProps {
 
 // non default props
 interface ImageFieldProps extends Partial<ImageFieldDefaultProps> {
-  onChange: ((image: string) => void);
+  onChange: ((image: string, mime?: IconMime) => void);
 }
 
 /**
@@ -26,6 +27,27 @@ class ImageField extends React.Component<ImageFieldProps, {}> {
     label: 'Image',
     placeholder: 'URL to image'
   };
+
+  /**
+   * Extract image mime-type from filename. Supported mime-types are
+   * image/png, image/jpeg, image/gif and image/svg+xml
+   *
+   * @param {String} path The image filepath
+   * @return {IconMime} The mime-type of the image or undefined if mime-type not supported
+   */
+  getImageFormat = (path: string): IconMime => {
+    const imgExt = path.split('.').pop();
+    switch (imgExt) {
+      case 'png':
+      case 'jpeg':
+      case 'gif':
+        return `image/${imgExt}` as IconMime;
+      case 'svg':
+        return `image/${imgExt}+xml` as IconMime;
+      default:
+        return undefined;
+    }
+  }
 
   render() {
     const {
@@ -44,7 +66,8 @@ class ImageField extends React.Component<ImageFieldProps, {}> {
           defaultValue={image}
           onChange={(evt: any) => {
             const value = evt.target.value;
-            onChange(value);
+            const mime = this.getImageFormat(value);
+            onChange(value, mime);
           }}
         />
       </div>

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import {
   Symbolizer,
-  IconSymbolizer
+  IconSymbolizer,
+  IconMime
 } from 'geostyler-style';
 
 import OpacityField from '../Field/OpacityField/OpacityField';
@@ -69,8 +70,9 @@ class IconEditor extends React.Component<IconEditorProps, {}> {
         <ImageField
           image={imageSrc}
           label={locale.imageLabel}
-          onChange={(value: string) => {
+          onChange={(value: string, mime: IconMime) => {
             symbolizer.image = value;
+            symbolizer.format = mime;
             this.props.onSymbolizerChange(symbolizer);
           }}
         />
@@ -82,6 +84,7 @@ class IconEditor extends React.Component<IconEditorProps, {}> {
             this.props.onSymbolizerChange(symbolizer);
           }}
         />
+
         <RotateField
           rotate={rotate}
           label={locale.rotateLabel}


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [ ] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/49)
- [ ] [this PR from geostyler-sld-parser](https://github.com/terrestris/geostyler-sld-parser/pull/72)
- [ ] [this PR from geostyler-openlayers-parser](https://github.com/terrestris/geostyler-openlayers-parser/pull/24)
were merged.

UI now also handles `format` property of IconSymbolizer. No components were added.

Supported mime-types are:
`image/png` `image/jpeg` `image/gif` `image/svg+xml`

**Example 1:** geostyler-style output of Icon

```json
"symbolizers": [
        {
          "kind": "Icon",
          "image": "img/openLayers_logo.svg",
          "format": "image/svg+xml"
        }
      ]
```

**Example 2:** SLD output of Icon

```xml
          <PointSymbolizer>
            <Graphic>
              <ExternalGraphic>
                <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="img/openLayers_logo.svg"/>
                <Format>image/svg+xml</Format>
              </ExternalGraphic>
            </Graphic>
          </PointSymbolizer>
```