### PR TITLE
Remove prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lodash": "4.17.11",
     "moment": "2.22.2",
     "ol": "4.6.5",
-    "prop-types": "15.6.2",
     "react": "16.6.0",
     "react-codemirror2": "5.1.0",
     "react-color": "2.14.1",


### PR DESCRIPTION
Since we are using typescript, dependency `prop-types` is not needed. Removed it.