### PR TITLE
Update geostyler-openlayers-parser to v0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "file-saver": "1.3.8",
     "geostyler-data": "0.5.1",
     "geostyler-geojson-parser": "0.4.2",
-    "geostyler-openlayers-parser": "0.17.1",
+    "geostyler-openlayers-parser": "0.18.0",
     "geostyler-sld-parser": "0.17.1",
     "geostyler-style": "0.14.1",
     "geostyler-wfs-parser": "0.7.1",


### PR DESCRIPTION
Version 0.18.0 contains a breaking change. Thus, update had to be done manually.

The returned style(s) of geostyler-openlayers-parser are now directly usable with openlayers. Thus, could remove some logic from `Preview`.