### PR TITLE
Update canvas-prebuilt to v1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/react-dom": "16.0.9",
     "awesome-typescript-loader": "4.0.1",
     "babel-loader": "8.0.4",
-    "canvas-prebuilt": "1.6.5-prerelease.1",
+    "canvas-prebuilt": "1.6.11",
     "copyfiles": "2.1.0",
     "coveralls": "3.0.1",
     "enzyme": "3.7.0",


### PR DESCRIPTION
Greenkeeper tried to install a now reverted version of canvas-prebuilt in #407. I guess because of this, it will not open a new PR with a previous version. Thus, making this PR on my own. 