### PR TITLE
Fix loading animation

### DIFF
--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -75,7 +75,6 @@ export class DataLoader extends React.Component<DataLoaderProps, DataLoaderState
   };
 
   parseUploadData = (uploadObject: any) => {
-    uploadObject.onProgress();
     const {
       activeParser
     } = this.state;

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -75,6 +75,7 @@ export class DataLoader extends React.Component<DataLoaderProps, DataLoaderState
   };
 
   parseUploadData = (uploadObject: any) => {
+    uploadObject.onProgress();
     const {
       activeParser
     } = this.state;
@@ -90,7 +91,13 @@ export class DataLoader extends React.Component<DataLoaderProps, DataLoaderState
 
       // TODO Remove JSON.parse when type of readData is more precise
       parser.readData(JSON.parse(fileContent))
-        .then(this.props.onDataRead);
+        .then((data: GsData) => {
+          this.props.onDataRead(data);
+          uploadObject.onSuccess(null, uploadObject.file);
+        })
+        .catch((e) => {
+          uploadObject.onError(e, 'Upload failed. Invalid Data.');
+        });
     };
   }
 

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -70,7 +70,13 @@ export class StyleLoader extends React.Component<StyleLoaderProps, StyleLoaderSt
     reader.onload = () => {
       const fileContent = reader.result;
       parser.readStyle(fileContent)
-      .then(this.props.onStyleRead);
+      .then((style: GsStyle) => {
+        uploadObject.onSuccess(null, uploadObject.file);
+        this.props.onStyleRead(style);
+      })
+      .catch((e: any) => {
+        uploadObject.onError(e, 'Upload failed. Invalid Style.');
+      });
     };
   }
 


### PR DESCRIPTION
**Important:** Do not merge this PR until a new version of geostyler-geojson-parser was released (currently version 0.4.5)

Fixes data and style upload loading animation. Before, loading animation did not stop after upload. Now it does. Also handles invalid uploads and shows information on tooltip (see screenshot).

Error message for upload style: _Upload failed. Invalid Style._  
Error message for upload data: _Upload failed. Invalid Data._

![image](https://user-images.githubusercontent.com/12186477/48554942-080a2100-e8e0-11e8-8782-c53e3352fc3d.png)
