### PR TITLE
Introduces outlineWidth input to FillSymbolizer

### DIFF
--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -10,6 +10,7 @@ import {
 import ColorField from '../Field/ColorField/ColorField';
 import OpacityField from '../Field/OpacityField/OpacityField';
 import GraphicEditor from '../GraphicEditor/GraphicEditor';
+import WidthField from '../Field/WidthField/WidthField';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _get = require('lodash/get');
@@ -23,6 +24,7 @@ export interface FillEditorLocale {
   fillOpacityLabel?: string;
   fillColorLabel?: string;
   outlineColorLabel?: string;
+  outlineWidthLabel?: string;
   graphicFillTypeLabel?: string;
 }
 
@@ -42,13 +44,14 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
   }
 
   render() {
-    const symbolizer = _cloneDeep(this.props.symbolizer);
+    const symbolizer: FillSymbolizer = _cloneDeep(this.props.symbolizer);
 
     const {
       color,
       opacity,
       outlineColor,
-      graphicFill
+      graphicFill,
+      outlineWidth
     } = symbolizer;
 
     const {
@@ -80,6 +83,14 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
               label={locale.outlineColorLabel}
               onChange={(value: string) => {
                 symbolizer.outlineColor = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <WidthField
+              width={outlineWidth}
+              label={locale.outlineWidthLabel}
+              onChange={(value: number) => {
+                symbolizer.outlineWidth = value;
                 this.props.onSymbolizerChange(symbolizer);
               }}
             />

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -54,6 +54,7 @@ export default {
         fillOpacityLabel: 'Fülldeckkraft',
         fillColorLabel: 'Füllfarbe',
         outlineColorLabel: 'Randfarbe',
+        outlineWidthLabel: 'Randbreite',
         graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -42,7 +42,8 @@ export default {
     GsFillEditor: {
         fillOpacityLabel: 'Fill-Opacity',
         fillColorLabel: 'Fill-Color',
-        outlineColorLabel: 'Stroke-Color',
+        outlineColorLabel: 'Outline-Color',
+        outlineWidthLabel: 'Outline-Width',
         graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {


### PR DESCRIPTION
This introduces the editor field for the `outlineWidth` of the `FillSymbolizer`:

![localhost_3000_ 16](https://user-images.githubusercontent.com/1849416/47658354-29a2a300-db93-11e8-9c40-c35fb881fc0d.png)
