### PR TITLE
Add config for building browser library with webpack 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /dist
 /build
 /dist
+/browser
 
 # misc
 .DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,12 @@
   "tasks": [
     {
       "type": "npm",
-      "script": "start",
+      "script": "build:dist",
+      "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "script": "build:browser",
       "problemMatcher": []
     }
   ]

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,4 +1,5 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const webpack = require("webpack");
 module.exports = {
   entry: "./src/index.js",
   output: {
@@ -43,7 +44,8 @@ module.exports = {
     ]
   },
   plugins: [
-    new ExtractTextPlugin("geostyler.css")
+    new ExtractTextPlugin("geostyler.css"),
+    new webpack.optimize.UglifyJsPlugin(),
   ],
   // When importing a module whose path matches one of the following, just
   // assume a corresponding global variable exists and use that instead.

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,51 +1,56 @@
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
- module.exports = {
+module.exports = {
   entry: "./src/index.js",
   output: {
-      filename: "geostyler.js",
-      path: __dirname + "/browser",
-      library: 'GeoStyler'
+    filename: "geostyler.js",
+    path: __dirname + "/browser",
+    library: "GeoStyler"
   },
-   // Enable sourcemaps for debugging webpack's output.
-  devtool: "source-map",
-   resolve: {
-      // Add '.ts' and '.tsx' as resolvable extensions.
-      extensions: [".ts", ".tsx", ".js", ".json"]
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".ts", ".tsx", ".js", ".json"]
   },
-   module: {
-      rules: [
-          {
-            test: /\.css$/,
-            use: ExtractTextPlugin.extract({
-              fallback: "style-loader",
-              use: "css-loader"
-            })
-          },
-          // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-          {
-            test: /\.tsx?$/,
-            loader: "awesome-typescript-loader"
-          },
-          // locale js files need to be transpiled to es5
-          {
-            test: /\.js?$/,
-            include: /src\/locale/,
-            loader: 'babel-loader',
-            query: {
-              presets: ['@babel/env']
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ExtractTextPlugin.extract({
+          fallback: "style-loader",
+          use: [
+            {
+              loader: "css-loader",
+              options: {
+                minimize: true
+              }
             }
-          }
-      ]
+          ]
+        })
+      },
+      // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+      {
+        test: /\.tsx?$/,
+        loader: "awesome-typescript-loader"
+      },
+      // locale js files need to be transpiled to es5
+      {
+        test: /\.js?$/,
+        include: /src\/locale/,
+        loader: "babel-loader",
+        query: {
+          presets: ["@babel/env"]
+        }
+      }
+    ]
   },
-   plugins: [
+  plugins: [
     new ExtractTextPlugin("geostyler.css")
   ],
-   // When importing a module whose path matches one of the following, just
+  // When importing a module whose path matches one of the following, just
   // assume a corresponding global variable exists and use that instead.
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
   externals: {
-      "react": "React",
-      "react-dom": "ReactDOM"
+    "react": "React",
+    "react-dom": "ReactDOM"
   }
 };

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,0 +1,51 @@
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+ module.exports = {
+  entry: "./src/index.js",
+  output: {
+      filename: "geostyler.js",
+      path: __dirname + "/browser",
+      library: 'GeoStyler'
+  },
+   // Enable sourcemaps for debugging webpack's output.
+  devtool: "source-map",
+   resolve: {
+      // Add '.ts' and '.tsx' as resolvable extensions.
+      extensions: [".ts", ".tsx", ".js", ".json"]
+  },
+   module: {
+      rules: [
+          {
+            test: /\.css$/,
+            use: ExtractTextPlugin.extract({
+              fallback: "style-loader",
+              use: "css-loader"
+            })
+          },
+          // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+          {
+            test: /\.tsx?$/,
+            loader: "awesome-typescript-loader"
+          },
+          // locale js files need to be transpiled to es5
+          {
+            test: /\.js?$/,
+            include: /src\/locale/,
+            loader: 'babel-loader',
+            query: {
+              presets: ['@babel/env']
+            }
+          }
+      ]
+  },
+   plugins: [
+    new ExtractTextPlugin("geostyler.css")
+  ],
+   // When importing a module whose path matches one of the following, just
+  // assume a corresponding global variable exists and use that instead.
+  // This is important because it allows us to avoid bundling all of our
+  // dependencies, which allows browsers to cache those libraries between builds.
+  externals: {
+      "react": "React",
+      "react-dom": "ReactDOM"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   },
   "homepage": ".",
   "scripts": {
-    "build": "npm run build:dist && npm run build:app && npm run build:styleguide",
+    "build": "npm run build:dist && npm run build:app && nm run build:browser && npm run build:styleguide",
     "build:app": "react-scripts-ts build",
     "build:dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
     "build:styleguide": "styleguidist build",
+    "build:browser": "webpack --config browser-build.config.js",
     "eject": "react-scripts-ts eject",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
     "lint:prod": "tslint --project tsconfig.json --config tslint.prod.json && tsc --noEmit --project tsconfig.json",
@@ -63,6 +64,9 @@
     "react-scripts-ts": "2.17.0"
   },
   "devDependencies": {
+    "@babel/core": "7.1.2",
+    "@babel/preset-env": "7.1.0",
+    "@babel/preset-stage-0": "7.0.0",
     "@types/codemirror": "0.0.61",
     "@types/color": "3.0.0",
     "@types/enzyme": "3.1.14",
@@ -76,17 +80,22 @@
     "@types/react": "16.4.14",
     "@types/react-color": "2.13.6",
     "@types/react-dom": "16.0.8",
+    "awesome-typescript-loader": "4.0.1",
+    "babel-loader": "8.0.4",
     "canvas-prebuilt": "1.6.5-prerelease.1",
     "copyfiles": "2.1.0",
     "coveralls": "3.0.1",
     "enzyme": "3.5.0",
     "enzyme-adapter-react-16": "1.3.0",
+    "extract-text-webpack-plugin": "3.0.2",
     "np": "3.0.4",
     "react-docgen-typescript": "1.9.1",
     "react-styleguidist": "7.3.8",
     "rimraf": "2.6.2",
     "ts-jest": "22.4.6",
-    "typescript": "2.9.2"
+    "typescript": "2.9.2",
+    "webpack": "3.12.0",
+    "webpack-cli": "3.1.2"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": ".",
   "scripts": {
-    "build": "npm run build:dist && npm run build:app && nm run build:browser && npm run build:styleguide",
+    "build": "npm run build:dist && npm run build:app && npm run build:browser && npm run build:styleguide",
     "build:app": "react-scripts-ts build",
     "build:dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
     "build:styleguide": "styleguidist build",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "browser"
   ],
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import FieldSet from './Component/FieldSet/FieldSet';
 import AttributeCombo from './Component/Filter/AttributeCombo/AttributeCombo';
 import BoolFilterField from './Component/Filter/BoolFilterField/BoolFilterField';
 import ComparisonFilter from './Component/Filter/ComparisonFilter/ComparisonFilter';
+import DataLoader from './Component/DataInput/DataLoader/DataLoader';
+import DataProvider from './DataProvider/DataProvider';
 import NumberFilterField from './Component/Filter/NumberFilterField/NumberFilterField';
 import OperatorCombo from './Component/Filter/OperatorCombo/OperatorCombo';
 import TextFilterField from './Component/Filter/TextFilterField/TextFilterField';
@@ -17,6 +19,7 @@ import Editor from './Component/Symbolizer/Editor/Editor';
 import LineEditor from './Component/Symbolizer/LineEditor/LineEditor';
 import FillEditor from './Component/Symbolizer/FillEditor/FillEditor';
 import TextEditor from './Component/Symbolizer/TextEditor/TextEditor';
+import CodeEditor from './Component/CodeEditor/CodeEditor';
 import PropTextEditor from './Component/Symbolizer/PropTextEditor/PropTextEditor';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
 import GraphicEditor from './Component/Symbolizer/GraphicEditor/GraphicEditor';
@@ -39,7 +42,16 @@ import LineDashField from './Component/Symbolizer/Field/LineDashField/LineDashFi
 import FontPicker from './Component/Symbolizer/Field/FontPicker/FontPicker';
 import UploadButton from './Component/UploadButton/UploadButton';
 import Style from './Component/Style/Style';
+import StyleLoader from './Component/DataInput/StyleLoader/StyleLoader';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
+
+import { LocaleProvider } from 'antd';
+import de_DE from './locale/de_DE';
+import en_US from './locale/en_US';
+ const locale = {
+  de_DE,
+  en_US
+};
 
 export {
   FieldSet,
@@ -83,5 +95,11 @@ export {
   TextEditor,
   PropTextEditor,
   Style,
-  localize
+  localize,
+  locale,
+  LocaleProvider,
+  DataLoader,
+  DataProvider,
+  CodeEditor,
+  StyleLoader
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   "exclude": [
     "node_modules",
     "build",
+    "browser",
     "dist",
     "scripts",
     "coverage",


### PR DESCRIPTION
This PR enables building of a browser library that allows using geostyler outside of the react universe. An existing PR for webpack 4 already exists [here](https://github.com/terrestris/geostyler/pull/413) as well as a corresponding [issue](https://github.com/terrestris/geostyler/issues/419), which will be partially solved through this PR. 

`browser-build.config.js` was created which is a simple webpack config. It was renamed so it is clear that it will only be used for creating the browser version. According script was added to package.json and can be called via `npm run build:browser`. This was also integrated into the `npm run build` script.

Since we are still using webpack 3, `create-react-app-typescript` still runs without errors.

The build output is available in `/browser`.

Also exported a few missing components.

Closes #419 