### PR TITLE
Updates typing of props

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -26,6 +26,7 @@ import {
 const _isEqual = require('lodash/isEqual');
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
+import en_US from '../../locale/en_US';
 
 // i18n
 export interface CodeEditorLocale {
@@ -34,7 +35,7 @@ export interface CodeEditorLocale {
 }
 
 interface DefaultCodeEditorProps {
-  locale?: CodeEditorLocale;
+  locale: CodeEditorLocale;
 }
 
 // non default props
@@ -56,6 +57,8 @@ interface CodeEditorState {
  */
 class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
 
+  static componentName: string = 'CodeEditor';
+
   constructor(props: CodeEditorProps) {
     super(props);
     this.state = {
@@ -63,7 +66,9 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
     };
   }
 
-  static componentName: string = 'CodeEditor';
+  public static defaultProps: DefaultCodeEditorProps = {
+    locale: en_US.GsCodeEditor
+  };
 
   componentDidMount() {
     if (this.props.style) {

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -26,6 +26,7 @@ export interface ReadParams {
 }
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface DataLoaderLocale {
@@ -36,7 +37,7 @@ export interface DataLoaderLocale {
 // default props
 interface DefaultDataLoaderProps {
   onDataRead: (data: GsData) => void;
-  locale?: DataLoaderLocale;
+  locale: DataLoaderLocale;
 }
 
 // non default props
@@ -62,6 +63,7 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
   static componentName: string = 'DataLoader';
 
   public static defaultProps: DefaultDataLoaderProps = {
+    locale: en_US.GsDataLoader,
     onDataRead: (data: GsData) => {return; }
   };
 
@@ -129,7 +131,6 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
         case 'GeoJSON Style Parser':
           return (
             <UploadButton
-              label="Upload Data"
               onUpload={this.parseUploadData}
             />
           );
@@ -150,7 +151,6 @@ class DataLoader extends React.Component<DataLoaderProps, DataLoaderState> {
         default:
           return (
             <UploadButton
-              label="Upload Data"
               onUpload={this.parseUploadData}
             />
           );

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -11,6 +11,7 @@ import {
 import UploadButton from '../../UploadButton/UploadButton';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface StyleLoaderLocale {
@@ -21,7 +22,7 @@ export interface StyleLoaderLocale {
 // default props
 interface DefaultStyleLoaderProps {
   onStyleRead: (style: GsStyle) => void;
-  locale?: StyleLoaderLocale;
+  locale: StyleLoaderLocale;
 }
 
 // non default props
@@ -44,7 +45,8 @@ class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderState> {
   static componentName: string = 'StyleLoader';
 
   public static defaultProps: DefaultStyleLoaderProps = {
-    onStyleRead: (style: GsStyle) => {return; },
+    locale: en_US.GsStyleLoader,
+    onStyleRead: (style: GsStyle) => {return; }
   };
 
   parseStyle = (uploadObject: any) => {
@@ -99,7 +101,6 @@ class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderState> {
         {
           activeParser ?
           <UploadButton
-            label={locale.uploadButtonLabel}
             onUpload={this.parseStyle}
           /> : null
         }

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -9,24 +9,25 @@ import {
 } from 'antd';
 const Option = Select.Option;
 
-const _get = require('lodash/get');
-
-import './WfsParserInput.css';
-
-// TODO should be replaced with import {ReadParams} from 'geostyler-wfs-parser'
-// once it exists
-interface ReadParams {
+// TODO This should be importable from the wfs-parser
+interface WfsParams {
   url: string;
   version: string;
   typeName: string;
   featureID?: string;
   propertyName?: string[];
+  srsName?: string;
   maxFeatures?: number;
   fetchParams?: Object;
 }
 
-// default props
-interface WfsParserInputDefaultProps {
+import en_US from '../../../locale/en_US';
+
+const _get = require('lodash/get');
+
+import './WfsParserInput.css';
+
+export interface WfsParserInputLocale {
   requestButtonText: string;
   urlLabel: string;
   versionLabel: string;
@@ -37,13 +38,18 @@ interface WfsParserInputDefaultProps {
   fetchParamsLabel: string;
 }
 
+// default props
+interface WfsParserInputDefaultProps {
+  locale: WfsParserInputLocale;
+}
+
 // non default props
 interface WfsParserInputProps extends Partial<WfsParserInputDefaultProps> {
-  onClick: ((wfsParams: ReadParams) => void);
+  onClick: (wfsParams: WfsParams) => void;
 }
 
 // state
-interface WfsParserState extends ReadParams {
+interface WfsParserState extends WfsParams {
   validation: any;
 }
 
@@ -53,14 +59,7 @@ interface WfsParserState extends ReadParams {
 class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState> {
 
   public static defaultProps: WfsParserInputDefaultProps = {
-    requestButtonText: 'Get Data',
-    urlLabel: 'Url',
-    versionLabel: 'Version',
-    typeNameLabel: 'FeatureTypeName',
-    featureIDLabel: 'FeatureID',
-    propertyNameLabel: 'PropertyName',
-    maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    locale: en_US.GsWfsParserInput
   };
 
   constructor(props: any) {
@@ -156,7 +155,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
 
   render() {
     const {
-      requestButtonText
+      locale
     } = this.props;
 
     const {
@@ -171,7 +170,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
     return (
       <div className="wfs-parser-input">
         <Form.Item
-          label={this.props.urlLabel}
+          label={locale.urlLabel}
           validateStatus={_get(this.state, 'validation.url.status')}
           help={_get(this.state, 'validation.url.message')}
           hasFeedback={true}
@@ -183,7 +182,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
           />
         </Form.Item>
         <Form.Item
-          label={this.props.typeNameLabel}
+          label={locale.typeNameLabel}
           validateStatus={_get(this.state, 'validation.typeName.status')}
           help={_get(this.state, 'validation.typeName.message')}
           hasFeedback={true}
@@ -195,7 +194,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
           />
         </Form.Item>
         <Form.Item
-          label={this.props.versionLabel}
+          label={locale.versionLabel}
           validateStatus={_get(this.state, 'validation.version.status')}
           help={_get(this.state, 'validation.version.message')}
           hasFeedback={true}
@@ -214,7 +213,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
           </Select>
         </Form.Item>
         <Form.Item
-          label={this.props.featureIDLabel}
+          label={locale.featureIDLabel}
           validateStatus={_get(this.state, 'validation.featureID.status')}
           help={_get(this.state, 'validation.featureID.message')}
           hasFeedback={true}
@@ -225,7 +224,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
           />
         </Form.Item>
         <Form.Item
-          label={this.props.propertyNameLabel}
+          label={locale.propertyNameLabel}
           validateStatus={_get(this.state, 'validation.propertyName.status')}
           help={_get(this.state, 'validation.propertyName.message')}
           hasFeedback={true}
@@ -238,7 +237,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
           />
         </Form.Item>
         <Form.Item
-          label={this.props.maxFeaturesLabel}
+          label={locale.maxFeaturesLabel}
           validateStatus={_get(this.state, 'validation.maxFeatures.status')}
           help={_get(this.state, 'validation.maxFeatures.message')}
           hasFeedback={true}
@@ -257,7 +256,7 @@ class WfsParserInput extends React.Component<WfsParserInputProps, WfsParserState
             type="primary"
             onClick={this.onClick}
           >
-            {requestButtonText}
+            {locale.requestButtonText}
           </Button>
         </Form.Item>
       </div>

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -22,9 +22,9 @@ interface DefaultAttributeComboProps {
   /** Mapping function for attribute names of this combo */
   attributeNameMappingFunction?: (originalAttributeName: string) => string;
   /** Validation status */
-  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  validateStatus: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
-  help?: React.ReactNode;
+  help: React.ReactNode;
 }
 // non default props
 interface AttributeComboProps extends Partial<DefaultAttributeComboProps> {

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -41,31 +41,31 @@ export interface DefaultComparisonFilterProps {
    */
   attributeNameFilter: (attributeName: string) => boolean;
   /** Label for the underlying AttributeCombo */
-  attributeLabel?: string;
+  attributeLabel: string;
   /** Placeholder text for the underlying AttributeCombo */
-  attributePlaceholderString?: string;
+  attributePlaceholderString: string;
   /** Validation help text for the underlying AttributeCombo */
-  attributeValidationHelpString?: string;
+  attributeValidationHelpString: string;
   /** Mapping function for attribute names of underlying AttributeCombo */
-  attributeNameMappingFunction?: (originalAttributeName: string) => string;
+  attributeNameMappingFunction: (originalAttributeName: string) => string;
   /** Label for the underlying OperatorCombo */
-  operatorLabel?: string;
+  operatorLabel: string;
   /** Show title of selected item in underlying OperatorCombo */
   showOperatorTitles: boolean;
   /** Placeholder for the underlying OperatorCombo */
-  operatorPlaceholderString?: string;
+  operatorPlaceholderString: string;
   /** Validation help text for the underlying OperatorCombo */
-  operatorValidationHelpString?: string;
+  operatorValidationHelpString: string;
   /** Mapping function for operator names of underlying OperatorCombo */
-  operatorNameMappingFunction?: (originalOperatorName: string) => string;
+  operatorNameMappingFunction: (originalOperatorName: string) => string;
   /** Mapping function for operator title in underlying OperatorCombo */
-  operatorTitleMappingFunction?: (originalOperatorName: string) => string;
+  operatorTitleMappingFunction: (originalOperatorName: string) => string;
   /** Label for the underlying value field */
-  valueLabel?: string;
+  valueLabel: string;
   /** Placeholder for the underlying value field */
-  valuePlaceholder?: string;
+  valuePlaceholder: string;
   /** Validation help text for the underlying value field */
-  valueValidationHelpString?: string;
+  valueValidationHelpString: string;
   /** Callback for onValidationChanged */
   onValidationChanged?: (status: ValidationStatus) => void;
   /** Object aggregating validation functions for attribute, operator and value */
@@ -74,7 +74,7 @@ export interface DefaultComparisonFilterProps {
   microUI: boolean;
 }
 // non default props
-interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
+export interface ComparisonFilterProps extends Partial<DefaultComparisonFilterProps> {
   /** Reference to internal data object (holding schema and example features) */
   internalDataDef: Data;
   /** Callback function for onFilterChange */

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -11,9 +11,9 @@ interface DefaultNumberFilterFieldProps {
   /** Initial value set to the field */
   value: number | undefined;
   /** Validation status */
-  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  validateStatus: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
-  help?: React.ReactNode;
+  help: React.ReactNode;
 }
 // non default props
 interface NumberFilterFieldProps extends Partial<DefaultNumberFilterFieldProps> {

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -19,13 +19,13 @@ interface DefaultOperatorComboProps {
   /** List of operators to show in this combo */
   operators: string[];
   /** Mapping function for operator names in this combo */
-  operatorNameMappingFunction?: (originalOperatorName: string) => string;
+  operatorNameMappingFunction: (originalOperatorName: string) => string;
   /** Mapping function for operator title in this combo */
-  operatorTitleMappingFunction?: (originalOperatorName: string) => string;
+  operatorTitleMappingFunction: (originalOperatorName: string) => string;
   /** Validation status */
-  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  validateStatus: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
-  help?: React.ReactNode;
+  help: React.ReactNode;
 }
 // non default props
 interface OperatorComboProps extends Partial<DefaultOperatorComboProps> {

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -15,9 +15,9 @@ interface DefaultTextFilterFieldProps {
   /** Initial value set to the field */
   value: string | undefined;
   /** Validation status */
-  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
+  validateStatus: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
-  help?: React.ReactNode;
+  help: React.ReactNode;
 }
 // non default props
 interface TextFilterFieldProps extends Partial<DefaultTextFilterFieldProps> {

--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -12,7 +12,7 @@ export interface DefaultNameFieldProps {
   placeholder: string;
 }
 // non default props
-interface NameFieldProps extends Partial<DefaultNameFieldProps> {
+export interface NameFieldProps extends Partial<DefaultNameFieldProps> {
   value: string | undefined;
   onChange: ((newValue: string) => void);
 }

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -12,19 +12,20 @@ import {
 } from 'geostyler-style';
 import { Data as GsData } from 'geostyler-data';
 
-import RuleNameField, { DefaultNameFieldProps } from '../NameField/NameField';
-import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
+import { localize } from '../LocaleWrapper/LocaleWrapper';
+
+import RuleNameField, { NameFieldProps } from '../NameField/NameField';
+import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 import ScaleDenominator from '../ScaleDenominator/ScaleDenominator';
 import Fieldset from '../FieldSet/FieldSet';
-
-import './Rule.css';
-
-import { localize } from '../LocaleWrapper/LocaleWrapper';
 import FilterTree from '../Filter/FilterTree/FilterTree';
 import Renderer from '../Symbolizer/Renderer/Renderer';
 import EditorWindow from '../Symbolizer/EditorWindow/EditorWindow';
 
 const _cloneDeep = require('lodash/cloneDeep');
+
+import './Rule.css';
+import en_US from '../../locale/en_US';
 
 // i18n
 export interface RuleLocale {
@@ -49,10 +50,9 @@ interface DefaultRuleProps {
   /** Optional Rule object holding inital values for the component */
   rule: GsRule;
   /** The data projection of example features */
-  dataProjection?: string;
-  filterUiProps?: DefaultComparisonFilterProps;
-  ruleNameProps?: DefaultNameFieldProps;
-  locale?: RuleLocale;
+  dataProjection: string;
+  rendererType: 'SLD' | 'OpenLayers';
+  locale: RuleLocale;
 }
 
 // non default props
@@ -69,6 +69,10 @@ interface RuleProps extends Partial<DefaultRuleProps> {
   onRemoveSymbolizer?: (rule: GsRule, symbolizer: GsSymbolizer, key: number) => void;
   /** Callback for onClick of the Renderer */
   onRendererClick?: (symbolizers: GsSymbolizer[], rule: GsRule) => void;
+  /** Properties that will be passed to the Comparison Filters */
+  filterUiProps?: Partial<ComparisonFilterProps>;
+  /** Properties that will be passed to the RuleNameField */
+  ruleNameProps?: Partial<NameFieldProps>;
 }
 
 // state
@@ -100,6 +104,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
   static componentName: string = 'Rule';
 
   public static defaultProps: DefaultRuleProps = {
+    locale: en_US.GsRule,
     rule: {
       name: 'My Style',
       symbolizers: [{
@@ -107,7 +112,8 @@ export class Rule extends React.Component<RuleProps, RuleState> {
         wellKnownName: 'Circle'
       }]
     },
-    dataProjection: 'EPSG:4326'
+    dataProjection: 'EPSG:4326',
+    rendererType: 'OpenLayers'
   };
 
   static getDerivedStateFromProps(

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -19,10 +19,11 @@ import {
 } from 'geostyler-data';
 
 import Rule from '../Rule/Rule';
-import NameField, { DefaultNameFieldProps } from '../NameField/NameField';
-import { DefaultComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
+import NameField, { NameFieldProps } from '../NameField/NameField';
+import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
+import en_US from '../../locale/en_US';
 
 // i18n
 export interface StyleLocale {
@@ -34,10 +35,8 @@ export interface StyleLocale {
 // default props
 interface DefaultStyleProps {
   style: GsStyle;
-  defaultIconSource?: string;
-  filterUiProps?: DefaultComparisonFilterProps;
-  ruleNameProps?: DefaultNameFieldProps;
-  locale?: StyleLocale;
+  defaultIconSource: string;
+  locale: StyleLocale;
 }
 
 // non default props
@@ -46,6 +45,8 @@ interface StyleProps extends Partial<DefaultStyleProps> {
   onStyleChange?: (rule: GsStyle) => void;
   /** The data projection of example features */
   dataProjection?: string;
+  filterUiProps?: Partial<ComparisonFilterProps>;
+  ruleNameProps?: Partial<NameFieldProps>;
 }
 
 // state
@@ -64,6 +65,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
   static componentName: string = 'Style';
 
   public static defaultProps: DefaultStyleProps = {
+    locale: en_US.GsStyle,
     style: {
       name: 'My Style',
       rules: []
@@ -159,6 +161,9 @@ export class Style extends React.Component<StyleProps, StyleState> {
     let rules: GsRule[] = [];
 
     const {
+      dataProjection,
+      filterUiProps,
+      ruleNameProps,
       locale
     } = this.props;
 
@@ -181,9 +186,9 @@ export class Style extends React.Component<StyleProps, StyleState> {
             onRemove={this.removeRule}
             internalDataDef={this.props.data}
             onRuleChange={this.onRuleChange}
-            dataProjection={this.props.dataProjection}
-            filterUiProps={this.props.filterUiProps}
-            ruleNameProps={this.props.ruleNameProps}
+            dataProjection={dataProjection}
+            filterUiProps={filterUiProps}
+            ruleNameProps={ruleNameProps}
           />)
         }
         <Button

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -18,20 +18,19 @@ import { Data } from 'geostyler-data';
 const  _cloneDeep = require('lodash/cloneDeep');
 
 import KindField from '../Field/KindField/KindField';
-import IconEditor, { DefaultIconEditorProps } from '../IconEditor/IconEditor';
+import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 
 // default props
 interface DefaultEditorProps {
   defaultIconSource: string;
   unknownSymbolizerText?: string;
-  kindLabelText?: string;
-  iconEditorProps?: DefaultIconEditorProps;
 }
 
 // non default props
 export interface EditorProps extends Partial<DefaultEditorProps> {
   symbolizer: Symbolizer;
   internalDataDef?: Data;
+  iconEditorProps: Partial<IconEditorProps>;
   onSymbolizerChange: (symbolizer: Symbolizer) => void;
 }
 

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -30,7 +30,7 @@ export interface DefaultEditorWindowProps {
 }
 
 // non default props
-interface EditorWindowProps extends Partial<DefaultEditorWindowProps> {
+export interface EditorWindowProps extends Partial<DefaultEditorWindowProps> {
   internalDataDef?: Data;
   x?: number;
   y?: number;

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -12,6 +12,7 @@ import {
 import './ColorField.css';
 
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../../locale/en_US';
 
 // i18n
 export interface ColorFieldLocale {
@@ -23,7 +24,7 @@ export interface ColorFieldLocale {
 // default props
 interface ColorFieldDefaultProps {
   label: string;
-  locale?: ColorFieldLocale;
+  locale: ColorFieldLocale;
 }
 
 // non default props
@@ -43,6 +44,7 @@ interface ColorFieldState {
 class ColorField extends React.Component<ColorFieldProps, ColorFieldState> {
 
   public static defaultProps: ColorFieldDefaultProps = {
+    locale: en_US.GsColorField,
     label: 'Color'
   };
 

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -4,6 +4,7 @@ import { Select } from 'antd';
 import { GraphicType } from 'geostyler-style';
 
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../../locale/en_US';
 
 const _get = require('lodash/get');
 
@@ -18,16 +19,16 @@ interface GraphicTypeFieldLocale {
 
 export interface DefaultGraphicTypeFieldProps {
   /** List of selectable GraphicTypes for Select */
-  graphicTypes?: GraphicType[];
+  graphicTypes: GraphicType[];
   /** Label rendered next to Select */
-  label?: String;
+  label: String;
   /** Language package */
-  locale?: GraphicTypeFieldLocale;
+  locale: GraphicTypeFieldLocale;
   /** If true GraphicTypeField can be cleared  */
-  clearable?: boolean;
+  clearable: boolean;
 }
 
-interface GraphicTypeFieldProps extends DefaultGraphicTypeFieldProps {
+export interface GraphicTypeFieldProps extends DefaultGraphicTypeFieldProps {
   /** Currently selected GraphicType */
   graphicType?: GraphicType;
   /** Callback when selection changes */
@@ -40,6 +41,7 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps, {}
   static componentName: string = 'GraphicTypeField';
 
   public static defaultProps: DefaultGraphicTypeFieldProps = {
+    locale: en_US.GsGraphicTypeField,
     graphicTypes: ['Mark', 'Icon'],
     label: 'Graphic',
     clearable: true

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -6,6 +6,7 @@ import {
 import { SymbolizerKind } from 'geostyler-style';
 
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../../locale/en_US';
 
 const Option = Select.Option;
 
@@ -25,7 +26,7 @@ export interface KindFieldLocale {
 interface KindFieldDefaultProps {
   kind: SymbolizerKind;
   symbolizerKinds: SymbolizerKind[];
-  locale?: KindFieldLocale;
+  locale: KindFieldLocale;
 }
 
 // non default props
@@ -39,6 +40,7 @@ interface KindFieldProps extends Partial<KindFieldDefaultProps> {
 class KindField extends React.Component<KindFieldProps, {}> {
 
   public static defaultProps: KindFieldDefaultProps = {
+    locale: en_US.GsKindField,
     kind: 'Mark',
     symbolizerKinds: ['Mark', 'Fill', 'Icon', 'Line', 'Text']
   };

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -1,17 +1,14 @@
 import * as React from 'react';
 
-import {
-  InputNumber
-} from 'antd';
+import InputNumber, { InputNumberProps } from 'antd/lib/input-number';
 
 // default props
 interface OffsetFieldDefaultProps {
   label: string;
-  disabled?: boolean;
 }
 
 // non default props
-interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps> {
+interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps>, Partial<InputNumberProps> {
   onChange: ((radius: number) => void);
   offset?: number;
 }

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -6,6 +6,7 @@ import {
 import { WellKnownName } from 'geostyler-style';
 
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../../locale/en_US';
 
 const _get = require('lodash/get');
 const Option = Select.Option;
@@ -27,7 +28,7 @@ export interface WellKnownNameFieldLocale {
 interface WellKnownNameFieldDefaultProps {
   wellKnownName: WellKnownName;
   wellKnownNames: WellKnownName[];
-  locale?: WellKnownNameFieldLocale;
+  locale: WellKnownNameFieldLocale;
 }
 
 // non default props
@@ -43,6 +44,7 @@ export class WellKnownNameField extends React.Component<WellKnownNameFieldProps,
   static componentName: string = 'WellKnownNameField';
 
   public static defaultProps: WellKnownNameFieldDefaultProps = {
+    locale: en_US.GsWellKnownNameField,
     wellKnownName: 'Circle',
     wellKnownNames: ['Circle', 'Square', 'Triangle', 'Star', 'Cross', 'X',
                     'shape://backslash', 'shape://carrow', 'shape://dot',

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -16,6 +16,7 @@ const _cloneDeep = require('lodash/cloneDeep');
 const _get = require('lodash/get');
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 const Panel = Collapse.Panel;
 
@@ -28,16 +29,23 @@ export interface FillEditorLocale {
   graphicFillTypeLabel?: string;
 }
 
+interface FillEditorDefaultProps {
+  locale: FillEditorLocale;
+}
+
 // non default props
-interface FillEditorProps {
+interface FillEditorProps extends Partial<FillEditorDefaultProps> {
   symbolizer: FillSymbolizer;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
-  locale?: FillEditorLocale;
 }
 
 export class FillEditor extends React.Component<FillEditorProps, {}> {
 
   static componentName: string = 'FillEditor';
+
+  public static defaultProps: FillEditorDefaultProps = {
+    locale: en_US.GsFillEditor
+  };
 
   onSymbolizerChange = (symbolizer: Symbolizer) => {
     this.props.onSymbolizerChange(symbolizer);

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -6,18 +6,16 @@ import {
   IconSymbolizer
 } from 'geostyler-style';
 import MarkEditor from '../MarkEditor/MarkEditor';
-import IconEditor, { DefaultIconEditorProps } from '../IconEditor/IconEditor';
-import GraphicTypeField, { DefaultGraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
+import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
+import GraphicTypeField, { GraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
 
 const _get = require('lodash/get');
 
 export interface DefaultGraphicEditorProps {
   /** Label being used on TypeField */
   graphicTypeFieldLabel: string;
-  /** Default GraphicTypeFieldProps */
-  graphicTypeFieldProps?: DefaultGraphicTypeFieldProps;
   /** Default IconEditorProps */
-  iconEditorProps?: DefaultIconEditorProps;
+  iconEditorProps: Partial<IconEditorProps>;
 }
 
 // non default props
@@ -28,6 +26,8 @@ interface GraphicEditorProps extends Partial<DefaultGraphicEditorProps> {
   graphicType: GraphicType;
   /** Gets called when changing a graphic */
   onGraphicChange: ((graphic: PointSymbolizer) => void);
+  /** Default GraphicTypeFieldProps */
+  graphicTypeFieldProps?: GraphicTypeFieldProps;
 }
 
 /** GraphicEditor to select between different graphic options */

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -14,6 +14,7 @@ import RotateField from '../Field/RotateField/RotateField';
 import SizeField from '../Field/SizeField/SizeField';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface IconEditorLocale {
@@ -26,11 +27,11 @@ export interface IconEditorLocale {
 // default props
 export interface DefaultIconEditorProps {
   defaultIconSource: string;
-  locale?: IconEditorLocale;
+  locale: IconEditorLocale;
 }
 
 // non default props
-interface IconEditorProps extends Partial<DefaultIconEditorProps> {
+export interface IconEditorProps extends Partial<DefaultIconEditorProps> {
   symbolizer: IconSymbolizer;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
 }
@@ -38,6 +39,7 @@ interface IconEditorProps extends Partial<DefaultIconEditorProps> {
 class IconEditor extends React.Component<IconEditorProps, {}> {
 
   public static defaultProps: DefaultIconEditorProps = {
+    locale: en_US.GsIconEditor,
     defaultIconSource: 'img/openLayers_logo.svg'
   };
 

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -21,6 +21,7 @@ const _cloneDeep = require('lodash/cloneDeep');
 const _get = require('lodash/get');
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 const Panel = Collapse.Panel;
 
@@ -37,17 +38,24 @@ export interface LineEditorLocale {
   graphicFillTypeLabel?: string;
 }
 
+export interface LineEditorDefaultProps {
+  /** Language package */
+  locale: LineEditorLocale;
+}
+
 // non default props
-interface LineEditorProps {
+export interface LineEditorProps extends Partial<LineEditorDefaultProps> {
   /** Symbolizer */
   symbolizer: LineSymbolizer;
   /** Callback when symbolizer changes */
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
-  /** Language package */
-  locale?: LineEditorLocale;
 }
 
 export class LineEditor extends React.Component<LineEditorProps, {}> {
+
+  public static defaultProps: LineEditorDefaultProps = {
+    locale: en_US.GsLineEditor
+  };
 
   static componentName: string = 'LineEditor';
 

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -14,6 +14,7 @@ import Editor from '../Editor/Editor';
 const TabPane = Tabs.TabPane;
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface MultiEditorLocale {
@@ -23,10 +24,6 @@ export interface MultiEditorLocale {
 
 // default props
 interface DefaultMultiEditorProps {
-  onAdd: () => void;
-  onRemove: (symbolizer: Symbolizer, idx: number) => void;
-  symbolizers: Symbolizer[];
-  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
   locale: MultiEditorLocale;
 }
 
@@ -34,11 +31,19 @@ interface DefaultMultiEditorProps {
 export interface MultiEditorProps extends Partial<DefaultMultiEditorProps> {
   internalDataDef?: Data;
   editorProps?: any;
+  symbolizers: Symbolizer[];
+  onAdd?: () => void;
+  onRemove?: (symbolizer: Symbolizer, idx: number) => void;
+  onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
 }
 
 export class MultiEditor extends React.Component<MultiEditorProps> {
 
   static componentName: string = 'MultiEditor';
+
+  public static defaultProps: DefaultMultiEditorProps = {
+    locale: en_US.GsMultiEditor
+  };
 
   addSymbolizer = () => {
     const {

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -19,6 +19,7 @@ import './PropTextEditor.css';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import RotateField from '../Field/RotateField/RotateField';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface PropTextEditorLocale {
@@ -35,12 +36,15 @@ export interface PropTextEditorLocale {
   attributeComboPlaceholder?: string;
 }
 
+interface PropTextEditorDefaultProps {
+  locale: PropTextEditorLocale;
+}
+
 // non default props
-interface PropTextEditorProps {
+interface PropTextEditorProps extends Partial<PropTextEditorDefaultProps> {
   symbolizer: TextSymbolizer;
   internalDataDef?: Data;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
-  locale?: PropTextEditorLocale;
 }
 
 /**
@@ -49,6 +53,10 @@ interface PropTextEditorProps {
  * of a feature. No static text is allowed.
  */
 export class PropTextEditor extends React.Component<PropTextEditorProps, {}> {
+
+  public static defaultProps: PropTextEditorDefaultProps = {
+    locale: en_US.GsPropTextEditor
+  };
 
   static componentName: string = 'PropTextEditor';
 

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -18,6 +18,7 @@ import './TextEditor.css';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import RotateField from '../Field/RotateField/RotateField';
+import en_US from '../../../locale/en_US';
 
 // i18n
 export interface TextEditorLocale {
@@ -34,11 +35,14 @@ export interface TextEditorLocale {
   attributeComboPlaceholder?: string;
 }
 
+interface TextEditorDefaultProps {
+  locale: TextEditorLocale;
+}
+
 // non default props
-interface TextEditorProps {
+interface TextEditorProps extends Partial<TextEditorDefaultProps> {
   symbolizer: TextSymbolizer;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
-  locale?: TextEditorLocale;
 }
 
 /**
@@ -47,6 +51,10 @@ interface TextEditorProps {
  * feature properties and text without curly braces as static text.
  */
 export class TextEditor extends React.Component<TextEditorProps, {}> {
+
+  public static defaultProps: TextEditorDefaultProps = {
+    locale: en_US.GsTextEditor
+  };
 
   static componentName: string = 'TextEditor';
 

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -10,6 +10,7 @@ import OpacityField from '../Field/OpacityField/OpacityField';
 import RadiusField from '../Field/RadiusField/RadiusField';
 import WidthField from '../Field/WidthField/WidthField';
 import RotateField from '../Field/RotateField/RotateField';
+import en_US from '../../../locale/en_US';
 
 const  _cloneDeep = require('lodash/cloneDeep');
 const _get = require('lodash/get');
@@ -25,14 +26,21 @@ interface WellKnownNameEditorLocale {
   rotateLabel?: string;
 }
 
+interface WellKnownNameEditorDefaultProps {
+  locale: WellKnownNameEditorLocale;
+}
+
 // non default props
-interface WellKnownNameEditorProps {
+interface WellKnownNameEditorProps extends Partial<WellKnownNameEditorDefaultProps> {
   symbolizer: MarkSymbolizer;
   onSymbolizerChange: ((changedSymb: Symbolizer) => void);
-  locale?: WellKnownNameEditorLocale;
 }
 
 export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProps, {}> {
+
+  public static defaultProps: WellKnownNameEditorDefaultProps = {
+    locale: en_US.GsWellKnownNameEditor
+  };
 
   static componentName: string = 'WellKnownNameEditor';
 

--- a/src/Component/UploadButton/UploadButton.tsx
+++ b/src/Component/UploadButton/UploadButton.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 
 import { Upload, Button, Icon } from 'antd';
+import en_US from '../../locale/en_US';
+
+interface UploadButtonLocale {
+  upload: string;
+}
 
 // default props
 interface DefaultUploadButton {
-  label: string;
+  locale: UploadButtonLocale;
   onUpload: (uploadObject: any) => void;
 }
 
@@ -18,14 +23,14 @@ interface UploadButtonProps extends Partial<DefaultUploadButton> {
 class UploadButton extends React.Component<UploadButtonProps, {}> {
 
   public static defaultProps: DefaultUploadButton = {
-    label: 'Upload',
+    locale: en_US.GsUploadButton,
     onUpload: () => {return; }
   };
 
   render() {
     const {
       onUpload,
-      label
+      locale
     } = this.props;
 
     return (
@@ -35,7 +40,7 @@ class UploadButton extends React.Component<UploadButtonProps, {}> {
         customRequest={onUpload}
       >
         <Button>
-          <Icon type="upload" /> {label}
+          <Icon type="upload" /> {locale.upload}
         </Button>
       </Upload>
     );

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -113,6 +113,10 @@ export default {
             Text: 'Text'
         }
     },
+    GsGraphicTypeField: {
+      Mark: 'Mark',
+      Icon: 'Icon'
+    },
     GsScaleDenominator: {
         minScaleDenominatorLabelText: 'Min. Maßstabszahl',
         maxScaleDenominatorLabelText: 'Max. Maßstabszahl',
@@ -140,6 +144,9 @@ export default {
     GsMultiEditor: {
       add: 'Hinzufügen',
       remove: 'Entfernen'
+    },
+    GsUploadButton: {
+      upload: 'Upload'
     },
     ...de_DE
 };

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -26,6 +26,16 @@ export default {
         label: 'Load Data: ',
         uploadButtonLabel: 'Upload Data'
     },
+    GsWfsParserInput: {
+      requestButtonText: 'Get Data',
+      urlLabel: 'Url',
+      versionLabel: 'Version',
+      typeNameLabel: 'FeatureTypeName',
+      featureIDLabel: 'FeatureID',
+      propertyNameLabel: 'PropertyName',
+      maxFeaturesLabel: 'MaxFeatures',
+      fetchParamsLabel: 'fetchParams'
+    },
     GsCodeEditor: {
         downloadButtonLabel: 'Save as File',
         formatSelectLabel: 'Format'
@@ -106,6 +116,10 @@ export default {
             Text: 'Text'
         }
     },
+    GsGraphicTypeField: {
+      Mark: 'Mark',
+      Icon: 'Icon'
+    },
     GsScaleDenominator: {
         minScaleDenominatorLabelText: 'Min. Scale',
         maxScaleDenominatorLabelText: 'Max. Scale',
@@ -129,6 +143,9 @@ export default {
     GsMultiEditor: {
       add: 'Add',
       remove: 'Remove'
+    },
+    GsUploadButton: {
+      upload: 'Upload'
     },
     ...en_US
 };


### PR DESCRIPTION
This updates the typing of props.

- The main focus is to make all default props obligatory. This leads to adding some locales where they where missing.

Some other issues that this PR fixes:

- Props that get passed to subcomponents are now typed with `<Partial>` .
- Props that get passed to subcomponents now use all props instead of only the default props.