### PR TITLE
Replace ButtonGroup with FooterMenu in RuleTable

### DIFF
--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -56,6 +56,7 @@ interface RuleTableDefaultProps extends Partial<TableProps<RuleRecord>> {
 export interface RuleTableProps extends Partial<RuleTableDefaultProps> {
   data?: GsData;
   rules: GsRule[];
+  footer?: (currentPageData?: any) => React.ReactNode;
   onRulesChange?: (rules: GsRule[]) => void;
   onSelectionChange?: (selectedRowKeys: string[], selectedRows: any[]) => void;
   /** Properties that will be passed to the Comparison Filters */

--- a/src/Component/Style/Style.css
+++ b/src/Component/Style/Style.css
@@ -7,3 +7,8 @@
 .gs-namefield {
   flex: 1;
 }
+
+.gs-rule-table .ant-table-footer {
+  margin-top: 1px;
+  padding: 0;
+}

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -204,7 +204,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
     });
   }
 
-  onMultiEdit = (param: any) => {
+  onTableMenuClick = (param: any) => {
     switch (param.key) {
       case 'addRule':
         this.addRule();
@@ -283,7 +283,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
     return (
       <Menu
         mode="horizontal"
-        onClick={this.onMultiEdit}
+        onClick={this.onTableMenuClick}
         selectable={false}
         >
         <Menu.Item key="addRule">

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -206,6 +206,12 @@ export class Style extends React.Component<StyleProps, StyleState> {
 
   onMultiEdit = (param: any) => {
     switch (param.key) {
+      case 'addRule':
+        this.addRule();
+        break;
+      case 'removeRule':
+        this.removeRules();
+        break;
       case 'color':
         this.setState({colorModalVisible: true});
         break;
@@ -262,6 +268,47 @@ export class Style extends React.Component<StyleProps, StyleState> {
     this.setState({ruleGeneratorWindowVisible: false});
   }
 
+  createFooter = () => {
+    const {
+      locale
+    } = this.props;
+
+    const {
+      style,
+      selectedRowKeys
+    } = this.state;
+
+    const allowRemove = selectedRowKeys.length > 0 && selectedRowKeys.length < style.rules.length;
+
+    return (
+      <Menu
+        mode="horizontal"
+        onClick={this.onMultiEdit}
+        selectable={false}
+        >
+        <Menu.Item key="addRule">
+          <Icon type="plus" />
+            {locale.addRuleBtnText}
+        </Menu.Item>
+        <Menu.Item key="removeRule"
+          disabled={!allowRemove}
+          >
+          <Icon type="minus" />
+            {locale.removeRulesBtnText}
+        </Menu.Item>
+        <Menu.SubMenu
+          popupClassName="styler-multiedit-popup"
+          title={<span><Icon type="menu-unfold" /><span>{locale.multiEditLabel}</span></span>}
+          >
+          <Menu.Item key="color">{locale.colorLabel}</Menu.Item>
+          <Menu.Item key="size">{locale.radiusLabel}</Menu.Item>
+          <Menu.Item key="opacity">{locale.opacityLabel}</Menu.Item>
+          <Menu.Item key="symbol">{locale.symbolLabel}</Menu.Item>
+        </Menu.SubMenu>
+      </Menu>
+    );
+  }
+
   render() {
     let rules: GsRule[] = [];
 
@@ -290,8 +337,6 @@ export class Style extends React.Component<StyleProps, StyleState> {
     if (style) {
       rules = style.rules;
     }
-
-    const allowRemove = selectedRowKeys.length > 0 && selectedRowKeys.length < style.rules.length;
 
     return (
       <div className="gs-style" >
@@ -333,6 +378,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
             sldRendererProps={sldRendererProps}
             filterUiProps={filterUiProps}
             data={data}
+            footer={this.createFooter}
           />
           : rules.map((rule, idx) => <Rule
             key={'rule_' + idx}
@@ -347,52 +393,17 @@ export class Style extends React.Component<StyleProps, StyleState> {
             sldRendererProps={sldRendererProps}
           />)
         }
-        <Button.Group>
+        {
+          compact ? null :
           <Button
             style={{'marginBottom': '20px', 'marginTop': '20px'}}
             icon="plus"
             size="large"
             onClick={this.addRule}
           >
-            {locale.addRuleBtnText}
-          </Button>
-          {
-            !compact ? null :
-            <Button
-              style={{'marginBottom': '20px', 'marginTop': '20px'}}
-              icon="minus"
-              disabled={!allowRemove}
-              size="large"
-              onClick={this.removeRules}
-            >
-              {locale.removeRulesBtnText}
-            </Button>
-          }
-          {
-            !compact ? null :
-            <Menu
-              style={{
-                display: 'inline-block',
-                top: '15px',
-                position: 'absolute',
-                width: '60%'
-              }}
-              mode="vertical"
-              onClick={this.onMultiEdit}
-              selectable={false}
-            >
-              <Menu.SubMenu
-                popupClassName="styler-multiedit-popup"
-                title={<span><Icon type="menu-unfold" /><span>{locale.multiEditLabel}</span></span>}
-              >
-                <Menu.Item key="color">{locale.colorLabel}</Menu.Item>
-                <Menu.Item key="size">{locale.radiusLabel}</Menu.Item>
-                <Menu.Item key="opacity">{locale.opacityLabel}</Menu.Item>
-                <Menu.Item key="symbol">{locale.symbolLabel}</Menu.Item>
-              </Menu.SubMenu>
-            </Menu>
-          }
-        </Button.Group>
+          {locale.addRuleBtnText}
+        </Button>
+        }
         <BulkEditModals
           colorModalVisible={colorModalVisible}
           sizeModalVisible={sizeModalVisible}


### PR DESCRIPTION
Added property `footer` to RuleTable. This passes through a custom footer to antd Table. Removed ButtonGroup below RuleTable and added a Menu into the footer, instead.

![image](https://user-images.githubusercontent.com/12186477/48898826-14e1c400-ee4e-11e8-81a0-8f4eb3999ca1.png)
