### PR TITLE
Removes duplicate entry in locale de

### DIFF
--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -127,10 +127,6 @@ export default {
             Text: 'Text'
         }
     },
-    GsGraphicTypeField: {
-      Mark: 'Mark',
-      Icon: 'Icon'
-    },
     GsScaleDenominator: {
         minScaleDenominatorLabelText: 'Min. Maßstabszahl',
         maxScaleDenominatorLabelText: 'Max. Maßstabszahl',


### PR DESCRIPTION
Title says it all.

Fixes bug in IE11 that doesn't allow duplicate entries in strict mode.