### PR TITLE
Fixes and improvements

### DIFF
--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -23,6 +23,8 @@ export interface DefaultGraphicTypeFieldProps {
   label?: String;
   /** Language package */
   locale?: GraphicTypeFieldLocale;
+  /** If true GraphicTypeField can be cleared  */
+  clearable?: boolean;
 }
 
 interface GraphicTypeFieldProps extends DefaultGraphicTypeFieldProps {
@@ -39,7 +41,8 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}
 
   public static defaultProps: DefaultGraphicTypeFieldProps = {
     graphicTypes: ['Mark', 'Icon'],
-    label: 'Graphic'
+    label: 'Graphic',
+    clearable: true
   };
 
   /**
@@ -50,7 +53,7 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}
    */
   getTypeSelectOptions = (locale: GraphicTypeFieldLocale): React.ReactNode[] => {
     return (this.props.graphicTypes.map((type: GraphicType) => {
-      const loc = _get(locale, 'graphicTypes[' + type + ']') || type;
+      const loc = _get(locale, type) || type;
       return (
         <Option
           key={type}
@@ -69,6 +72,7 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}
       graphicType,
       graphicTypes,
       onChange,
+      clearable,
       ...passThroughProps
     } = this.props;
 
@@ -78,7 +82,7 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}
         <Select
           value={graphicType}
           onChange={onChange}
-          allowClear={true}
+          allowClear={clearable}
           {...passThroughProps}
         >
           {this.getTypeSelectOptions(locale)}

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -117,7 +117,7 @@ export class LineEditor extends React.Component<LineEditorProps, {}> {
                 symbolizer.dashOffset = value;
                 this.props.onSymbolizerChange(symbolizer);
               }}
-              disabled={symbolizer.dasharray === undefined || symbolizer.dasharray.length === 0}
+              disabled={symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0}
             />
             <LineCapField
               cap={cap}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import TitleField from './Component/Rule/TitleField/TitleField';
 import Rule from './Component/Rule/Rule';
 import MaxScaleDenominator from './Component/ScaleDenominator/MaxScaleDenominator';
 import MinScaleDenominator from './Component/ScaleDenominator/MinScaleDenominator';
+import ScaleDenominator from './Component/ScaleDenominator/ScaleDenominator';
 import Preview from './Component/Symbolizer/Preview/Preview';
 import Editor from './Component/Symbolizer/Editor/Editor';
 import LineEditor from './Component/Symbolizer/LineEditor/LineEditor';
@@ -52,6 +53,7 @@ export {
   Rule,
   MaxScaleDenominator,
   MinScaleDenominator,
+  ScaleDenominator,
   Preview,
   Editor,
   GraphicEditor,

--- a/src/index.js
+++ b/src/index.js
@@ -18,14 +18,22 @@ import FillEditor from './Component/Symbolizer/FillEditor/FillEditor';
 import TextEditor from './Component/Symbolizer/TextEditor/TextEditor';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
 import GraphicEditor from './Component/Symbolizer/GraphicEditor/GraphicEditor';
+import MarkEditor from './Component/Symbolizer/MarkEditor/MarkEditor';
+import WellKnownNameEditor from './Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor';
 import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
+import ImageField from './Component/Symbolizer/Field/ImageField/ImageField';
+import KindField from './Component/Symbolizer/Field/KindField/KindField';
 import OffsetField from './Component/Symbolizer/Field/OffsetField/OffsetField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
+import RotateField from './Component/Symbolizer/Field/RotateField/RotateField';
+import SizeField from './Component/Symbolizer/Field/SizeField/SizeField';
+import WellKnownNameField from './Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
 import GraphicTypeField from './Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField';
 import LineCapField from './Component/Symbolizer/Field/LineCapField/LineCapField';
 import LineJoinField from './Component/Symbolizer/Field/LineJoinField/LineJoinField';
+import LineDashField from './Component/Symbolizer/Field/LineDashField/LineDashField';
 import UploadButton from './Component/UploadButton/UploadButton';
 import Style from './Component/Style/Style';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
@@ -47,14 +55,22 @@ export {
   Preview,
   Editor,
   GraphicEditor,
+  MarkEditor,
+  WellKnownNameEditor,
   ColorField,
+  ImageField,
+  KindField,
   OffsetField,
   OpacityField,
   RadiusField,
+  RotateField,
+  SizeField,
+  WellKnownNameField,
   WidthField,
   GraphicTypeField,
   LineCapField,
   LineJoinField,
+  LineDashField,
   UploadButton,
   IconEditor,
   LineEditor,

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import OffsetField from './Component/Symbolizer/Field/OffsetField/OffsetField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
-import GraphicField from './Component/Symbolizer/Field/GraphicField/GraphicField';
+import GraphicTypeField from './Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField';
 import LineCapField from './Component/Symbolizer/Field/LineCapField/LineCapField';
 import LineJoinField from './Component/Symbolizer/Field/LineJoinField/LineJoinField';
 import UploadButton from './Component/UploadButton/UploadButton';
@@ -52,7 +52,7 @@ export {
   OpacityField,
   RadiusField,
   WidthField,
-  GraphicField,
+  GraphicTypeField,
   LineCapField,
   LineJoinField,
   UploadButton,

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -41,17 +41,17 @@ export default {
     },
     GsWellKnownNameEditor: {
         radiusLabel: 'Radius',
-        fillOpacityLabel: 'Deckkraft Füllung',
+        fillOpacityLabel: 'Fülldeckkraft',
         fillColorLabel: 'Füllfarbe',
-        strokeColorLabel: 'Randfarbe',
-        strokeWidthLabel: 'Randbreite',
-        strokeOpacityLabel: 'Deckkraft Rand',
+        strokeColorLabel: 'Strichfarbe',
+        strokeWidthLabel: 'Strichstärke',
+        strokeOpacityLabel: 'Strichdeckkraft',
         rotateLabel: 'Drehung',
         haloColorLabel: 'Halofarbe',
         haloWidthLabel: 'Halobreite'
     },
     GsFillEditor: {
-        fillOpacityLabel: 'Deckkraft Füllung',
+        fillOpacityLabel: 'Fülldeckkraft',
         fillColorLabel: 'Füllfarbe',
         outlineColorLabel: 'Randfarbe',
         graphicFillTypeLabel: 'Graphic Fill Type'
@@ -75,7 +75,7 @@ export default {
     },
     GsTextEditor: {
         fieldLabel: 'Feld',
-        opacityLabel: 'Deckkraft Text',
+        opacityLabel: 'Deckkraft',
         colorLabel: 'Textfarbe',
         sizeLabel: 'Textgröße',
         offsetXLabel: 'Versatz X',
@@ -95,9 +95,9 @@ export default {
     GsKindField: {
         label: 'Art',
         symbolizerKinds: {
-            Mark: 'Mark',
+            Mark: 'Punktsymbol',
             Fill: 'Füllung',
-            Icon: 'Icon',
+            Icon: 'Bilddatei',
             Line: 'Linie',
             Text: 'Text'
         }
@@ -109,7 +109,7 @@ export default {
         maxScaleDenominatorPlaceholderText: 'Max. Maßstabszahl eingeben (Optional)'
     },
     GsWellKnownNameField: {
-        label: 'WellKnownName',
+        label: 'Symbol',
         wellKnownNames: {
           Circle: 'Kreis',
           Square: 'Quadrat',
@@ -118,6 +118,10 @@ export default {
           Cross: 'Kreuz',
           X: 'X'
         }
+    },
+    GsGraphicTypeField: {
+        Mark: 'Punktsymbol',
+        Icon: 'Bilddatei'
     },
     ...de_DE
 };

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -100,7 +100,7 @@ export default {
         maxScaleDenominatorPlaceholderText: 'Enter max. Scale (Optional)'
     },
     GsWellKnownNameField: {
-        label: 'WellKnownName',
+        label: 'Symbol',
         wellKnownNames: {
           Circle: 'Circle',
           Square: 'Square',


### PR DESCRIPTION
**Important:** Please wait with merging this PR until new version of geostyler-openlayers-parser was released.


graphicTypeField was not exported correctly. instead of pointing to `/Field/GraphicTypeField/GraphicTypeField` it was pointed to `/Field/GraphicField/GraphicField`. 

Multiple other components were not exported in index.js.

Improved i18n translations.

Added graphicTypeField property `clearable`. 

