### PR TITLE
update geostyler-openlayers-parser to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "file-saver": "1.3.8",
     "geostyler-data": "0.5.0",
     "geostyler-geojson-parser": "0.3.0",
-    "geostyler-openlayers-parser": "0.13.0",
+    "geostyler-openlayers-parser": "0.12.1",
     "geostyler-sld-parser": "0.15.0",
     "geostyler-style": "0.13.0",
     "lodash": "4.17.10",


### PR DESCRIPTION
greenkeeper did not update to geostyler-openlayers-parser v0.12.1, probably because v0.13.0 was released before. On [npm latest tag](https://www.npmjs.com/package/geostyler-openlayers-parser) is set to version v0.12.1. So this version was set in package.json.