### PR TITLE
Keep styles when switching between WellKnownNames

### DIFF
--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
@@ -1,6 +1,5 @@
 import MarkEditor from './MarkEditor';
 import TestUtil from '../../../Util/TestUtil';
-import { MarkSymbolizer } from 'geostyler-style';
 
 describe('MarkEditor', () => {
 
@@ -28,42 +27,5 @@ describe('MarkEditor', () => {
     });
     wrapper.instance().onSymbolizerChange(markstyle.rules[0].symbolizers[0]);
     expect(counter).toEqual(1);
-  });
-
-  it('gets the right default MarkSymbolizer', () => {
-    expect.assertions(16);
-    const circle: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('Circle');
-    const square: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('Square');
-    const triangle: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('Triangle');
-    const star: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('Star');
-    const cross: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('Cross');
-    const x: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('X');
-    const slash: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://slash');
-    const backslash: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://backslash');
-    const vertline: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://vertline');
-    const horline: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://horline');
-    const plus: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://plus');
-    const times: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://times');
-    const carrow: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://carrow');
-    const oarrow: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://oarrow');
-    const dot: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer('shape://dot');
-    const emptyWkn: MarkSymbolizer = wrapper.instance().getDefaultMarkSymbolizer();
-
-    expect(circle.wellKnownName).toEqual('Circle');
-    expect(square.wellKnownName).toEqual('Square');
-    expect(triangle.wellKnownName).toEqual('Triangle');
-    expect(star.wellKnownName).toEqual('Star');
-    expect(cross.wellKnownName).toEqual('Cross');
-    expect(x.wellKnownName).toEqual('X');
-    expect(slash.wellKnownName).toEqual('shape://slash');
-    expect(backslash.wellKnownName).toEqual('shape://backslash');
-    expect(vertline.wellKnownName).toEqual('shape://vertline');
-    expect(horline.wellKnownName).toEqual('shape://horline');
-    expect(plus.wellKnownName).toEqual('shape://plus');
-    expect(times.wellKnownName).toEqual('shape://times');
-    expect(carrow.wellKnownName).toEqual('shape://carrow');
-    expect(oarrow.wellKnownName).toEqual('shape://oarrow');
-    expect(dot.wellKnownName).toEqual('shape://dot');
-    expect(emptyWkn.wellKnownName).toEqual('Circle');
   });
 });

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -45,19 +45,6 @@ class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState> {
     this.props.onSymbolizerChange(symbolizer);
   }
 
-  getDefaultMarkSymbolizer = (wkn: WellKnownName): MarkSymbolizer => {
-    let defaultSymbolizer: MarkSymbolizer = {
-      kind: 'Mark'
-    } as MarkSymbolizer;
-    if (wkn) {
-      defaultSymbolizer.wellKnownName = wkn;
-    } else {
-      defaultSymbolizer.wellKnownName = 'Circle';
-    }
-
-    return defaultSymbolizer;
-  }
-
   render() {
     const symbolizer = _cloneDeep(this.state.symbolizer);
 
@@ -66,8 +53,8 @@ class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState> {
         <WellKnownNameField
           wellKnownName={symbolizer.wellKnownName}
           onChange={(wkn: WellKnownName) => {
-            const newSymbolizer = this.getDefaultMarkSymbolizer(wkn);
-            this.onSymbolizerChange(newSymbolizer);
+            symbolizer.wellKnownName = wkn;
+            this.onSymbolizerChange(symbolizer);
           }}
         />
         <WellKnownNameEditor


### PR DESCRIPTION
Styles will not reset anymore when switching between different WellKnownNames. Since all Symbols have the same properties, it does not make sense to do so. -> this PR.

Example: Default Symbolizer with styles
![image](https://user-images.githubusercontent.com/12186477/46087724-3f473600-c1ab-11e8-90a5-964165f93830.png)

Directly after changing Symbol from `Circle` to `Square`
![image](https://user-images.githubusercontent.com/12186477/46087792-5d149b00-c1ab-11e8-9599-df79e76bbea9.png)
