### PR TITLE
Fix performance related bugs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,11 @@
     {
       "type": "npm",
       "script": "build:dist",
-      "problemMatcher": []
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
     },
     {
       "type": "npm",

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -24,7 +24,6 @@ interface WfsParams {
 import en_US from '../../../locale/en_US';
 
 const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
 
 import './WfsParserInput.css';
 
@@ -80,12 +79,6 @@ export class WfsParserInput extends React.Component<WfsParserInputProps, WfsPars
         fetchParams: undefined
       }
     };
-  }
-
-  public shouldComponentUpdate(nextProps: WfsParserInputProps, nextState: WfsParserState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   onUrlChange = (event: any) => {

--- a/src/Component/FieldSet/FieldSet.tsx
+++ b/src/Component/FieldSet/FieldSet.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Checkbox } from 'antd';
 
-const _isEqual = require('lodash/isEqual');
-
 import './FieldSet.css';
 
 // default props
@@ -32,11 +30,6 @@ export class FieldSet extends React.Component<FieldSetProps> {
   public static defaultProps: FieldSetDefaultProps = {
     checked: true
   };
-
-  public shouldComponentUpdate(nextProps: FieldSetProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   /**
    * Toggles the state according to the checkbox check state.

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { Select, Form, Input } from 'antd';
 import { Data } from 'geostyler-data';
 const Option = Select.Option;
-const _isEqual = require('lodash/isEqual');
 
 // default props
 interface AttributeComboDefaultProps {
@@ -68,12 +67,6 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
     return {
       value: nextProps.value
     };
-  }
-
-  public shouldComponentUpdate(nextProps: AttributeComboProps, nextState: AttributeComboState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   render() {

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { Checkbox, Form } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox/Checkbox';
-const _isEqual = require('lodash/isEqual');
 
 // default props
 interface BoolFilterFieldDefaultProps {
@@ -44,12 +43,6 @@ export class BoolFilterField extends React.Component<BoolFilterFieldProps, BoolF
     return {
       value: nextProps.value
     };
-  }
-
-  public shouldComponentUpdate(nextProps: BoolFilterFieldProps, nextState: BoolFilterFieldState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   /**

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -212,7 +212,6 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
 
   constructor(props: ComparisonFilterProps) {
     super(props);
-
     const {
       filter,
       internalDataDef,
@@ -289,7 +288,7 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
   }
 
   /**
-   * Retuns the state part showing which balue UI should be rendered according to attribute type.
+   * Retuns the state part showing which value UI should be rendered according to attribute type.
    *
    * @param {string} The attribute name to get the value visalization state for
    */
@@ -364,15 +363,17 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
       attribute: isValid ? 'success' : 'error'
     };
 
-    onFilterChange(filter);
     this.setState({
       filter,
       validateStatus: validationStateNew
-    },            () => {
-        if (_isFunction(onValidationChanged)) {
-          onValidationChanged(validationStateNew);
-        }
-      });
+    }, () => {
+      if (onFilterChange) {
+        onFilterChange(filter);
+      }
+      if (_isFunction(onValidationChanged)) {
+        onValidationChanged(validationStateNew);
+      }
+    });
   }
 
   /**
@@ -381,10 +382,12 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
    * Stores the appropriate operator as member.
    */
   onOperatorChange = (newOperator: ComparisonOperator) => {
+    const {
+      onFilterChange
+    } = this.props;
     let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[0] = newOperator;
     this.setState({filter});
-    this.props.onFilterChange(filter);
 
     const isValid = this.props.validators.operator(newOperator);
     const validationStateNew: ValidationStatus = {
@@ -398,6 +401,9 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
         operator: newOperator
       },
       () => {
+        if (onFilterChange) {
+          onFilterChange(filter);
+        }
         if (_isFunction(this.props.onValidationChanged)) {
           this.props.onValidationChanged(validationStateNew);
         }
@@ -412,6 +418,9 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
    * Stores the appropriate filter value as member.
    */
   onValueChange = (newValue: string | number | boolean) => {
+    const {
+      onFilterChange
+    } = this.props;
     let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[2] = newValue;
 
@@ -430,13 +439,14 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
         valueValidationHelpString: validationRes.errorMsg
       },
       () => {
+        if (onFilterChange) {
+          onFilterChange(filter);
+        }
         if (_isFunction(this.props.onValidationChanged)) {
           this.props.onValidationChanged(validationStateNew);
         }
       }
     );
-
-    this.props.onFilterChange(filter);
   }
 
   /**

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -131,12 +131,6 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
     };
   }
 
-  public shouldComponentUpdate(nextProps: ComparisonFilterProps, nextState: ComparisonFilterState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
-  }
-
   /**
    * Default validation function for filter values.
    *

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -12,6 +12,7 @@ import {
 const _get = require('lodash/get');
 const _set = require('lodash/set');
 const _isEqual = require('lodash/isEqual');
+const _cloneDeep = require('lodash/cloneDeep');
 
 const TreeNode = Tree.TreeNode;
 
@@ -27,10 +28,26 @@ import {
 } from 'geostyler-data';
 
 import ComparisonFilter from '../ComparisonFilter/ComparisonFilter';
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+
+interface FilterTreeLocale {
+  andDrpdwnLabel: string;
+  orDrpdwnLabel: string;
+  notDrpdwnLabel: string;
+  comparisonDrpdwnLabel: string;
+  addFilterLabel: string;
+  changeFilterLabel: string;
+  removeFilterLabel: string;
+  andFilterText: string;
+  orFilterText: string;
+  notFilterText: string;
+}
 
 // default props
 export interface FilterTreeDefaultProps {
   filter: GsFilter;
+  locale: FilterTreeLocale;
 }
 // non default props
 export interface FilterTreeProps extends Partial<FilterTreeDefaultProps> {
@@ -55,8 +72,11 @@ interface FilterTreeState {
 export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState> {
 
   public static defaultProps: FilterTreeDefaultProps = {
-    filter: ['==', '', null]
+    filter: ['==', '', null],
+    locale: en_US.GsFilterTree
   };
+
+  static componentName = 'FilterTree';
 
   constructor(props: FilterTreeProps) {
     super(props);
@@ -68,6 +88,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
   public shouldComponentUpdate = (nextProps: FilterTreeProps, nextState: FilterTreeState): boolean => {
     const diffProps = !_isEqual(this.props, nextProps);
     const diffState = !_isEqual(this.state, nextState);
+    console.log(JSON.stringify(this.props.filter) + ' <--old\n' + JSON.stringify(nextProps.filter));
     return diffProps || diffState;
   }
 
@@ -79,11 +100,13 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     const {
       filter: rootFilter
     } = this.props;
-    if (filter === rootFilter) {
+    // if (filter === rootFilter) {
+    if (_isEqual(filter, rootFilter)) {
       this.props.onFilterChange(filter);
     }
 
-    let newFilter = [...rootFilter];
+    // let newFilter = [...rootFilter];
+    let newFilter = _cloneDeep(rootFilter);
     if (position === '') {
       newFilter = filter;
     } else {
@@ -100,7 +123,8 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
    */
   getNodeByFilter = (filter: GsFilter, position: string = ''): any => {
     const {
-      internalDataDef
+      internalDataDef,
+      locale
     } = this.props;
     const operator = filter[0];
 
@@ -118,24 +142,24 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
 
     const addFilterMenu = (
       <Menu onClick={({key}) => this.addFilter(position, key)}>
-        <Menu.Item key="and">And-Filter</Menu.Item>
-        <Menu.Item key="or">Or-Filter</Menu.Item>
-        <Menu.Item key="not">Not-Filter</Menu.Item>
-        <Menu.Item key="comparison">Comparison-Filter</Menu.Item>
+        <Menu.Item key="and">{locale.andDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="or">{locale.orDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="not">{locale.notDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="comparison">{locale.comparisonDrpdwnLabel}</Menu.Item>
       </Menu>
     );
 
     const changeFilterMenu = (
       <Menu onClick={({key}) => this.changeFilter(position, key)}>
-        <Menu.Item key="and">And-Filter</Menu.Item>
-        <Menu.Item key="or">Or-Filter</Menu.Item>
-        <Menu.Item key="not">Not-Filter</Menu.Item>
-        <Menu.Item key="comparison">Comparison-Filter</Menu.Item>
+        <Menu.Item key="and">{locale.andDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="or">{locale.orDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="not">{locale.notDrpdwnLabel}</Menu.Item>
+        <Menu.Item key="comparison">{locale.comparisonDrpdwnLabel}</Menu.Item>
       </Menu>
     );
 
     const addButton = (
-      <Tooltip title="Add Filter" placement="top">
+      <Tooltip title={locale.addFilterLabel} placement="top">
         <Dropdown
           trigger={['click']}
           overlay={addFilterMenu}
@@ -148,7 +172,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     );
 
     const removeButton = (
-      <Tooltip title="Remove Filter" placement="right">
+      <Tooltip title={locale.removeFilterLabel} placement="right">
         <Button
           size="small"
           onClick={() => this.removeFilter(position)}
@@ -161,7 +185,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     );
 
     const changeButton = (
-      <Tooltip title="Change Filter" placement="left">
+      <Tooltip title={locale.changeFilterLabel} placement="left">
         <Dropdown
           trigger={['click']}
           overlay={changeFilterMenu}
@@ -183,7 +207,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             isLeaf={false}
             title={
               <span className="node-title">
-                <span className="filter-text">And</span>
+                <span className="filter-text">{locale.andFilterText}</span>
                 <span className="filter-tools">
                   {changeButton}
                   {addButton}
@@ -208,7 +232,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             isLeaf={false}
             title={
               <span className="node-title">
-                <span className="filter-text">Or</span>
+                <span className="filter-text">{locale.orFilterText}</span>
                 <span className="filter-tools">
                   {changeButton}
                   {addButton}
@@ -233,7 +257,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             isLeaf={false}
             title={
               <span className="node-title">
-                <span className="filter-text">Not</span>
+                <span className="filter-text">{locale.notFilterText}</span>
                 <span className="filter-tools">
                   {changeButton}
                   {showRemoveButton ? removeButton : undefined}
@@ -283,7 +307,8 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     } = this.props;
 
     let addedFilter: GsFilter ;
-    const newFilter: GsFilter = [...filter];
+    // const newFilter: GsFilter = [...filter];
+    const newFilter: GsFilter = _cloneDeep(filter);
 
     switch (type) {
       case 'and':
@@ -323,7 +348,8 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     } = this.props;
 
     let addedFilter: GsFilter ;
-    const newFilter: GsFilter = [...filter];
+    // const newFilter: GsFilter = [...filter];
+    const newFilter: GsFilter = _cloneDeep(filter);
     const previousFilter = position === '' ? newFilter : _get(newFilter, position);
 
     switch (type) {
@@ -570,4 +596,4 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
   }
 }
 
-export default FilterTree;
+export default localize(FilterTree, FilterTree.componentName);

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -88,7 +88,6 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
   public shouldComponentUpdate = (nextProps: FilterTreeProps, nextState: FilterTreeState): boolean => {
     const diffProps = !_isEqual(this.props, nextProps);
     const diffState = !_isEqual(this.state, nextState);
-    console.log(JSON.stringify(this.props.filter) + ' <--old\n' + JSON.stringify(nextProps.filter));
     return diffProps || diffState;
   }
 

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -99,12 +99,10 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     const {
       filter: rootFilter
     } = this.props;
-    // if (filter === rootFilter) {
     if (_isEqual(filter, rootFilter)) {
       this.props.onFilterChange(filter);
     }
 
-    // let newFilter = [...rootFilter];
     let newFilter = _cloneDeep(rootFilter);
     if (position === '') {
       newFilter = filter;
@@ -347,7 +345,6 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     } = this.props;
 
     let addedFilter: GsFilter ;
-    // const newFilter: GsFilter = [...filter];
     const newFilter: GsFilter = _cloneDeep(filter);
     const previousFilter = position === '' ? newFilter : _get(newFilter, position);
 

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { InputNumber, Form } from 'antd';
 import { Data } from 'geostyler-data';
-const _isEqual = require('lodash/isEqual');
 
 // default props
 interface NumberFilterFieldDefaultProps {
@@ -56,12 +55,6 @@ export class NumberFilterField extends React.Component<NumberFilterFieldProps, N
     return {
       value: nextProps.value
     };
-  }
-
-  public shouldComponentUpdate(nextProps: NumberFilterFieldProps, nextState: NumberFilterFieldState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   /**

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -4,7 +4,6 @@ import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
 import { Data } from 'geostyler-data';
 const _indexOf = require('lodash/indexOf');
-const _isEqual = require('lodash/isEqual');
 const Option = Select.Option;
 
 // default props
@@ -81,12 +80,6 @@ export class OperatorCombo extends React.Component<OperatorComboProps, OperatorS
     return {
       value: value
     };
-  }
-
-  public shouldComponentUpdate(nextProps: OperatorComboProps, nextState: OperatorState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   render() {

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -4,7 +4,6 @@ import { Input, Form, AutoComplete } from 'antd';
 import { Data } from 'geostyler-data';
 
 const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
 import { Feature } from 'geojson';
 
 // default props
@@ -60,12 +59,6 @@ export class TextFilterField extends React.Component<TextFilterFieldProps, TextF
     return {
       value: nextProps.value
     };
-  }
-
-  public shouldComponentUpdate(nextProps: TextFilterFieldProps, nextState: TextFilterFieldState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   /**

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -16,7 +16,6 @@ import 'ol/ol.css';
 import { Data } from 'geostyler-data';
 
 const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
 
 import KindField from '../Field/KindField/KindField';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
@@ -46,12 +45,6 @@ export class Editor extends React.Component<EditorProps, EditorState> {
     this.state = {
       symbolizer: SymbolizerUtil.generateSymbolizer()
     };
-  }
-
-  public shouldComponentUpdate(nextProps: EditorProps, nextState: EditorState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   public static defaultProps: EditorDefaultProps = {

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -5,8 +5,6 @@ import {
 } from 'antd';
 const Option = Select.Option;
 
-const _isEqual = require('lodash/isEqual');
-
 // default props
 interface FontPickerDefaultProps {
   label: string;
@@ -32,11 +30,6 @@ export class FontPicker extends React.Component<FontPickerProps> {
       'Times New Roman', 'Georgia', 'Serif'
     ]
   };
-
-  public shouldComponentUpdate(nextProps: FontPickerProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   render() {
     const {

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
@@ -9,8 +9,6 @@ import {
     LineSymbolizer
 } from 'geostyler-style';
 
-const _isEqual = require('lodash/isEqual');
-
 // default props
 interface LineCapFieldDefaultProps {
   label: string;
@@ -32,11 +30,6 @@ export class LineCapField extends React.Component<LineCapFieldProps> {
     label: 'Line-Cap',
     capOptions: ['butt', 'round', 'square']
   };
-
-  public shouldComponentUpdate(nextProps: LineCapFieldProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   getCapSelectOptions = () => {
     return this.props.capOptions.map(capOpt => {

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
@@ -4,65 +4,35 @@ import {
   InputNumber, Button
 } from 'antd';
 
-const _isEqual = require('lodash/isEqual');
-
 import './LineDashField.css';
 
 // default props
 interface LineDashFieldDefaultProps {
   label: string;
+  dashArray: number[];
 }
 
 // non default props
 export interface LineDashFieldProps extends Partial<LineDashFieldDefaultProps> {
-  dashArray?: number[];
   onChange?: (dashArray: number[]) => void;
-}
-
-// state
-interface LineDashFieldState {
-  dashArray: number[];
 }
 
 /**
  * LineDashField to edit dashes for LineSymbolizers
  */
-export class LineDashField extends React.Component<LineDashFieldProps, LineDashFieldState> {
+export class LineDashField extends React.Component<LineDashFieldProps> {
 
   public static defaultProps: LineDashFieldDefaultProps = {
-    label: 'Dash Pattern'
+    label: 'Dash Pattern',
+    dashArray: []
   };
-
-  constructor(props: LineDashFieldProps) {
-    super(props);
-    this.state = {
-      dashArray: props.dashArray || []
-    };
-  }
-
-  static getDerivedStateFromProps(
-    nextProps: LineDashFieldProps,
-    prevState: LineDashFieldState): Partial<LineDashFieldState> {
-      return {
-        dashArray: nextProps.dashArray || []
-      };
-    }
-
-  public shouldComponentUpdate(nextProps: LineDashFieldProps, nextState: LineDashFieldState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
-  }
 
   render() {
     const {
       label,
-      onChange
+      onChange,
+      dashArray
     } = this.props;
-
-    const {
-      dashArray,
-    } = this.state;
 
     return (
       <div className="editor-field linedash-field">
@@ -76,10 +46,10 @@ export class LineDashField extends React.Component<LineDashFieldProps, LineDashF
             style={{ width: 55 }}
             onChange={(value: number) => {
               // replace current dash value
-              dashArray[idx] = value;
-              this.setState({dashArray});
+              let newDashArray = [...dashArray];
+              newDashArray[idx] = value;
               if (onChange) {
-                onChange(dashArray);
+                onChange(newDashArray);
               }
             }}
           />)
@@ -89,9 +59,11 @@ export class LineDashField extends React.Component<LineDashFieldProps, LineDashF
           icon="plus"
           onClick={() => {
             // add a new dash (UI)
-            dashArray.push(1);
-            this.setState({dashArray});
-            this.props.onChange(dashArray);
+            let newDashArray = [...dashArray];
+            newDashArray.push(1);
+            if (onChange) {
+              onChange(newDashArray);
+            }
           }}
         />
         <Button
@@ -99,9 +71,11 @@ export class LineDashField extends React.Component<LineDashFieldProps, LineDashF
           icon="minus"
           onClick={() => {
             // remove last dash (UI)
-            dashArray.splice(dashArray.length - 1, 1);
-            this.setState({dashArray});
-            this.props.onChange(dashArray);
+            let newDashArray = [...dashArray];
+            newDashArray.splice(newDashArray.length - 1, 1);
+            if (onChange) {
+              onChange(newDashArray);
+            }
           }}
         />
       </div>

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
@@ -9,8 +9,6 @@ import {
     LineSymbolizer
 } from 'geostyler-style';
 
-const _isEqual = require('lodash/isEqual');
-
 // default props
 interface LineJoinFieldDefaultProps {
   label: string;
@@ -32,11 +30,6 @@ export class LineJoinField extends React.Component<LineJoinFieldProps> {
     label: 'Line-Join',
     joinOptions: ['bevel', 'round', 'miter']
   };
-
-  public shouldComponentUpdate(nextProps: LineJoinFieldProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   getJoinSelectOptions = () => {
     return this.props.joinOptions.map(joinOpt => {

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -11,7 +11,6 @@ import GraphicTypeField, { GraphicTypeFieldProps } from '../Field/GraphicTypeFie
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 
 const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
 
 export interface GraphicEditorDefaultProps {
   /** Label being used on TypeField */
@@ -38,11 +37,6 @@ export class GraphicEditor extends React.Component <GraphicEditorProps> {
   public static defaultProps: GraphicEditorDefaultProps = {
     graphicTypeFieldLabel: 'Graphic-Type'
   };
-
-  public shouldComponentUpdate(nextProps: GraphicEditorProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   /**
    * Get the right Editor depending on kind of PointSymbolizer

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -10,7 +10,6 @@ import WellKnownNameField from '../Field/WellKnownNameField/WellKnownNameField';
 import WellKnownNameEditor from '../WellKnownNameEditor/WellKnownNameEditor';
 
 const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
 
 // non default props
 export interface MarkEditorProps {
@@ -40,12 +39,6 @@ export class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState
     return {
       symbolizer: nextProps.symbolizer
     };
-  }
-
-  public shouldComponentUpdate(nextProps: MarkEditorProps, nextState: MarkEditorState): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
   }
 
   onWellKnownNameChange = (wkn: WellKnownName) => {

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -47,11 +47,6 @@ export class Renderer extends React.Component<RendererProps> {
     this._mapId = _uniqueId('map_');
   }
 
-  public shouldComponentUpdate(nextProps: RendererProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
-
   public componentDidMount() {
     const {
       symbolizers

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -39,8 +39,7 @@ export interface WellKnownNameEditorProps extends Partial<WellKnownNameEditorDef
 
 export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProps> {
 
-  public shouldComponentUpdate(nextProps: WellKnownNameEditorProps, nextState: any, cont: any): boolean {
-    console.log(cont);
+  public shouldComponentUpdate(nextProps: WellKnownNameEditorProps): boolean {
     const diffProps = !_isEqual(this.props, nextProps);
     return diffProps;
   }

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -39,7 +39,8 @@ export interface WellKnownNameEditorProps extends Partial<WellKnownNameEditorDef
 
 export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProps> {
 
-  public shouldComponentUpdate(nextProps: WellKnownNameEditorProps): boolean {
+  public shouldComponentUpdate(nextProps: WellKnownNameEditorProps, nextState: any, cont: any): boolean {
+    console.log(cont);
     const diffProps = !_isEqual(this.props, nextProps);
     return diffProps;
   }

--- a/src/Component/UploadButton/UploadButton.tsx
+++ b/src/Component/UploadButton/UploadButton.tsx
@@ -11,8 +11,6 @@ interface UploadButtonLocale {
   upload: string;
 }
 
-const _isEqual = require('lodash/isEqual');
-
 // default props
 interface UploadButtonDefaultProps {
   locale: UploadButtonLocale;
@@ -27,11 +25,6 @@ export interface UploadButtonProps extends Partial<UploadButtonDefaultProps> {
  * Button to upload / import geodata file.
  */
 export class UploadButton extends React.Component<UploadButtonProps> {
-
-  public shouldComponentUpdate(nextProps: UploadButtonProps): boolean {
-    const diffProps = !_isEqual(this.props, nextProps);
-    return diffProps;
-  }
 
   public static defaultProps: UploadButtonDefaultProps = {
     locale: en_US.GsUploadButton

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -47,9 +47,7 @@ export default {
         strokeColorLabel: 'Strichfarbe',
         strokeWidthLabel: 'Strichstärke',
         strokeOpacityLabel: 'Strichdeckkraft',
-        rotateLabel: 'Drehung',
-        haloColorLabel: 'Halofarbe',
-        haloWidthLabel: 'Halobreite'
+        rotateLabel: 'Drehung'
     },
     GsFillEditor: {
         fillOpacityLabel: 'Fülldeckkraft',
@@ -84,7 +82,9 @@ export default {
         offsetXLabel: 'Versatz X',
         offsetYLabel: 'Versatz Y',
         attributeComboPlaceholder: 'Feld wählen',
-        rotateLabel: 'Drehung'
+        rotateLabel: 'Drehung',
+        haloColorLabel: 'Halofarbe',
+        haloWidthLabel: 'Halobreite'
     },
     GsPropTextEditor: {
         propFieldLabel: 'Feld',
@@ -152,6 +152,18 @@ export default {
     },
     GsUploadButton: {
       upload: 'Upload'
+    },
+    GsFilterTree: {
+        andDrpdwnLabel: 'UND-Filter',
+        orDrpdwnLabel: 'ODER-Filter',
+        notDrpdwnLabel: 'NICHT-Filter',
+        comparisonDrpdwnLabel: 'Vergleichs-Filter',
+        addFilterLabel: 'Filter hinzufügen',
+        changeFilterLabel: 'Filter ändern',
+        removeFilterLabel: 'Filter entfernen',
+        andFilterText: 'UND',
+        orFilterText: 'ODER',
+        notFilterText: 'NICHT'
     },
     GsRuleTable: {
       symbolizersColumnTitle: 'Symbolisierung',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -152,6 +152,18 @@ export default {
     GsUploadButton: {
       upload: 'Upload'
     },
+    GsFilterTree: {
+        andDrpdwnLabel: 'AND-Filter',
+        orDrpdwnLabel: 'OR-Filter',
+        notDrpdwnLabel: 'NOT-Filter',
+        comparisonDrpdwnLabel: 'Comparison-Filter',
+        addFilterLabel: 'Add Filter',
+        changeFilterLabel: 'Change Filter',
+        removeFilterLabel: 'Remove Filter',
+        andFilterText: 'AND',
+        orFilterText: 'OR',
+        notFilterText: 'NOT'
+    },
     GsRuleTable: {
       symbolizersColumnTitle: 'Symbolizers',
       nameColumnTitle: 'Name',


### PR DESCRIPTION
Some components did not update properly since our performance optimizations. Especially switching languages did not work properly, due to some parent components not having locales on their own, and thus, not updating child components. This PR fixes this.

Also added `build:dist` as default task to vscode to run it with `ctrl + shift + b` from within vscode.

Note: FilterTree is still quite slow in comparison to the other components. Relates to #505 

Closes #576