### PR TITLE
Always compare as float for > and < filters

### DIFF
--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -114,28 +114,29 @@ class FilterUtil {
    * Handle simple filters, i.e. non-nested filters.
    */
   static handleSimpleFilter = (filter: Filter, feature: any): boolean => {
-    const prop: any = _get(feature, 'properties[' + filter[1] + ']');
+    const featureValue: any = _get(feature, 'properties[' + filter[1] + ']');
+    const filterValue = filter[2];
     switch (filter[0]) {
       case '==':
-        return (('' + prop) === ('' + filter[2]));
+        return (('' + featureValue) === ('' + filterValue));
       case '*=':
-        if (prop && filter[2].length > prop.length) {
+        if (featureValue && filterValue.length > featureValue.length) {
           return false;
-        } else if (prop) {
-          return (prop.indexOf(filter[2]) !== -1);
+        } else if (featureValue) {
+          return (featureValue.indexOf(filterValue) !== -1);
         } else {
           return false;
         }
       case '!=':
-        return (('' + prop) !== ('' + filter[2]));
+        return (('' + featureValue) !== ('' + filterValue));
       case '<':
-        return (parseFloat(prop) < parseFloat(filter[2]));
+        return (parseFloat(featureValue) < parseFloat(filterValue));
       case '<=':
-        return (parseFloat(prop) <= parseFloat(filter[2]));
+        return (parseFloat(featureValue) <= parseFloat(filterValue));
       case '>':
-        return (parseFloat(prop) > parseFloat(filter[2]));
+        return (parseFloat(featureValue) > parseFloat(filterValue));
       case '>=':
-        return (parseFloat(prop) >= parseFloat(filter[2]));
+        return (parseFloat(featureValue) >= parseFloat(filterValue));
       default:
         throw new Error(`Cannot parse Filter. Unknown comparison operator.`);
     }

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -129,29 +129,13 @@ class FilterUtil {
       case '!=':
         return (prop !== filter[2]);
       case '<':
-        if (typeof prop === typeof filter[2]) {
-          return (prop < filter[2]);
-        } else {
-          return false;
-        }
+        return (parseFloat(prop) < parseFloat(filter[2]));
       case '<=':
-        if (typeof prop === typeof filter[2]) {
-          return (prop <= filter[2]);
-        } else {
-          return false;
-        }
+        return (parseFloat(prop) <= parseFloat(filter[2]));
       case '>':
-        if (typeof prop === typeof filter[2]) {
-          return (prop > filter[2]);
-        } else {
-          return false;
-        }
+        return (parseFloat(prop) > parseFloat(filter[2]));
       case '>=':
-        if (typeof prop === typeof filter[2]) {
-          return (prop >= filter[2]);
-        } else {
-          return false;
-        }
+        return (parseFloat(prop) >= parseFloat(filter[2]));
       default:
         throw new Error(`Cannot parse Filter. Unknown comparison operator.`);
     }

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -117,7 +117,7 @@ class FilterUtil {
     const prop: any = _get(feature, 'properties[' + filter[1] + ']');
     switch (filter[0]) {
       case '==':
-        return (prop === filter[2]);
+        return (('' + prop) === ('' + filter[2]));
       case '*=':
         if (prop && filter[2].length > prop.length) {
           return false;
@@ -127,7 +127,7 @@ class FilterUtil {
           return false;
         }
       case '!=':
-        return (prop !== filter[2]);
+        return (('' + prop) !== ('' + filter[2]));
       case '<':
         return (parseFloat(prop) < parseFloat(filter[2]));
       case '<=':


### PR DESCRIPTION
This fixes the comparison when the filter was parsed (at least) from SLD. In that case all literals will be stored internally as strings, thus previously all comparisons would fail.

This also forces (in-)equality comparisons as strings.

@terrestris/devs @chrismayer Do you have any thoughts on this? IMHO this approach makes the most sense:

* comparing (in-)equality will work perfectly for numbers and strings alike when done as strings
* comparing with `PropertyIsLike` filters makes only really sense in case all operands are strings anyway
* all other comparisons make only sense when using numbers (although the edge case of classifying with the beginning letter might come around some day)
