### PR TITLE
Restrict multi-edits in RuleTable

### DIFF
--- a/src/Component/Style/Style.spec.tsx
+++ b/src/Component/Style/Style.spec.tsx
@@ -58,4 +58,37 @@ describe('Style', () => {
     wrapper.instance().removeRule(lineStyle.rules[0]);
     expect(wrapper.state().style.rules).toHaveLength(0);
   });
+
+  it('disables the color menu item', () => {
+    let twoRules = TestUtil.getTwoRulesStyle();
+    wrapper.instance().setState({style: twoRules});
+    let disabled = wrapper.instance().disableMenu('color', [0, 1]);
+    expect(disabled).toEqual(false);
+    twoRules.rules[0].symbolizers[0].kind = 'Icon';
+    wrapper.instance().setState({style: twoRules});
+    disabled = wrapper.instance().disableMenu('color', [0, 1]);
+    expect(disabled).toEqual(true);
+  });
+
+  it('disables the size menu item', () => {
+    let twoRules = TestUtil.getTwoRulesStyle();
+    wrapper.instance().setState({style: twoRules});
+    let disabled = wrapper.instance().disableMenu('size', [0, 1]);
+    expect(disabled).toEqual(false);
+    twoRules.rules[0].symbolizers[0].kind = 'Line';
+    wrapper.instance().setState({style: twoRules});
+    disabled = wrapper.instance().disableMenu('size', [0, 1]);
+    expect(disabled).toEqual(true);
+  });
+
+  it('disables the symbol menu item', () => {
+    let twoRules = TestUtil.getTwoRulesStyle();
+    wrapper.instance().setState({style: twoRules});
+    let disabled = wrapper.instance().disableMenu('symbol', [0, 1]);
+    expect(disabled).toEqual(false);
+    twoRules.rules[0].symbolizers[0].kind = 'Line';
+    wrapper.instance().setState({style: twoRules});
+    disabled = wrapper.instance().disableMenu('symbol', [0, 1]);
+    expect(disabled).toEqual(true);
+  });
 });

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -276,6 +276,13 @@ export class Style extends React.Component<StyleProps, StyleState> {
     this.setState({ruleGeneratorWindowVisible: false});
   }
 
+  /**
+   * Checks if a specific menu item of multi-edit menu should be disabled.
+   *
+   * @param name Name of menu item
+   * @param rowKeys array of selected rowkeys
+   * @return boolean true if menu item should be disabled, otherwise false
+   */
   disableMenu = (name: string, rowKeys: number[]): boolean => {
     const {
       style

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -276,6 +276,49 @@ export class Style extends React.Component<StyleProps, StyleState> {
     this.setState({ruleGeneratorWindowVisible: false});
   }
 
+  disableMenu = (name: string, rowKeys: number[]): boolean => {
+    const {
+      style
+    } = this.state;
+    let isValid = true;
+    switch (name) {
+      case 'size':
+        rowKeys.forEach((key: number) => {
+          let symbolizers = style.rules[key].symbolizers;
+          symbolizers.forEach((symbolizer: GsSymbolizer) => {
+            let kind = symbolizer.kind;
+            if (kind === 'Fill' || kind === 'Text' || kind === 'Line') {
+              isValid = false;
+            }
+          });
+        });
+        return !isValid;
+      case 'symbol':
+        rowKeys.forEach((key: number) => {
+          let symbolizers = style.rules[key].symbolizers;
+          symbolizers.forEach((symbolizer: GsSymbolizer) => {
+            let kind = symbolizer.kind;
+            if (kind !== 'Mark') {
+              isValid = false;
+            }
+          });
+        });
+        return !isValid;
+      case 'color':
+        rowKeys.forEach((key: number) => {
+          let symbolizers = style.rules[key].symbolizers;
+          symbolizers.forEach((symbolizer: GsSymbolizer) => {
+            let kind = symbolizer.kind;
+            if (kind === 'Icon') {
+              isValid = false;
+            }
+          });
+        });
+        return !isValid;
+      default:
+        return !isValid;
+    }
+  }
   createFooter = () => {
     const {
       locale
@@ -307,11 +350,21 @@ export class Style extends React.Component<StyleProps, StyleState> {
         <Menu.SubMenu
           popupClassName="styler-multiedit-popup"
           title={<span><Icon type="menu-unfold" /><span>{locale.multiEditLabel}</span></span>}
+          disabled={selectedRowKeys.length <= 1}
           >
-          <Menu.Item key="color">{locale.colorLabel}</Menu.Item>
-          <Menu.Item key="size">{locale.radiusLabel}</Menu.Item>
+          <Menu.Item
+            key="color"
+            disabled={this.disableMenu('color', selectedRowKeys)}
+          >{locale.colorLabel}</Menu.Item>
+          <Menu.Item
+            key="size"
+            disabled={this.disableMenu('size', selectedRowKeys)}
+          >{locale.radiusLabel}</Menu.Item>
           <Menu.Item key="opacity">{locale.opacityLabel}</Menu.Item>
-          <Menu.Item key="symbol">{locale.symbolLabel}</Menu.Item>
+          <Menu.Item
+            key="symbol"
+            disabled={this.disableMenu('symbol', selectedRowKeys)}
+          >{locale.symbolLabel}</Menu.Item>
         </Menu.SubMenu>
       </Menu>
     );


### PR DESCRIPTION
The multi-edit submenu in the footer of RuleTable will now be disabled if the number of selected rows is `<=1`.

Also, only those menu items of multi-edit are enabled that kann actually be changed for all symbolizers in the current selection. E.g. if a symbolizer of kind 'Line' and a symbolizer of kind 'Mark' are selected, the `size` and `symbol` items are disabled.

![image](https://user-images.githubusercontent.com/12186477/49015497-8b9afc00-f183-11e8-935c-ec8f18f06f9d.png)


![image](https://user-images.githubusercontent.com/12186477/49015513-9786be00-f183-11e8-80eb-2cb79afc5eed.png)
