### PR TITLE
Make rule renderer configurable

### DIFF
--- a/src/Component/Rule/Rule.spec.tsx
+++ b/src/Component/Rule/Rule.spec.tsx
@@ -5,6 +5,8 @@ import en_US from '../../locale/en_US';
 import {
   Rule as GsRule
 } from 'geostyler-style';
+import { SLDRenderer } from '../Symbolizer/SLDRenderer/SLDRenderer';
+import { Renderer } from '../Symbolizer/Renderer/Renderer';
 
 describe('Rule', () => {
 
@@ -182,6 +184,24 @@ describe('Rule', () => {
       expect(wrapper.state().editorVisible).toBe(!editorVisible);
       renderer.simulate('click');
       expect(wrapper.state().editorVisible).toBe(editorVisible);
+    });
+  });
+
+  describe('renders configured: ', () => {
+    it('SLD renderer', () => {
+      wrapper.setProps({
+        rendererType: 'SLD'
+      });
+      const targetRenderer = wrapper.find(SLDRenderer);
+      expect(targetRenderer).toBeDefined();
+    });
+
+    it('OpenLayers renderer', () => {
+      wrapper.setProps({
+        rendererType: 'OpenLayers'
+      });
+      const targetRenderer = wrapper.find(Renderer);
+      expect(targetRenderer).toBeDefined();
     });
   });
 

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -27,6 +27,7 @@ const _isEqual = require('lodash/isEqual');
 
 import './Rule.css';
 import en_US from '../../locale/en_US';
+import { SLDRenderer, SLDRendererProps } from '../Symbolizer/SLDRenderer/SLDRenderer';
 
 // i18n
 export interface RuleLocale {
@@ -53,6 +54,7 @@ interface RuleDefaultProps {
   /** The data projection of example features */
   dataProjection: string;
   rendererType: 'SLD' | 'OpenLayers';
+  sldRendererProps: SLDRendererProps;
   locale: RuleLocale;
 }
 
@@ -114,7 +116,15 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       }]
     },
     dataProjection: 'EPSG:4326',
-    rendererType: 'OpenLayers'
+    rendererType: 'OpenLayers',
+    sldRendererProps: {
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle'
+      }],
+      wmsBaseUrl: '',
+      layer: ''
+    }
   };
 
   static getDerivedStateFromProps(
@@ -253,6 +263,8 @@ export class Rule extends React.Component<RuleProps, RuleState> {
   render() {
     const {
       internalDataDef,
+      rendererType,
+      sldRendererProps,
       locale
     } = this.props;
 
@@ -262,6 +274,20 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       scaleFieldChecked,
       filterFieldChecked
     } = this.state;
+
+    let featureRenderer;
+    if (rendererType === 'SLD') {
+      featureRenderer = <SLDRenderer
+        symbolizers={rule.symbolizers}
+        onClick={this.onRendererClick}
+        {...sldRendererProps}
+      />;
+    } else {
+      featureRenderer = <Renderer
+        symbolizers={rule.symbolizers}
+        onClick={this.onRendererClick}
+      />;
+    }
 
     // cast the current filter object to pass over to ComparisonFilterUi
     const cmpFilter = rule.filter as GsComparisonFilter;
@@ -280,10 +306,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
               placeholder={locale.nameFieldPlaceholder}
               {...this.props.ruleNameProps}
             />
-            <Renderer
-              symbolizers={rule.symbolizers}
-              onClick={this.onRendererClick}
-            />
+            {featureRenderer}
             {
               !editorVisible ? null :
                 <SymbolizerEditorWindow

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -19,7 +19,7 @@ import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilt
 import ScaleDenominator from '../ScaleDenominator/ScaleDenominator';
 import Fieldset from '../FieldSet/FieldSet';
 import FilterTree from '../Filter/FilterTree/FilterTree';
-import Renderer from '../Symbolizer/Renderer/Renderer';
+import Renderer, { RendererProps } from '../Symbolizer/Renderer/Renderer';
 import SymbolizerEditorWindow from '../Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow';
 
 const _cloneDeep = require('lodash/cloneDeep');
@@ -54,7 +54,8 @@ interface RuleDefaultProps {
   /** The data projection of example features */
   dataProjection: string;
   rendererType: 'SLD' | 'OpenLayers';
-  sldRendererProps: SLDRendererProps;
+  sldRendererProps?: SLDRendererProps;
+  oLRendererProps?: RendererProps;
   locale: RuleLocale;
 }
 
@@ -116,15 +117,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       }]
     },
     dataProjection: 'EPSG:4326',
-    rendererType: 'OpenLayers',
-    sldRendererProps: {
-      symbolizers: [{
-        kind: 'Mark',
-        wellKnownName: 'Circle'
-      }],
-      wmsBaseUrl: '',
-      layer: ''
-    }
+    rendererType: 'OpenLayers'
   };
 
   static getDerivedStateFromProps(
@@ -264,6 +257,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
     const {
       internalDataDef,
       rendererType,
+      oLRendererProps,
       sldRendererProps,
       locale
     } = this.props;
@@ -286,6 +280,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       featureRenderer = <Renderer
         symbolizers={rule.symbolizers}
         onClick={this.onRendererClick}
+        {...oLRendererProps}
       />;
     }
 

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -21,7 +21,7 @@ import {
   Data as GsData
 } from 'geostyler-data';
 
-import Rule from '../Rule/Rule';
+import Rule, { RuleProps } from '../Rule/Rule';
 import NameField, { NameFieldProps } from '../NameField/NameField';
 import BulkEditModals from '../Symbolizer/BulkEditModals/BulkEditModals';
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
@@ -31,6 +31,7 @@ import en_US from '../../locale/en_US';
 import SymbolizerUtil from '../../Util/SymbolizerUtil';
 import RuleTable from '../RuleTable/RuleTable';
 import RuleGeneratorWindow from '../RuleGenerator/RuleGeneratorWindow';
+import { SLDRendererProps } from '../Symbolizer/SLDRenderer/SLDRenderer';
 
 import './Style.css';
 
@@ -63,6 +64,9 @@ export interface StyleProps extends Partial<StyleDefaultProps> {
   dataProjection?: string;
   filterUiProps?: Partial<ComparisonFilterProps>;
   ruleNameProps?: Partial<NameFieldProps>;
+  ruleProps?: Partial<RuleProps>;
+  ruleRendererType?: 'SLD' | 'OpenLayers';
+  sldRendererProps?: SLDRendererProps;
 }
 
 // state
@@ -264,6 +268,8 @@ export class Style extends React.Component<StyleProps, StyleState> {
       dataProjection,
       filterUiProps,
       ruleNameProps,
+      ruleRendererType,
+      sldRendererProps,
       locale,
       data
     } = this.props;
@@ -327,6 +333,8 @@ export class Style extends React.Component<StyleProps, StyleState> {
             dataProjection={dataProjection}
             filterUiProps={filterUiProps}
             ruleNameProps={ruleNameProps}
+            rendererType={ruleRendererType}
+            sldRendererProps={sldRendererProps}
           />)
         }
         <Button.Group>

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
@@ -19,6 +19,7 @@ export interface SLDRendererProps extends Partial<SLDRendererDefaultProps> {
   symbolizers: Symbolizer[];
   wmsBaseUrl: string;
   layer: string;
+  additionalHeaders?: any;
   wmsParams?: any;
 }
 
@@ -76,7 +77,8 @@ export class SLDRenderer extends React.Component<SLDRendererProps, SLDRendererSt
    */
   setLegendGraphicUrlForRule = (symbolizers: Symbolizer[]) => {
     const {
-      requestDelay
+      requestDelay,
+      additionalHeaders
     } = this.props;
 
     this.setState({
@@ -118,7 +120,8 @@ export class SLDRenderer extends React.Component<SLDRendererProps, SLDRendererSt
           };
           HTTPUtil.post({
             url: wmsBaseUrl,
-            params: params
+            params: params,
+            additionalHeaders: additionalHeaders
           })
             .then((response: any) => {
               if (response && response.ok) {


### PR DESCRIPTION
Make rule renderer configurable in `Rule.tsx`.
In addition, additional headers for POST request in `SLDRenderer` can be passed (e.g. CSRF token)

Depends on https://github.com/terrestris/geostyler/pull/605

Please review @terrestris/devs 
