### PR TITLE
Set last bound to max value

### DIFF
--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -312,12 +312,6 @@ export class RuleGenerator extends React.Component<RuleGeneratorProps, RuleGener
                 {locale.nominal}
               </Radio.Button>
               <Radio.Button
-                value="ordinal"
-                disabled={attributeType === 'string'}
-              >
-                {locale.ordinal}
-              </Radio.Button>
-              <Radio.Button
                 value="cardinal"
                 disabled={attributeType === 'string'}
               >

--- a/src/Util/RuleGeneratorUtil.spec.ts
+++ b/src/Util/RuleGeneratorUtil.spec.ts
@@ -55,16 +55,16 @@ describe('RuleGeneratorUtil', () => {
       let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
       let numberOfRules = 3;
       let ranges = RuleGeneratorUtil.getQuantileRanges(values, numberOfRules);
-      expect(ranges).toEqual([[1, 4], [4, 7], [7, 11]]);
+      expect(ranges).toEqual([[1, 4], [4, 7], [7, 10]]);
 
       numberOfRules = 5;
       ranges = RuleGeneratorUtil.getQuantileRanges(values, numberOfRules);
-      expect(ranges).toEqual([[1, 3], [3, 5], [5, 7], [7, 9], [9, 11]]);
+      expect(ranges).toEqual([[1, 3], [3, 5], [5, 7], [7, 9], [9, 10]]);
 
       values = [1, 1, 1, 2, 2, 2, 3, 3, 3];
       numberOfRules = 3;
       ranges = RuleGeneratorUtil.getQuantileRanges(values, numberOfRules);
-      expect(ranges).toEqual([[1, 2], [2, 3], [3, 4]]);
+      expect(ranges).toEqual([[1, 2], [2, 3], [3, 3]]);
     });
   });
 

--- a/src/Util/RuleGeneratorUtil.ts
+++ b/src/Util/RuleGeneratorUtil.ts
@@ -197,8 +197,7 @@ class RuleGeneratorUtil {
         const value = sortedValues[(i * valuesPerClass)];
         bounds[i] = value;
       } else {
-        // Set last bound to max value + 1 so that it cannot exclude itself.
-        bounds[i] = sortedValues[(sortedValues.length - 1)] + 1;
+        bounds[i] = sortedValues[(sortedValues.length - 1)];
       }
     }
 


### PR DESCRIPTION
Setting last bound to max value instead of max value + 1. The generator is already implemented in a way that the last bound is included.

Also removed option`ordinal` since it has no functionality yet and only returns empty rules.