### PR TITLE
Introduces OutlineDasharray Field to FillEditor

### DIFF
--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -17,6 +17,7 @@ const _get = require('lodash/get');
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
+import LineDashField from '../Field/LineDashField/LineDashField';
 
 const Panel = Collapse.Panel;
 
@@ -27,6 +28,7 @@ export interface FillEditorLocale {
   outlineColorLabel?: string;
   outlineWidthLabel?: string;
   graphicFillTypeLabel?: string;
+  outlineDasharrayLabel?: string;
 }
 
 interface FillEditorDefaultProps {
@@ -59,7 +61,8 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
       opacity,
       outlineColor,
       graphicFill,
-      outlineWidth
+      outlineWidth,
+      outlineDasharray
     } = symbolizer;
 
     const {
@@ -99,6 +102,14 @@ export class FillEditor extends React.Component<FillEditorProps, {}> {
               label={locale.outlineWidthLabel}
               onChange={(value: number) => {
                 symbolizer.outlineWidth = value;
+                this.props.onSymbolizerChange(symbolizer);
+              }}
+            />
+            <LineDashField
+              dashArray={outlineDasharray}
+              label={locale.outlineDasharrayLabel}
+              onChange={(value: number[]) => {
+                symbolizer.outlineDasharray = value;
                 this.props.onSymbolizerChange(symbolizer);
               }}
             />

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -55,6 +55,7 @@ export default {
         fillColorLabel: 'Füllfarbe',
         outlineColorLabel: 'Randfarbe',
         outlineWidthLabel: 'Randbreite',
+        outlineDasharrayLabel: 'Rand-Strichmuster',
         graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -54,6 +54,7 @@ export default {
         fillColorLabel: 'Fill-Color',
         outlineColorLabel: 'Outline-Color',
         outlineWidthLabel: 'Outline-Width',
+        outlineDasharrayLabel: 'Outline-Dasharray',
         graphicFillTypeLabel: 'Graphic Fill Type'
     },
     GsIconEditor: {


### PR DESCRIPTION
This adds a `LineDashField` to configure an outline-dasharray for a `FillSymbolizer`.

![outlinedasharray](https://user-images.githubusercontent.com/1849416/47920461-61228f80-deb2-11e8-9006-560a882376c1.png)
