### PR TITLE
Fix localewrapper without locale bug

### DIFF
--- a/src/Component/LocaleWrapper/LocaleWrapper.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+const _get = require('lodash/get');
 
 export interface LocaleProps {
     locale?: object;
@@ -13,9 +14,10 @@ export const localize = <P extends {}>(Component: React.ComponentType<P & Locale
 
     render() {
       const { antLocale } = this.context;
+      const locale = _get(antLocale, 'Gs' + componentName);
       return (
         <Component
-          locale={antLocale['Gs' + componentName]}
+          locale={locale}
           {...this.props}
         />
       );

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -13,6 +13,7 @@ import './EditorWindow.css';
 import { Button } from 'antd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
 
 const _isEqual = require('lodash/isEqual');
 // i18n
@@ -22,16 +23,16 @@ export interface EditorWindowLocale {
 
 // default props
 export interface DefaultEditorWindowProps {
-  onAdd: () => void;
-  onClose: () => void;
-  onRemove: (symbolizer: Symbolizer, idx: number) => void;
-  symbolizers: Symbolizer[];
-  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
   locale: EditorWindowLocale;
 }
 
 // non default props
 export interface EditorWindowProps extends Partial<DefaultEditorWindowProps> {
+  symbolizers: Symbolizer[];
+  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
+  onAdd?: () => void;
+  onClose?: () => void;
+  onRemove?: (symbolizer: Symbolizer, idx: number) => void;
   internalDataDef?: Data;
   x?: number;
   y?: number;
@@ -45,6 +46,10 @@ interface EditorWindowState {
  * Symbolizer editorwindow UI.
  */
 export class EditorWindow extends React.Component<EditorWindowProps, EditorWindowState> {
+
+  public static defaultProps: DefaultEditorWindowProps = {
+    locale: en_US.GsEditorWindow
+  };
 
   public shouldComponentUpdate(nextProps: EditorWindowProps, nextState: EditorWindowState): boolean {
     const diffProps = !_isEqual(this.props, nextProps);

--- a/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
+++ b/src/Component/Symbolizer/EditorWindow/EditorWindow.tsx
@@ -29,7 +29,7 @@ export interface DefaultEditorWindowProps {
 // non default props
 export interface EditorWindowProps extends Partial<DefaultEditorWindowProps> {
   symbolizers: Symbolizer[];
-  onSymbolizersChange: (symbolizers: Symbolizer[]) => void;
+  onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
   onAdd?: () => void;
   onClose?: () => void;
   onRemove?: (symbolizer: Symbolizer, idx: number) => void;


### PR DESCRIPTION
GeoStyler crashed if components were being used without specifying locales. This is now fixed.
Now, if no `LocaleProvider` is specified, `locale` will be set to `undefined` and components use their fallback locales.