### PR TITLE
Replace Preview with (new) Renderer Component

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,11 @@
       "type": "npm",
       "script": "build:browser",
       "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "script": "start",
+      "problemMatcher": []
     }
   ]
 }

--- a/src/Component/LocaleWrapper/LocaleWrapper.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.tsx
@@ -6,20 +6,20 @@ export interface LocaleProps {
 }
 
 export const localize = <P extends {}>(Component: React.ComponentType<P & LocaleProps>, componentName: string) => {
-    class Wrap extends React.Component<P & LocaleProps> {
-        static contextTypes = {
-            antLocale: PropTypes.object
-        };
+  class Wrap extends React.Component<P & LocaleProps> {
+    static contextTypes = {
+      antLocale: PropTypes.object
+    };
 
-        render() {
-            const { antLocale } = this.context;
-            return (
-                <Component
-                    locale={antLocale['Gs' + componentName]}
-                    {...this.props}
-                />
-            );
-        }
+    render() {
+      const { antLocale } = this.context;
+      return (
+        <Component
+          locale={antLocale['Gs' + componentName]}
+          {...this.props}
+        />
+      );
     }
-    return Wrap;
+  }
+  return Wrap;
 };

--- a/src/Component/Rule/Rule.css
+++ b/src/Component/Rule/Rule.css
@@ -1,4 +1,3 @@
-
 .gs-rule {
   border: 1px solid lightgrey;
   border-radius: 4px;
@@ -8,17 +7,19 @@
   flex-direction: column;
 }
 
-
 .gs-rule-fields {
   display: flex;
 }
 
 .gs-rule-left-fields,
 .gs-rule-right-fields {
-  flex: 1;
   display: flex;
   flex-direction: column;
   padding: 2px;
+}
+
+.gs-rule-right-fields {
+  flex: 1
 }
 
 .gs-rule-left-fields > .gs-namefield {

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -67,7 +67,7 @@ interface RuleProps extends Partial<DefaultRuleProps> {
   onAddSymbolizer?: (rule: GsRule) => void;
   /** Callback for onClick of the RemoveSymbolizerButton */
   onRemoveSymbolizer?: (rule: GsRule, symbolizer: GsSymbolizer, key: number) => void;
-  /** Callbakc for onClick of the Renderer */
+  /** Callback for onClick of the Renderer */
   onRendererClick?: (symbolizers: GsSymbolizer[], rule: GsRule) => void;
 }
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -173,12 +173,6 @@ export class Rule extends React.Component<RuleProps, RuleState> {
     this.setState({rule});
   }
 
-  onEditPreviewButtonClicked = () => {
-    this.setState({
-      symbolizerEditorVisible: !this.state.symbolizerEditorVisible
-    });
-  }
-
   onScaleCheckChange = (e: any) => {
     const checked = e.target.checked;
     const rule: GsRule = _cloneDeep(this.state.rule);

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -16,12 +16,13 @@ import RuleNameField, { DefaultNameFieldProps } from '../NameField/NameField';
 import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 import ScaleDenominator from '../ScaleDenominator/ScaleDenominator';
 import Fieldset from '../FieldSet/FieldSet';
-import Preview, { DefaultPreviewProps } from '../Symbolizer/Preview/Preview';
 
 import './Rule.css';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
 import FilterTree from '../Filter/FilterTree/FilterTree';
+import Renderer from '../Symbolizer/Renderer/Renderer';
+import EditorWindow from '../Symbolizer/EditorWindow/EditorWindow';
 
 const _cloneDeep = require('lodash/cloneDeep');
 
@@ -50,7 +51,6 @@ interface DefaultRuleProps {
   /** The data projection of example features */
   dataProjection?: string;
   filterUiProps?: DefaultComparisonFilterProps;
-  previewProps?: DefaultPreviewProps;
   ruleNameProps?: DefaultNameFieldProps;
   locale?: RuleLocale;
 }
@@ -67,10 +67,13 @@ interface RuleProps extends Partial<DefaultRuleProps> {
   onAddSymbolizer?: (rule: GsRule) => void;
   /** Callback for onClick of the RemoveSymbolizerButton */
   onRemoveSymbolizer?: (rule: GsRule, symbolizer: GsSymbolizer, key: number) => void;
+  /** Callbakc for onClick of the Renderer */
+  onRendererClick?: (symbolizers: GsSymbolizer[], rule: GsRule) => void;
 }
 
 // state
 interface RuleState {
+  editorVisible: boolean;
   rule: GsRule;
   symbolizerEditorVisible: boolean;
   storedFilter: GsFilter;
@@ -86,6 +89,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
   constructor(props: RuleProps) {
     super(props);
     this.state = {
+      editorVisible: false,
       rule: Rule.defaultProps.rule,
       symbolizerEditorVisible: false,
       storedFilter: ['=='],
@@ -160,9 +164,9 @@ export class Rule extends React.Component<RuleProps, RuleState> {
   /**
    * Handles changing rule symbolizer
    */
-  onSymbolizerChange = (symbolizer: GsSymbolizer, key: number) => {
+  onSymbolizersChange = (symbolizers: GsSymbolizer[]) => {
     let rule: GsRule = _cloneDeep(this.state.rule);
-    rule.symbolizers[key] = symbolizer;
+    rule.symbolizers = symbolizers;
     if (this.props.onRuleChange) {
       this.props.onRuleChange(rule, this.state.rule);
     }
@@ -215,13 +219,13 @@ export class Rule extends React.Component<RuleProps, RuleState> {
 
   render() {
     const {
-      dataProjection,
       internalDataDef,
       onRemove,
       locale
     } = this.props;
 
     const {
+      editorVisible,
       rule,
       scaleFieldChecked,
       filterFieldChecked
@@ -244,23 +248,24 @@ export class Rule extends React.Component<RuleProps, RuleState> {
               placeholder={locale.nameFieldPlaceholder}
               {...this.props.ruleNameProps}
             />
-            <Preview
-              dataProjection={dataProjection}
+            <Renderer
               symbolizers={rule.symbolizers}
-              internalDataDef={gsData}
-              onSymbolizerChange={this.onSymbolizerChange}
-              onAddSymbolizer={() => {
-                if (this.props.onAddSymbolizer) {
-                  this.props.onAddSymbolizer(this.props.rule);
-                }
+              onClick={() => {
+                this.setState({
+                  editorVisible: !editorVisible
+                });
               }}
-              onRemoveSymbolizer={(symb: GsSymbolizer, key: number) => {
-                if (this.props.onRemoveSymbolizer) {
-                  this.props.onRemoveSymbolizer(this.props.rule, symb, key);
-                }
-              }}
-              {...this.props.previewProps}
             />
+            {
+              !editorVisible ? null :
+                <EditorWindow
+                  onClose={() => {
+                    this.setState({editorVisible: false});
+                  }}
+                  symbolizers={rule.symbolizers}
+                  onSymbolizersChange={this.onSymbolizersChange}
+                />
+            }
           </div>
           <div className="gs-rule-right-fields" >
             <Fieldset

--- a/src/Component/Style/Style.spec.tsx
+++ b/src/Component/Style/Style.spec.tsx
@@ -73,16 +73,4 @@ describe('Style', () => {
     wrapper.instance().removeRule(lineStyle.rules[0]);
     expect(wrapper.state().style.rules).toHaveLength(0);
   });
-
-  it('adds a Symbolizer', () => {
-    expect(wrapper.state().style.rules[0].symbolizers).toHaveLength(1);
-    wrapper.instance().addSymbolizer(lineStyle.rules[0]);
-    expect(wrapper.state().style.rules[0].symbolizers).toHaveLength(2);
-  });
-
-  it('removes a Symbolizer', () => {
-    expect(wrapper.state().style.rules[0].symbolizers).toHaveLength(1);
-    wrapper.instance().removeSymbolizer(lineStyle.rules[0], lineStyle.rules[0].symbolizers[0]);
-    expect(wrapper.state().style.rules[0].symbolizers).toHaveLength(0);
-  });
 });

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -157,41 +157,6 @@ export class Style extends React.Component<StyleProps, StyleState> {
     this.setState({style});
   }
 
-  addSymbolizer = (rule: GsRule) => {
-    const style = _cloneDeep(this.state.style);
-    // TODO generate some kind of id
-    // right now, all properties of symbolizer must match
-    let newSymbolizer: GsSymbolizer = this.getDefaultSymbolizer(_get(rule, 'symbolizers[0]'));
-    const ruleIdx = style.rules.findIndex((r: GsRule) => r.name === rule.name);
-    if (ruleIdx > -1) {
-      style.rules[ruleIdx].symbolizers.push(newSymbolizer);
-      if (this.props.onStyleChange) {
-        this.props.onStyleChange(style);
-      }
-      this.setState({style});
-    }
-  }
-
-  removeSymbolizer = (rule: GsRule, symbolizer: GsSymbolizer, key: number) => {
-    const style = _cloneDeep(this.state.style);
-    const ruleIdx = style.rules.findIndex((r: GsRule) => r.name === rule.name);
-
-    const newSymbolizers = style.rules[ruleIdx].symbolizers
-    .filter((symb: GsSymbolizer, index: number) => {
-      if (key) {
-        return key !== index;
-      } else {
-          // if all properties of a symbolizer are equal, remove this symbolizer
-          return !_isEqual(symb, symbolizer);
-        }
-      });
-    style.rules[ruleIdx].symbolizers = newSymbolizers;
-    if (this.props.onStyleChange) {
-      this.props.onStyleChange(style);
-    }
-    this.setState({style});
-  }
-
   render() {
     let rules: GsRule[] = [];
 
@@ -216,13 +181,10 @@ export class Style extends React.Component<StyleProps, StyleState> {
             key={'rule_' + idx}
             rule={rule}
             onRemove={this.removeRule}
-            onAddSymbolizer={this.addSymbolizer}
-            onRemoveSymbolizer={this.removeSymbolizer}
             internalDataDef={this.props.data}
             onRuleChange={this.onRuleChange}
             dataProjection={this.props.dataProjection}
             filterUiProps={this.props.filterUiProps}
-            previewProps={this.props.previewProps}
             ruleNameProps={this.props.ruleNameProps}
           />)
         }

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+const _get = require('lodash/get');
+const _isEqual = require('lodash/isEqual');
+const _cloneDeep = require('lodash/cloneDeep');
+
+import { Button } from 'antd';
+
 import {
   Style as GsStyle,
   Rule as GsRule,
@@ -12,13 +18,11 @@ import {
   Data as GsData
 } from 'geostyler-data';
 
-import { Button } from 'antd';
 import Rule from '../Rule/Rule';
 import NameField, { DefaultNameFieldProps } from '../NameField/NameField';
+import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
-
-const _get = require('lodash/get');
 
 // i18n
 export interface StyleLocale {
@@ -35,10 +39,6 @@ interface DefaultStyleProps {
   ruleNameProps?: DefaultNameFieldProps;
   locale?: StyleLocale;
 }
-
-const _isEqual = require('lodash/isEqual');
-const _cloneDeep = require('lodash/cloneDeep');
-import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 
 // non default props
 interface StyleProps extends Partial<DefaultStyleProps> {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -32,7 +32,6 @@ interface DefaultStyleProps {
   style: GsStyle;
   defaultIconSource?: string;
   filterUiProps?: DefaultComparisonFilterProps;
-  previewProps?: DefaultPreviewProps;
   ruleNameProps?: DefaultNameFieldProps;
   locale?: StyleLocale;
 }
@@ -40,7 +39,6 @@ interface DefaultStyleProps {
 const _isEqual = require('lodash/isEqual');
 const _cloneDeep = require('lodash/cloneDeep');
 import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
-import { DefaultPreviewProps } from '../Symbolizer/Preview/Preview';
 
 // non default props
 interface StyleProps extends Partial<DefaultStyleProps> {

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -25,7 +25,7 @@ export interface DefaultEditorWindowProps {
   onClose: () => void;
   onRemove: (symbolizer: Symbolizer, idx: number) => void;
   symbolizers: Symbolizer[];
-  onSymbolizerChange: (symbolizer: Symbolizer, key: number) => void;
+  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
   locale: EditorWindowLocale;
 }
 
@@ -55,7 +55,7 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
       onClose,
       onRemove,
       symbolizers,
-      onSymbolizerChange,
+      onSymbolizersChange,
       locale
     } = this.props;
 
@@ -93,7 +93,7 @@ export class EditorWindow extends React.Component<EditorWindowProps, EditorWindo
           </div>
           <MultiEditor
             symbolizers={symbolizers}
-            onSymbolizerChange={onSymbolizerChange}
+            onSymbolizersChange={onSymbolizersChange}
             onAdd={onAdd}
             onRemove={onRemove}
           />

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
@@ -1,0 +1,48 @@
+import { MultiEditor } from './MultiEditor';
+import TestUtil from '../../../Util/TestUtil';
+import en_US from '../../../locale/en_US';
+import { Symbolizer } from 'geostyler-style';
+
+describe('Renderer', () => {
+
+  let wrapper: any;
+  let dummyOnSymbolizerChange: any = jest.fn();
+  const dummySymbolizers: Symbolizer[] = [{
+    kind: 'Mark',
+    wellKnownName: 'Circle',
+    color: '#FF0000'
+  }, {
+    kind: 'Mark',
+    wellKnownName: 'Circle',
+    color: '#FF00FF'
+  }];
+
+  beforeEach(() => {
+    dummyOnSymbolizerChange = jest.fn();
+    wrapper = TestUtil.shallowRenderComponent(MultiEditor, {
+      locale: en_US.GsPreview,
+      onSymbolizersChange: dummyOnSymbolizerChange,
+      symbolizers: dummySymbolizers
+    });
+  });
+
+  it('is defined', () => {
+    expect(MultiEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  it('adds a Symbolizer', () => {
+    wrapper.instance().addSymbolizer();
+    expect(dummyOnSymbolizerChange).toHaveBeenCalledTimes(1);
+    dummyOnSymbolizerChange.mockRestore();
+  });
+
+  it('removes a Symbolizer', () => {
+    wrapper.instance().removeSymbolizer(1);
+    expect(dummyOnSymbolizerChange).toHaveBeenCalledTimes(1);
+    dummyOnSymbolizerChange.mockRestore();
+  });
+});

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -45,7 +45,8 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
       onSymbolizersChange,
       symbolizers
     } = this.props;
-    const newSymbolizer = this.getDefaultSymbolizer(symbolizers[0].kind);
+    const symbolizerKind = symbolizers.length > 0 ? symbolizers[0].kind : undefined;
+    const newSymbolizer = this.getDefaultSymbolizer(symbolizerKind);
     onSymbolizersChange([...symbolizers, newSymbolizer]);
   }
 

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -36,7 +36,7 @@ export interface MultiEditorProps extends Partial<DefaultMultiEditorProps> {
   editorProps?: any;
 }
 
-class MultiEditor extends React.Component<MultiEditorProps> {
+export class MultiEditor extends React.Component<MultiEditorProps> {
 
   static componentName: string = 'MultiEditor';
 

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {
-  Symbolizer
+  Symbolizer, IconSymbolizer, MarkSymbolizer, SymbolizerKind
 } from 'geostyler-style';
 
 import './MultiEditor.css';
@@ -26,7 +26,7 @@ interface DefaultMultiEditorProps {
   onAdd: () => void;
   onRemove: (symbolizer: Symbolizer, idx: number) => void;
   symbolizers: Symbolizer[];
-  onSymbolizerChange: (symbolizer: Symbolizer, idx: number) => void;
+  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
   locale: MultiEditorLocale;
 }
 
@@ -40,13 +40,69 @@ class MultiEditor extends React.Component<MultiEditorProps> {
 
   static componentName: string = 'MultiEditor';
 
+  addSymbolizer = () => {
+    const {
+      onSymbolizersChange,
+      symbolizers
+    } = this.props;
+    const newSymbolizer = this.getDefaultSymbolizer(symbolizers[0].kind);
+    onSymbolizersChange([...symbolizers, newSymbolizer]);
+  }
+
+  removeSymbolizer = (key: number) => {
+    const {
+      onSymbolizersChange,
+      symbolizers
+    } = this.props;
+    const symbolizersClone = [...symbolizers];
+    symbolizersClone.splice(key, 1);
+    onSymbolizersChange(symbolizersClone);
+  }
+
+  onSymbolizerChange = (symbolizer: Symbolizer, key: number) => {
+    const {
+      onSymbolizersChange,
+      symbolizers
+    } = this.props;
+    const symbolizersClone = [...symbolizers];
+    symbolizersClone[key] = symbolizer;
+    onSymbolizersChange(symbolizersClone);
+  }
+
+  /**
+   *
+   */
+  getDefaultSymbolizer(kind?: SymbolizerKind): Symbolizer {
+    if (kind) {
+      if (kind === 'Mark') {
+        return {
+          kind,
+          wellKnownName: 'Circle'
+        } as MarkSymbolizer;
+      } else if (kind === 'Icon') {
+        return {
+          kind,
+          image: ''
+        } as IconSymbolizer;
+      } else {
+        return {
+          kind
+        } as Symbolizer;
+      }
+    } else {
+      return {
+        kind: 'Mark',
+        wellKnownName: 'Circle'
+      } as MarkSymbolizer;
+    }
+  }
+
   render() {
     const {
       onAdd,
       onRemove,
       symbolizers,
       editorProps,
-      onSymbolizerChange,
       locale,
       ...passThroughProps
     } = this.props;
@@ -62,14 +118,14 @@ class MultiEditor extends React.Component<MultiEditorProps> {
             <Editor
               symbolizer={symbolizer}
               onSymbolizerChange={(sym: Symbolizer) => {
-                onSymbolizerChange(sym, idx);
+                this.onSymbolizerChange(sym, idx);
               }}
               {...editorProps}
             />
-            {idx === 0 ? null :
+            {symbolizers.length === 1 ? null :
               <Button
                 onClick={() => {
-                  onRemove(symbolizer, idx);
+                  this.removeSymbolizer(idx);
                 }}
               >
                 {locale.remove}
@@ -84,7 +140,11 @@ class MultiEditor extends React.Component<MultiEditorProps> {
         className="gs-symbolizer-multi-editor"
         defaultActiveKey="0"
         animated={false}
-        tabBarExtraContent={<Button onClick={onAdd}>{locale.add}</Button>}
+        tabBarExtraContent={(
+          <Button onClick={this.addSymbolizer}>
+            {locale.add}
+          </Button>
+        )}
         {...passThroughProps}
       >
         {tabs}

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -65,7 +65,7 @@ export interface DefaultPreviewProps {
 interface PreviewProps extends Partial<DefaultPreviewProps> {
   internalDataDef?: Data;
   symbolizers: Symbolizer[];
-  onSymbolizerChange: (symbolizer: Symbolizer, key: number) => void;
+  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
   onAddSymbolizer?: () => void;
   onRemoveSymbolizer?: (symbolizer: Symbolizer, key: number) => void;
 }
@@ -317,7 +317,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
       locale,
       symbolizers,
       hideEditButton,
-      onSymbolizerChange,
+      onSymbolizersChange,
       onAddSymbolizer,
       onRemoveSymbolizer
     } = this.props;
@@ -364,7 +364,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
               onClose={this.onEditButtonClicked}
               onRemove={onRemoveSymbolizer}
               symbolizers={symbolizers}
-              onSymbolizerChange={onSymbolizerChange}
+              onSymbolizersChange={onSymbolizersChange}
             /> : null
         }
         </div>

--- a/src/Component/Symbolizer/Renderer/Renderer.css
+++ b/src/Component/Symbolizer/Renderer/Renderer.css
@@ -1,0 +1,7 @@
+.gs-symbolizer-renderer {
+  position: relative;
+  border: 1px solid lightgrey;
+  border-radius: 4px;
+  background-color: white;
+}
+

--- a/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
@@ -1,0 +1,28 @@
+import { Renderer } from './Renderer';
+import TestUtil from '../../../Util/TestUtil';
+import { Symbolizer } from 'geostyler-style';
+
+describe('Renderer', () => {
+
+  let wrapper: any;
+  const dummySymbolizers: Symbolizer[] = [{
+    kind: 'Mark',
+    wellKnownName: 'Circle',
+    color: '#FF0000'
+  }];
+
+  beforeEach(() => {
+    wrapper = TestUtil.shallowRenderComponent(Renderer, {
+      onSymbolizerChange: jest.fn(),
+      symbolizers: dummySymbolizers
+    });
+  });
+
+  it('is defined', () => {
+    expect(Renderer).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+});

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+
+const _isEqual = require('lodash/isEqual');
+const _get = require('lodash/get');
+const _uniqueId = require('lodash/uniqueId');
+
+import OlMap from 'ol/map';
+import OlLayerVector from 'ol/layer/vector';
+import OlSourceVector from 'ol/source/vector';
+import OlGeomPoint from 'ol/geom/point';
+import OlGeomLineString from 'ol/geom/linestring';
+import OlGeomPolygon from 'ol/geom/polygon';
+import OlFeature from 'ol/feature';
+import OlView from 'ol/view';
+import OlStyle from 'ol/style/style';
+
+import OlStyleParser from 'geostyler-openlayers-parser';
+
+import { Symbolizer, SymbolizerKind } from 'geostyler-style';
+
+import './Renderer.css';
+
+import 'ol/ol.css';
+import './Renderer.css';
+
+// non default props
+interface RendererProps {
+  symbolizers: Symbolizer[];
+  symbolizerKind?: SymbolizerKind;
+  onClick?: (symbolizers: Symbolizer[]) => void;
+}
+
+/**
+ * Symbolizer Renderer UI.
+ */
+export class Renderer extends React.PureComponent<RendererProps> {
+
+  /** reference to the underlying OpenLayers map */
+  _map: OlMap;
+
+  _layer: OlLayerVector;
+
+  _mapId: string;
+
+  constructor(props: RendererProps) {
+    super(props);
+    this._mapId = _uniqueId('map_');
+  }
+
+  public componentDidMount() {
+    const {
+      symbolizers
+    } = this.props;
+
+    this._layer = new OlLayerVector({
+      source: new OlSourceVector()
+    });
+    this._map = new OlMap({
+        layers: [this._layer],
+        controls: [],
+        interactions: [],
+        target: this._mapId,
+        view: new OlView({
+          projection: 'EPSG:4326'
+        })
+    });
+
+    this.updateFeature();
+    this.applySymbolizers(symbolizers);
+  }
+
+  componentDidUpdate(prevProps: RendererProps) {
+    const {
+      symbolizers
+    } = this.props;
+
+    if (!_isEqual(symbolizers, prevProps.symbolizers)) {
+      this.updateFeature();
+      this.applySymbolizers(symbolizers);
+    }
+  }
+
+  updateFeature() {
+    this._layer.getSource().clear();
+    const sampleFeature = new OlFeature({
+      geometry: this.getSampleGeomFromSymbolizer(),
+      Name: 'Sample Feature'
+    });
+    this._layer.getSource().addFeature(sampleFeature);
+    // zoom to feature extent
+    const extent = this._layer.getSource().getExtent();
+    this._map.getView().fit(extent, {
+      maxZoom: 20
+    });
+  }
+
+  getSampleGeomFromSymbolizer = () => {
+    const {
+      symbolizerKind,
+      symbolizers
+    } = this.props;
+    const kind: SymbolizerKind = symbolizerKind || _get(symbolizers, '[0].kind');
+    switch (kind) {
+      case 'Mark':
+      case 'Icon':
+      case 'Text':
+        return new OlGeomPoint([7.10066, 50.735851]);
+      case 'Fill':
+        return new OlGeomPolygon([[
+            [7.1031761169433585, 50.734268655851345],
+            [7.109270095825195, 50.734268655851345, ],
+            [7.109270095825195, 50.73824770380063],
+            [7.1031761169433585, 50.73824770380063],
+            [7.1031761169433585, 50.734268655851345, ]
+          ]]);
+      case 'Line':
+        return new OlGeomLineString([
+          [7.062578201293945, 50.721786104206004],
+          [7.077512741088867, 50.729610159968296],
+          [7.082319259643555, 50.732435192351126],
+          [7.097940444946289, 50.73748722929948],
+          [7.106866836547852, 50.73775882875318],
+          [7.117509841918945, 50.73889952925885],
+          [7.129182815551758, 50.7504679214779]
+        ]);
+      default:
+        return new OlGeomPoint([7.10066, 50.735851]);
+    }
+  }
+
+  /**
+   * Transforms the incoming symbolizers to an OpenLayers style object the
+   * GeoStyler parser and applies it to the vector features on the map.
+   *
+   * @param {Symbolizer[]} symbolizers The symbolizers holding the style to apply
+   */
+  applySymbolizers = (symbolizers: Symbolizer[]) => {
+    const styleParser = new OlStyleParser();
+
+    // we have to wrap the symbolizer in a Style object since the writeStyle
+    // only accepts a Style object
+    const style = {
+      name: 'WrapperStyle4Symbolizer',
+      rules: [{
+        symbolizers: symbolizers
+      }]
+    };
+    // parser style to OL style
+    styleParser.writeStyle(style)
+      .then((olStyles: (OlStyle|OlStyle[]|ol.StyleFunction)) => {
+        // apply new OL style to vector layer
+        this._layer.setStyle(olStyles);
+        return olStyles;
+      });
+  }
+
+  render() {
+    const { onClick, symbolizers } = this.props;
+    return (
+      <div
+        onClick={() => {
+          if (onClick) {
+            onClick(symbolizers);
+          }
+        }}
+        className="gs-symbolizer-renderer"
+        id={this._mapId}
+      />
+    );
+  }
+
+}
+
+export default Renderer;

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -51,3 +51,7 @@
     margin-right: 10px;
   }
 }
+
+.gs-symbolizer-renderer {
+  cursor: pointer;
+}


### PR DESCRIPTION
This introduces the Symbolizer `Renderer` which is a "lightweight" component to show just one feature with an applied style.

It replaces the `Preview` component in the `Rule`. This leads to further adjustments in other components.

![localhost_3000_ 17](https://user-images.githubusercontent.com/1849416/47728049-dea19200-dc5d-11e8-940c-f81f4a83d5db.png)
