### PR TITLE
Add enableSymbolizerButton to Preview Component

### DIFF
--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -53,6 +53,7 @@ export interface PreviewLocale {
 
 // default props
 export interface DefaultPreviewProps {
+  enableSymbolizerButton: boolean;
   projection: string;
   dataProjection: string;
   showOsmBackground: boolean;
@@ -94,6 +95,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
   dataLayer: OlLayerVector;
 
   public static defaultProps: DefaultPreviewProps = {
+    enableSymbolizerButton: true,
     projection: 'EPSG:3857',
     dataProjection: 'EPSG:4326',
     showOsmBackground: true,
@@ -416,7 +418,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           )
         }
       </Tabs>
-  );
+    );
   }
 
   render() {
@@ -431,6 +433,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
       locale,
       symbolizers,
       onSymbolizerChange,
+      enableSymbolizerButton,
       ...editorProps
     } = this.props;
 
@@ -441,6 +444,8 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           className="map"
           style={{ height: mapHeight }}
         >
+        {
+          enableSymbolizerButton &&
           <Button
             className="gs-edit-preview-button"
             icon="edit"
@@ -448,10 +453,11 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           >
             {this.state.editorVisible ? locale.closeEditorText : locale.openEditorText}
           </Button>
-          {
-            this.state.editorVisible ?
-              this.getUIFromSymbolizers(this.state.symbolizers, {...editorProps}) : null
-          }
+        }
+        {
+          this.state.editorVisible && enableSymbolizerButton ?
+            this.getUIFromSymbolizers(this.state.symbolizers, {...editorProps}) : null
+        }
         </div>
       </div>
     );

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -53,7 +53,7 @@ export interface PreviewLocale {
 
 // default props
 export interface DefaultPreviewProps {
-  enableSymbolizerButton: boolean;
+  hideEditButton: boolean;
   projection: string;
   dataProjection: string;
   showOsmBackground: boolean;
@@ -95,7 +95,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
   dataLayer: OlLayerVector;
 
   public static defaultProps: DefaultPreviewProps = {
-    enableSymbolizerButton: true,
+    hideEditButton: false,
     projection: 'EPSG:3857',
     dataProjection: 'EPSG:4326',
     showOsmBackground: true,
@@ -433,7 +433,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
       locale,
       symbolizers,
       onSymbolizerChange,
-      enableSymbolizerButton,
+      hideEditButton,
       ...editorProps
     } = this.props;
 
@@ -445,7 +445,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           style={{ height: mapHeight }}
         >
         {
-          enableSymbolizerButton &&
+          !hideEditButton &&
           <Button
             className="gs-edit-preview-button"
             icon="edit"
@@ -455,7 +455,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           </Button>
         }
         {
-          this.state.editorVisible && enableSymbolizerButton ?
+          this.state.editorVisible && !hideEditButton ?
             this.getUIFromSymbolizers(this.state.symbolizers, {...editorProps}) : null
         }
         </div>


### PR DESCRIPTION
Additional prop `enableSymbolizerButton` was added to Preview component. Defaults to `true`. If false, the Preview does not show the `Edit Symbolizer` and hence, symbolizers cannot be opened from within the Preview. This is useful for cases where Symbolizers should not be placed within the Preview but at other positions, e.g. above the ScaleDenominator Fieldset.