### PR TITLE
Add RuleTable to Styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -32,6 +32,9 @@ module.exports = {
       name: 'Rule',
       components: 'src/Component/Rule/**/*.tsx'
     }, {
+      name: 'RuleTable',
+      components: 'src/Component/RuleTable/**/*.tsx'
+    },{
       name: 'ScaleDenominator',
       components: 'src/Component/ScaleDenominator/**/*.tsx'
     }, {


### PR DESCRIPTION
RuleTable was not included as a section in styleguide.config.js. Changed this. 