### PR TITLE
Add popover to show whole filter

### DIFF
--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -9,7 +9,8 @@ import {
   Table,
   Input,
   InputNumber,
-  Icon
+  Icon,
+  Popover
 } from 'antd';
 
 import {
@@ -163,9 +164,12 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
   }
 
   filterRenderer = (text: string, record: RuleRecord) => {
+    const {
+      locale
+    } = this.props;
     const cql = FilterUtil.writeAsCql(record.filter);
-
-    return (
+    let filterCell: React.ReactNode;
+    const inputSearch = (
       <Input.Search
         value={cql}
         onChange={(event) => {
@@ -187,8 +191,19 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
           const filterPosition = event.target.getBoundingClientRect();
           this.onFilterEditClick(record.key, filterPosition);
         }}
-      />
-    );
+      />);
+    if (cql.length > 0) {
+      filterCell = (
+        <Popover
+          content={cql}
+          title={locale.filterColumnTitle}
+        >
+          {inputSearch}
+        </Popover>);
+    } else {
+      filterCell = inputSearch;
+    }
+    return filterCell;
   }
 
   onFilterEditClick = (ruleEditIndex: number, filterEditorPosition: DOMRect) => {


### PR DESCRIPTION
Adding a onHover popover to the filter column of RuleTable to show the whole filter. Text in popover can also be marked and copied. Automatically makes line breaks if content is too long for a single line.

![image](https://user-images.githubusercontent.com/12186477/49000847-26cbab80-f15b-11e8-9490-f469597f4a64.png)

![image](https://user-images.githubusercontent.com/12186477/49000926-5bd7fe00-f15b-11e8-958e-40ebde65f1c8.png)
