### PR TITLE
Remove unnecessary antd.css

### DIFF
--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { Select } from 'antd';
 const Option = Select.Option;
-import 'antd/dist/antd.css';
 
 import {
   Style as GsStyle,


### PR DESCRIPTION
The removed line led to adding the whole antd.css to the browser-build css, which overwrote our own styles. Fixed this.