### PR TITLE
WIP: handle scaleDenominator in preview

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@terrestris/ol-util/dist/MapUtil/MapUtil';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:watch": "react-scripts-ts test --env=jsdom --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd|codemirror)\""
   },
   "dependencies": {
+    "@terrestris/ol-util": "0.4.0",
     "antd": "3.9.3",
     "blob": "0.0.4",
     "codemirror": "5.41.0",

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -247,6 +247,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
             <Preview
               dataProjection={dataProjection}
               symbolizers={rule.symbolizers}
+              scaleDenominator={rule.scaleDenominator}
               internalDataDef={gsData}
               onSymbolizerChange={this.onSymbolizerChange}
               onAddSymbolizer={() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import 'antd/dist/antd.css';
 
+import OlInteractionMouseWheelZoom from 'ol/interaction/mousewheelzoom';
+import OlInteractionDragPan from 'ol/interaction/dragpan';
+
 import {
   Style as GsStyle,
   StyleParser as GsStyleParser
@@ -56,6 +59,9 @@ class App extends React.Component<AppProps, AppState> {
     };
   }
 
+  private zoomInteraction = new OlInteractionMouseWheelZoom();
+  private dragpanInteraction = new OlInteractionDragPan();
+
   static componentName: string = 'App';
 
   render() {
@@ -92,6 +98,17 @@ class App extends React.Component<AppProps, AppState> {
               data={this.state.data}
               onStyleChange={(style: GsStyle) => {
                 this.setState({style});
+              }}
+              previewProps={{
+                interactions: [this.zoomInteraction, this.dragpanInteraction],
+                hideEditButton: false,
+                projection: 'EPSG:3857',
+                dataProjection: 'EPSG:4326',
+                showOsmBackground: true,
+                mapHeight: 267,
+                map: undefined,
+                layers: undefined,
+                controls: undefined
               }}
             />
           </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,8 +72,8 @@ class Starter extends React.Component <{}, DefaultStarterState>{
       <LocaleProvider locale={locale}>
         <div>
           <div>
-            <button onClick={()=>{this.onChange(true)}}>German</button>
-            <button onClick={()=>{this.onChange(false)}}>English</button>
+            <button onClick={() => {this.onChange(true); }}>German</button>
+            <button onClick={() => {this.onChange(false); }}>English</button>
           </div>
           <App />
         </div>

--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,7 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
+    "no-unused-variable": false,
     "no-use-before-declare": true,
     "one-line": [
       true,

--- a/tslint.prod.json
+++ b/tslint.prod.json
@@ -12,6 +12,7 @@
       "timeEnd",
       "trace"
     ],
-    "no-debugger": true
+    "no-debugger": true,
+    "no-unused-variable": true
   }
 }


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [this PR of geostyler-openlayers-parser]()
was released.

Preview now applies defined scaleDenominators to map. When changing a style, map will always center on the feature and zoom to a resolution within defined scaleDenominator. If no scaleDenominator was defined, map will zoom to fit extend of feature. Also added zoom and pan interaction to map in demo. So a user can check the ranges where style will be applied and where not, depending on scaleDenominator.

Also made small changes to eslint files, to allow unused variables in dev mode.

![half-opt](https://user-images.githubusercontent.com/12186477/47508272-1383a280-d874-11e8-91f0-e16ef95ea91b.gif)
