### PR TITLE
Prevent DragEvent on Filter Inputfields

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -128,6 +128,8 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
               </Select>
               :
               <Input
+                draggable={true}
+                onDragStart={(e) => e.preventDefault()}
                 value={this.state.value}
                 placeholder={placeholder}
                 style={{ width: '100%' }}

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -76,7 +76,11 @@ export class NumberFilterField extends React.Component<NumberFilterFieldProps, N
     const helpTxt = validateStatus !== 'success' ? help : null;
 
     return (
-      <div className="gs-text-filter-fld">
+      <div
+        className="gs-text-filter-fld"
+        draggable={true}
+        onDragStart={(e) => e.preventDefault()}
+      >
         <Form.Item
           label={this.props.label}
           colon={false}

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -129,6 +129,8 @@ export class TextFilterField extends React.Component<TextFilterFieldProps, TextF
           />
           :
           <Input
+            draggable={true}
+            onDragStart={(e) => e.preventDefault()}
             value={this.state.value}
             style={{ width: '100%' }}
             onChange={this.onInputChange}


### PR DESCRIPTION
Preventing drag event on input fileds. This allows the selection of text in input fields within a FilterTree component.