### PR TITLE
Fix EditorWindow Drag Bug

### DIFF
--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.css
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.css
@@ -16,5 +16,9 @@
 }
 
 .editor-window-header:hover {
-  cursor: pointer;
+  cursor: grab;
+}
+
+.editor-window-header:active {
+  cursor: grabbing;
 }

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.css
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.css
@@ -14,3 +14,7 @@
 .editor-window .header .title {
   flex: 1;
 }
+
+.editor-window-header:hover {
+  cursor: pointer;
+}

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -79,8 +79,9 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
             topLeft: false,
             topRight: false
           }}
+          dragHandleClassName="editor-window-header"
         >
-          <div className="header">
+          <div className="header editor-window-header">
             <span className="title">
               {locale.symbolizersEditor}
             </span>


### PR DESCRIPTION
The drag event on the whole window lead to loosing focus of input fields (related issue here #504). Problem was fixed through limiting the drag event to the EditorWindow Titlebar. Also Cursor style is set to pointer when hovering over Titlebar.

![dragwindow](https://user-images.githubusercontent.com/12186477/47509793-1e8c0200-d877-11e8-9590-0385ad66dcb5.gif)
