### PR TITLE
Filter as CQL

### DIFF
--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -30,6 +30,7 @@ import Renderer from '../Symbolizer/Renderer/Renderer';
 import FilterEditorWindow from '../Filter/FilterEditorWindow/FilterEditorWindow';
 import SymbolizerEditorWindow from '../Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow';
 import { TableProps } from 'antd/lib/table';
+import FilterUtil from '../../Util/FilterUtil';
 
 // i18n
 export interface RuleTableLocale {
@@ -137,16 +138,20 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
   }
 
   filterRenderer = (text: string, record: RuleRecord) => {
+    const cql = FilterUtil.writeAsCql(record.filter);
+
     return (
       <Input.Search
-        value={JSON.stringify(record.filter)}
+        value={cql}
         onChange={(event) => {
-          try {
-            const newFilter = JSON.parse(event.target.value);
-            this.setValueForRule(record.key, 'filter', newFilter);
-          } catch (error) {
-            // TODO Feedback
-          }
+          // TODO The CQL representation is currently not editable
+          // const value = event.target.value;
+          // try {
+          //   const newFilter = FilterUtil.readFromCql(value);
+          //   this.setValueForRule(record.key, 'filter', newFilter);
+          // } catch (error) {
+          //   // TODO Feedback
+          // }
         }}
         enterButton={(
           <Icon

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -12,7 +12,7 @@ describe('FilterUtil', () => {
 
   describe('writeAsCql', () => {
     it('writes a geostyler-style filter as an cql string', () => {
-        const cql = '(state = germany AND (population = 100000 OR population = 200000) AND (name = Schalke))';
+        const cql = 'state = germany AND (population >= 100000 OR population < 200000) AND (NOT name = Schalke)';
         const got = FilterUtil.writeAsCql(filter);
         expect(got).toEqual(cql);
     });

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -1,0 +1,21 @@
+import FilterUtil from './FilterUtil';
+import { Filter } from 'geostyler-style';
+import TestUtil from './TestUtil';
+
+describe('FilterUtil', () => {
+
+  let filter: Filter;
+
+  beforeEach(() => {
+    filter = TestUtil.getDummyGsFilter();
+  });
+
+  describe('writeAsCql', () => {
+    it('writes a geostyler-style filter as an cql string', () => {
+        const cql = '(state = germany AND (population = 100000 OR population = 200000) AND (name = Schalke))';
+        const got = FilterUtil.writeAsCql(filter);
+        expect(got).toEqual(cql);
+    });
+  });
+
+});

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -1,0 +1,68 @@
+import {
+  Filter,
+  Operator,
+  CombinationOperator,
+  NegationOpertaor
+} from 'geostyler-style';
+
+/**
+ * @class SymbolizerUtil
+ */
+class FilterUtil {
+
+  static operatorMapping = {
+    '&&': 'AND',
+    '||': 'OR',
+    '!': 'NOT'
+  };
+
+  /**
+   * Transforms a filter into a CQL string.
+   *
+   * @param {Filter} filter A geostyler-style Filter.
+   * @returns {string} A CQL string representation of the geostyler-style Filter.
+   */
+  static writeAsCql(filter: Filter): string {
+    const operator: Operator = filter[0];
+    let cql: string;
+    let isNestedFilter = false;
+
+    if (FilterUtil.operatorMapping[operator]) {
+      isNestedFilter = true;
+    }
+
+    if (isNestedFilter) {
+      const nestedOperator: CombinationOperator | NegationOpertaor = FilterUtil.operatorMapping[operator];
+      if (nestedOperator === '!') {
+        const childFilter = FilterUtil.writeAsCql(filter[1]);
+        cql = `(${nestedOperator} ${childFilter})`;
+        return cql;
+      }
+      const childFilters = [...filter];
+      childFilters.shift();
+      const childCqls = childFilters.map(FilterUtil.writeAsCql);
+      const joinedCqls = childCqls.join(` ${nestedOperator} `);
+      cql = `(${joinedCqls})`;
+      return cql;
+    } else {
+      cql = `${filter[1]} = ${filter[2]}`;
+      return cql;
+    }
+  }
+
+  // TODO Parse cqlString and create a filter
+
+  // /**
+  //  * Transforms a CQL string into a filter.
+  //  *
+  //  * @param {string} cqlString  A CQL string representation of the geostyler-style Filter.
+  //  * @returns {Filter}  A geostyler-style Filter
+  //  */
+  // static readFromCql(cqlString: string): Filter {
+  //   let filter: Filter = [];
+  //   return filter;
+  // }
+
+}
+
+export default FilterUtil;


### PR DESCRIPTION
Introduces textual CQL representation of the geostyler-style `Filter`.

For example a geostyler filter of format:
```javascript
[
      '&&',
      ['==', 'state', 'germany'],
      [
        '||',
        ['>=', 'population', 100000],
        ['<', 'population', 200000]
      ],
      [
        '!',
        ['==', 'name', 'Schalke']
      ]
    ]
```
becomes
```
'state = germany AND (population >= 100000 OR population < 200000) AND (NOT name = Schalke)'
```

This representation is currently used in the filter field of the `RecordTable`.
We should introduce backwards parsing to allow editing of the `InputField`.