### PR TITLE
Use whatwg-fetch for browser builds

### DIFF
--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -5,7 +5,11 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 require("@babel/polyfill");
 
 module.exports = {
-  entry: ["@babel/polyfill", "./src/index.js"],
+  entry: [
+    "@babel/polyfill",
+    "whatwg-fetch",
+    "./src/index.js"
+  ],
   output: {
     filename: "geostyler.js",
     path: __dirname + "/browser",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "typescript": "3.1.4",
     "url-loader": "1.1.2",
     "webpack": "4.25.1",
-    "webpack-cli": "3.1.2"
+    "webpack-cli": "3.1.2",
+    "whatwg-fetch": "3.0.0"
   },
   "peerDependencies": {
     "antd": "~3.0",


### PR DESCRIPTION
Since older browsers don't support the `fetch` API, this PR introduces `whatwg-fetch` to browser-build config.

Please review