### PR TITLE
RuleTable enhancements

### DIFF
--- a/src/Component/RuleTable/RuleTable.css
+++ b/src/Component/RuleTable/RuleTable.css
@@ -2,8 +2,35 @@
   padding: 10px;
 }
 
+.gs-rule-table .ant-table-body td {
+  padding: 0;
+  border-bottom: 0;
+}
 
-.gs-rule-table .gs-symbolizer-renderer {
-  width: 60px;
-  height: 60px;
+.gs-rule-table .ant-table-body .ant-input,
+.gs-rule-table .ant-table-body .ant-input-number,
+.gs-rule-table .ant-table-body .gs-symbolizer-renderer {
+  border-radius: 0;
+}
+
+.gs-rule-table .ant-table-body .ant-input {
+  padding: 0 10;
+}
+
+.gs-rule-table .ant-table-body .ant-input-search .ant-input-search-button {
+  border-radius: 0;
+  display: none;
+}
+
+.gs-rule-table .ant-table-body .ant-input-search:hover .ant-input-search-button {
+  display: inherit;
+}
+
+.gs-rule-table .ant-table-body .gs-symbolizer-renderer {
+  height: 32px;
+  width: 32px;
+}
+
+.gs-rule-table .ant-table-body .scale-denominator {
+  width: 100%
 }

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -175,6 +175,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const value = minScaleDenominator ? parseFloat(minScaleDenominator) : undefined;
     return (
       <InputNumber
+        className="scale-denominator min-scale-denominator"
         value={value}
         min={0}
         formatter={val => `1:${val}`}
@@ -191,6 +192,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const value = maxScaleDenominator ? parseFloat(maxScaleDenominator) : undefined;
     return (
       <InputNumber
+        className="scale-denominator max-scale-denominator"
         value={value}
         min={0}
         formatter={val => `1:${val}`}

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -178,7 +178,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
         className="scale-denominator min-scale-denominator"
         value={value}
         min={0}
-        formatter={val => `1:${val}`}
+        formatter={val => val ? `1:${val}` : ''}
         parser={(val: string) => parseFloat(val.replace('1:', ''))}
         onChange={(newValue: number) => {
           this.setValueForRule(record.key, 'scaleDenominator.min', newValue);
@@ -195,7 +195,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
         className="scale-denominator max-scale-denominator"
         value={value}
         min={0}
-        formatter={val => `1:${val}`}
+        formatter={val => val ? `1:${val}` : ''}
         parser={(val: string) => parseFloat(val.replace('1:', ''))}
         onChange={(newValue: number) => {
           this.setValueForRule(record.key, 'scaleDenominator.max', newValue);


### PR DESCRIPTION
This makes the `RuleTable` appearance to be more compact by removing padding and decreasing the size of the `Renderer`.

It also removes the `1:` prefix for scales when the value is empty.

![localhost_3000_ 19](https://user-images.githubusercontent.com/1849416/48350015-22e15900-e686-11e8-9f3f-c98d051111a2.png)
