### PR TITLE
Introduces the EditorWindow and MultiEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,24 @@
     "url": "https://github.com/terrestris/geostyler/issues"
   },
   "homepage": ".",
+  "scripts": {
+    "build": "npm run build:dist && npm run build:app && npm run build:styleguide",
+    "build:app": "react-scripts-ts build",
+    "build:dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
+    "build:styleguide": "styleguidist build",
+    "eject": "react-scripts-ts eject",
+    "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
+    "lint:prod": "tslint --project tsconfig.json --config tslint.prod.json && tsc --noEmit --project tsconfig.json",
+    "pretest": "npm run lint:prod",
+    "prebuild": "rimraf dist/** && rimraf build/**",
+    "prepublishOnly": "npm run build",
+    "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags",
+    "styleguide": "styleguidist server",
+    "start": "react-scripts-ts start",
+    "start:styleguide": "styleguidist server",
+    "test": "CI=true react-scripts-ts test --env=jsdom --runInBand --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\"",
+    "test:watch": "react-scripts-ts test --env=jsdom --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\""
+  },
   "dependencies": {
     "antd": "3.9.3",
     "blob": "0.0.4",
@@ -41,25 +59,8 @@
     "react-codemirror2": "5.1.0",
     "react-color": "2.14.1",
     "react-dom": "16.5.2",
+    "react-rnd": "9.0.2",
     "react-scripts-ts": "2.17.0"
-  },
-  "scripts": {
-    "build": "npm run build:dist && npm run build:app && npm run build:styleguide",
-    "build:app": "react-scripts-ts build",
-    "build:dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
-    "build:styleguide": "styleguidist build",
-    "eject": "react-scripts-ts eject",
-    "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
-    "lint:prod": "tslint --project tsconfig.json --config tslint.prod.json && tsc --noEmit --project tsconfig.json",
-    "pretest": "npm run lint:prod",
-    "prebuild": "rimraf dist/** && rimraf build/**",
-    "prepublishOnly": "npm run build",
-    "release": "np --no-yarn && git push https://github.com/terrestris/geostyler.git master --tags",
-    "styleguide": "styleguidist server",
-    "start": "react-scripts-ts start",
-    "start:styleguide": "styleguidist server",
-    "test": "CI=true react-scripts-ts test --env=jsdom --runInBand --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\"",
-    "test:watch": "react-scripts-ts test --env=jsdom --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\""
   },
   "devDependencies": {
     "@types/codemirror": "0.0.60",

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -69,7 +69,7 @@ interface RuleProps extends Partial<DefaultRuleProps> {
   /** Callback for onClick of the AddSymbolizerButton */
   onAddSymbolizer?: (rule: GsRule) => void;
   /** Callback for onClick of the RemoveSymbolizerButton */
-  onRemoveSymbolizer?: (rule: GsRule, symbolizer: GsSymbolizer) => void;
+  onRemoveSymbolizer?: (rule: GsRule, symbolizer: GsSymbolizer, key: number) => void;
 }
 
 // state
@@ -257,9 +257,9 @@ export class Rule extends React.Component<RuleProps, RuleState> {
                   this.props.onAddSymbolizer(this.props.rule);
                 }
               }}
-              onRemoveSymbolizer={(symb: GsSymbolizer) => {
+              onRemoveSymbolizer={(symb: GsSymbolizer, key: number) => {
                 if (this.props.onRemoveSymbolizer) {
-                  this.props.onRemoveSymbolizer(this.props.rule, symb);
+                  this.props.onRemoveSymbolizer(this.props.rule, symb, key);
                 }
               }}
               {...this.props.previewProps}

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -172,12 +172,19 @@ export class Style extends React.Component<StyleProps, StyleState> {
     }
   }
 
-  removeSymbolizer = (rule: GsRule, symbolizer: GsSymbolizer) => {
+  removeSymbolizer = (rule: GsRule, symbolizer: GsSymbolizer, key: number) => {
     const style = _cloneDeep(this.state.style);
     const ruleIdx = style.rules.findIndex((r: GsRule) => r.name === rule.name);
-    // if all properties of a symbolizer are equal, remove this symbolizer
+
     const newSymbolizers = style.rules[ruleIdx].symbolizers
-      .filter((symb: GsSymbolizer) => !_isEqual(symb, symbolizer));
+    .filter((symb: GsSymbolizer, index: number) => {
+      if (key) {
+        return key !== index;
+      } else {
+          // if all properties of a symbolizer are equal, remove this symbolizer
+          return !_isEqual(symb, symbolizer);
+        }
+      });
     style.rules[ruleIdx].symbolizers = newSymbolizers;
     if (this.props.onStyleChange) {
       this.props.onStyleChange(style);

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 
-import OlMap from 'ol/map';
-import OlLayerVector from 'ol/layer/vector';
-
 import {
   Symbolizer,
   SymbolizerKind
@@ -32,7 +29,7 @@ interface DefaultEditorProps {
 }
 
 // non default props
-interface EditorProps extends Partial<DefaultEditorProps> {
+export interface EditorProps extends Partial<DefaultEditorProps> {
   symbolizer: Symbolizer;
   internalDataDef?: Data;
   onSymbolizerChange: (symbolizer: Symbolizer) => void;
@@ -53,12 +50,6 @@ class Editor extends React.Component<EditorProps, EditorState> {
       }
     };
   }
-
-  /** reference to the underlying OpenLayers map */
-  map: OlMap;
-
-  /** refrence to the vector layer for the passed in features  */
-  dataLayer: OlLayerVector;
 
   public static defaultProps: DefaultEditorProps = {
     defaultIconSource: 'img/openLayers_logo.svg',

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.css
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.css
@@ -1,0 +1,16 @@
+.editor-window {
+  background-color: white;
+  border: 3px solid grey;
+  border-radius: 3px;
+  z-index: 10;
+}
+
+.editor-window .header {
+  background-color: lightgrey;
+  padding: 3px;
+  display: flex;
+}
+
+.editor-window .header .title {
+  flex: 1;
+}

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { Rnd } from 'react-rnd';
+
+import { Symbolizer } from 'geostyler-style';
+
+import MultiEditor from '../MultiEditor/MultiEditor';
+
+import { Data } from 'geostyler-data';
+
+import './EditorWindow.css';
+import { Button } from 'antd';
+
+// default props
+export interface DefaultEditorWindowProps {
+  onAdd: () => void;
+  onClose: () => void;
+  onRemove: (symbolizer: Symbolizer, idx: number) => void;
+  symbolizers: Symbolizer[];
+  onSymbolizerChange: (symbolizer: Symbolizer, key: number) => void;
+}
+
+// non default props
+interface EditorWindowProps extends Partial<DefaultEditorWindowProps> {
+  internalDataDef?: Data;
+  x?: number;
+  y?: number;
+}
+
+// state
+interface EditorWindowState {
+}
+
+/**
+ * Symbolizer editorwindow UI.
+ */
+export class EditorWindow extends React.Component<EditorWindowProps, EditorWindowState> {
+
+  render() {
+    const {
+      x,
+      y,
+      onAdd,
+      onClose,
+      onRemove,
+      symbolizers,
+      onSymbolizerChange
+    } = this.props;
+
+    return (
+      ReactDOM.createPortal(
+        <Rnd
+          className="editor-window"
+          default={{
+            x: x || window.innerWidth / 2,
+            y: y || window.innerHeight / 2,
+            width: undefined,
+            height: undefined
+          }}
+          enableResizing={{
+            bottom: false,
+            bottomLeft: false,
+            bottomRight: false,
+            left: false,
+            right: false,
+            top: false,
+            topLeft: false,
+            topRight: false
+          }}
+        >
+          <div className="header">
+            <span className="title">
+              Symbolizers Editor
+            </span>
+            <Button
+              icon="close"
+              size="small"
+              onClick={onClose}
+            />
+          </div>
+          <MultiEditor
+            symbolizers={symbolizers}
+            onSymbolizerChange={onSymbolizerChange}
+            onAdd={onAdd}
+            onRemove={onRemove}
+          />
+        </Rnd>,
+        document.body
+      )
+    );
+  }
+}
+
+export default EditorWindow;

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -12,6 +12,13 @@ import { Data } from 'geostyler-data';
 import './EditorWindow.css';
 import { Button } from 'antd';
 
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+
+// i18n
+export interface EditorWindowLocale {
+  symbolizersEditor: string;
+}
+
 // default props
 export interface DefaultEditorWindowProps {
   onAdd: () => void;
@@ -19,6 +26,7 @@ export interface DefaultEditorWindowProps {
   onRemove: (symbolizer: Symbolizer, idx: number) => void;
   symbolizers: Symbolizer[];
   onSymbolizerChange: (symbolizer: Symbolizer, key: number) => void;
+  locale: EditorWindowLocale;
 }
 
 // non default props
@@ -37,6 +45,8 @@ interface EditorWindowState {
  */
 export class EditorWindow extends React.Component<EditorWindowProps, EditorWindowState> {
 
+  static componentName: string = 'EditorWindow';
+
   render() {
     const {
       x,
@@ -45,7 +55,8 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
       onClose,
       onRemove,
       symbolizers,
-      onSymbolizerChange
+      onSymbolizerChange,
+      locale
     } = this.props;
 
     return (
@@ -71,7 +82,7 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
         >
           <div className="header">
             <span className="title">
-              Symbolizers Editor
+              {locale.symbolizersEditor}
             </span>
             <Button
               icon="close"
@@ -92,4 +103,4 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
   }
 }
 
-export default EditorWindow;
+export default localize(EditorWindow, EditorWindow.componentName);

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.css
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.css
@@ -1,0 +1,11 @@
+.gs-symbolizer-multi-editor {
+  overflow: inherit;
+}
+
+.gs-symbolizer-multi-editor .ant-tabs-extra-content {
+  margin-right: 5px;
+}
+
+.gs-symbolizer-multi-editor .gs-symbolizer-multi-editor-tab {
+  padding: 10px;
+}

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -36,17 +36,9 @@ export interface MultiEditorProps extends Partial<DefaultMultiEditorProps> {
   editorProps?: any;
 }
 
-// state
-interface MultiEditorState {
-}
-
-class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
+class MultiEditor extends React.Component<MultiEditorProps> {
 
   static componentName: string = 'MultiEditor';
-
-  constructor(props: any) {
-    super(props);
-  }
 
   render() {
     const {

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+
+import {
+  Symbolizer
+} from 'geostyler-style';
+
+import './MultiEditor.css';
+
+import 'ol/ol.css';
+import { Data } from 'geostyler-data';
+
+import { Tabs, Button } from 'antd';
+import Editor from '../Editor/Editor';
+const TabPane = Tabs.TabPane;
+
+// default props
+interface DefaultMultiEditorProps {
+  onAdd: () => void;
+  onRemove: (symbolizer: Symbolizer, idx: number) => void;
+  symbolizers: Symbolizer[];
+  onSymbolizerChange: (symbolizer: Symbolizer, idx: number) => void;
+}
+
+// non default props
+export interface MultiEditorProps extends Partial<DefaultMultiEditorProps> {
+  internalDataDef?: Data;
+  editorProps?: any;
+}
+
+// state
+interface MultiEditorState {
+}
+
+class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
+  constructor(props: any) {
+    super(props);
+  }
+
+  render() {
+    const {
+      onAdd,
+      onRemove,
+      symbolizers,
+      editorProps,
+      onSymbolizerChange,
+      ...passThroughProps
+    } = this.props;
+
+    const tabs = symbolizers.map((symbolizer: Symbolizer, idx: number) => {
+        return (
+          <TabPane
+            className="gs-symbolizer-multi-editor-tab"
+            key={idx}
+            tab={idx}
+            closable={true}
+          >
+            <Editor
+              symbolizer={symbolizer}
+              onSymbolizerChange={(sym: Symbolizer) => {
+                onSymbolizerChange(sym, idx);
+              }}
+              {...editorProps}
+            />
+            {idx === 0 ? null :
+              <Button
+                onClick={() => {
+                  onRemove(symbolizer, idx);
+                }}
+              >
+                Remove
+              </Button>
+            }
+          </TabPane>
+        );
+      });
+
+    return (
+      <Tabs
+        className="gs-symbolizer-multi-editor"
+        defaultActiveKey="0"
+        animated={false}
+        tabBarExtraContent={<Button onClick={onAdd}>Add</Button>}
+        {...passThroughProps}
+      >
+        {tabs}
+      </Tabs>
+    );
+  }
+}
+
+export default MultiEditor;

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -13,12 +13,21 @@ import { Tabs, Button } from 'antd';
 import Editor from '../Editor/Editor';
 const TabPane = Tabs.TabPane;
 
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+
+// i18n
+export interface MultiEditorLocale {
+  add: string;
+  remove: string;
+}
+
 // default props
 interface DefaultMultiEditorProps {
   onAdd: () => void;
   onRemove: (symbolizer: Symbolizer, idx: number) => void;
   symbolizers: Symbolizer[];
   onSymbolizerChange: (symbolizer: Symbolizer, idx: number) => void;
+  locale: MultiEditorLocale;
 }
 
 // non default props
@@ -32,6 +41,9 @@ interface MultiEditorState {
 }
 
 class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
+
+  static componentName: string = 'MultiEditor';
+
   constructor(props: any) {
     super(props);
   }
@@ -43,6 +55,7 @@ class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
       symbolizers,
       editorProps,
       onSymbolizerChange,
+      locale,
       ...passThroughProps
     } = this.props;
 
@@ -67,7 +80,7 @@ class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
                   onRemove(symbolizer, idx);
                 }}
               >
-                Remove
+                {locale.remove}
               </Button>
             }
           </TabPane>
@@ -79,7 +92,7 @@ class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
         className="gs-symbolizer-multi-editor"
         defaultActiveKey="0"
         animated={false}
-        tabBarExtraContent={<Button onClick={onAdd}>Add</Button>}
+        tabBarExtraContent={<Button onClick={onAdd}>{locale.add}</Button>}
         {...passThroughProps}
       >
         {tabs}
@@ -88,4 +101,4 @@ class MultiEditor extends React.Component<MultiEditorProps, MultiEditorState> {
   }
 }
 
-export default MultiEditor;
+export default localize(MultiEditor, MultiEditor.componentName);

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -24,15 +24,11 @@ import { Symbolizer, SymbolizerKind } from 'geostyler-style';
 import './Preview.css';
 
 import {
-  Button,
-  Tabs
+  Button
 } from 'antd';
-
-const TabPane = Tabs.TabPane;
 
 import 'ol/ol.css';
 import './Preview.css';
-import Editor from '../Editor/Editor';
 
 import OlStyleParser from 'geostyler-openlayers-parser';
 
@@ -44,6 +40,7 @@ import { Data } from 'geostyler-data';
 import { DefaultIconEditorProps } from '../IconEditor/IconEditor';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import { EditorWindow } from '../EditorWindow/EditorWindow';
 
 // i18n
 export interface PreviewLocale {
@@ -73,7 +70,7 @@ interface PreviewProps extends Partial<DefaultPreviewProps> {
   symbolizers: Symbolizer[];
   onSymbolizerChange: (symbolizer: Symbolizer, key: number) => void;
   onAddSymbolizer?: () => void;
-  onRemoveSymbolizer?: (symbolizer: Symbolizer) => void;
+  onRemoveSymbolizer?: (symbolizer: Symbolizer, key: number) => void;
 }
 
 // state
@@ -81,6 +78,7 @@ interface PreviewState {
   symbolizers: Symbolizer[];
   editorVisible: boolean;
   mapTargetId: string;
+  editorId: string;
 }
 
 /**
@@ -93,6 +91,9 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
 
   /** refrence to the vector layer for the passed in features  */
   dataLayer: OlLayerVector;
+
+  /** reference to the editButton */
+  _editButton: any;
 
   public static defaultProps: DefaultPreviewProps = {
     hideEditButton: false,
@@ -113,7 +114,8 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
     this.state = {
       editorVisible: false,
       symbolizers: props.symbolizers,
-      mapTargetId: `map_${randomId}`
+      mapTargetId: `map_${randomId}`,
+      editorId: `gs-edit-preview-button_${randomId}`
     };
   }
 
@@ -373,93 +375,61 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
       });
   }
 
-  /**
-   * Checks if removeSymbolizer Button or addSymbolizer Button was clicked.
-   * Calls corresponding function, if it was passed through props.
-   */
-  onAddRemoveSymbolizer = (tabIdx: string, action: string) => {
-    if (action === 'add') {
-      if (this.props.onAddSymbolizer) {
-        this.props.onAddSymbolizer();
-      }
-    } else if (action === 'remove') {
-      const symbIdx = parseInt(tabIdx, 10);
-      const symb: Symbolizer = this.props.symbolizers[symbIdx];
-      if (this.props.onRemoveSymbolizer) {
-        this.props.onRemoveSymbolizer(symb);
-      }
-    }
-  }
-
-  getUIFromSymbolizers = (symbolizers: Symbolizer[], editorProps: any): React.ReactNode => {
-    return(
-      <Tabs
-        className="gs-symbolizer-preview-tabs"
-        type="editable-card"
-        defaultActiveKey="0"
-        onEdit={this.onAddRemoveSymbolizer}
-      >
-        {
-          symbolizers.map(
-            (symb: Symbolizer, idx: number) => {
-              return (
-                <TabPane
-                  key={idx}
-                  tab={idx}
-                  closable={true}
-                >
-                  <Editor
-                    symbolizer={symb}
-                    onSymbolizerChange={(sym: Symbolizer) => {
-                      this.props.onSymbolizerChange(sym, idx);
-                    }}
-                    {...editorProps}
-                  />
-                </TabPane>
-              );
-            }
-          )
-        }
-      </Tabs>
-    );
-  }
-
   render() {
     const {
       mapHeight,
-      projection,
-      map,
-      controls,
-      interactions,
-      dataProjection,
-      showOsmBackground,
       locale,
       symbolizers,
-      onSymbolizerChange,
       hideEditButton,
-      ...editorProps
+      onSymbolizerChange,
+      onAddSymbolizer,
+      onRemoveSymbolizer
     } = this.props;
+
+    const {
+      editorVisible,
+      editorId,
+      mapTargetId
+    } = this.state;
+
+    let windowX, windowY;
+
+    if (editorVisible && !hideEditButton ) {
+      const buttonElement = document.getElementById(editorId);
+      const buttonBounds = buttonElement.getBoundingClientRect();
+      windowX = buttonBounds.right + window.scrollX;
+      windowY = buttonBounds.top + window.scrollY;
+    }
 
     return (
       <div className="gs-symbolizer-preview">
         <div
-          id={this.state.mapTargetId}
+          id={mapTargetId}
           className="map"
           style={{ height: mapHeight }}
         >
         {
           !hideEditButton &&
           <Button
+            id={editorId}
             className="gs-edit-preview-button"
             icon="edit"
             onClick={this.onEditButtonClicked}
           >
-            {this.state.editorVisible ? locale.closeEditorText : locale.openEditorText}
+            {editorVisible ? locale.closeEditorText : locale.openEditorText}
           </Button>
         }
         {
-          this.state.editorVisible && !hideEditButton ?
-            this.getUIFromSymbolizers(this.state.symbolizers, {...editorProps}) : null
+          editorVisible && !hideEditButton ?
+            <EditorWindow
+              x={windowX}
+              y={windowY}
+              onAdd={onAddSymbolizer}
+              onClose={this.onEditButtonClicked}
+              onRemove={onRemoveSymbolizer}
+              symbolizers={symbolizers}
+              onSymbolizerChange={onSymbolizerChange}
+            /> : null
         }
         </div>
       </div>

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -40,7 +40,7 @@ import { Data } from 'geostyler-data';
 import { DefaultIconEditorProps } from '../IconEditor/IconEditor';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
-import { EditorWindow } from '../EditorWindow/EditorWindow';
+import EditorWindow from '../EditorWindow/EditorWindow';
 
 // i18n
 export interface PreviewLocale {

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -134,11 +134,11 @@ export default {
         Icon: 'Bilddatei'
     },
     GsEditorWindow: {
-      symbolizersEditor: 'Symoblisierungseditor'
+      symbolizersEditor: 'Symbolisierungseditor'
     },
     GsMultiEditor: {
       add: 'Hinzufügen',
-      remove: 'entfernen'
+      remove: 'Entfernen'
     },
     ...de_DE
 };

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -133,5 +133,12 @@ export default {
         Mark: 'Punktsymbol',
         Icon: 'Bilddatei'
     },
+    GsEditorWindow: {
+      symbolizersEditor: 'Symoblisierungseditor'
+    },
+    GsMultiEditor: {
+      add: 'Hinzufügen',
+      remove: 'entfernen'
+    },
     ...de_DE
 };

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -122,5 +122,12 @@ export default {
           X: 'X'
         }
     },
+    GsEditorWindow: {
+      symbolizersEditor: 'Symbolizer Editor'
+    },
+    GsMultiEditor: {
+      add: 'Add',
+      remove: 'Remove'
+    },
     ...en_US
 };


### PR DESCRIPTION
This introduces two new Components:
`MultiEditor` -> Receives multiple symbolizers and creates the needed tabs and buttons.
`EditorWindow` -> Edit symbolizers in a window-like component

![localhost_3000_ 12](https://user-images.githubusercontent.com/1849416/45947259-dff2f580-bff3-11e8-9923-5f7c09ffaf2a.png)

@terrestris/devs @chrismayer review appreciated