### PR TITLE
Introduce IconSelectorWindow

### DIFF
--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -21,6 +21,7 @@ import Fieldset from '../FieldSet/FieldSet';
 import FilterTree from '../Filter/FilterTree/FilterTree';
 import Renderer, { RendererProps } from '../Symbolizer/Renderer/Renderer';
 import SymbolizerEditorWindow from '../Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow';
+import { IconLibrary } from '../Symbolizer/IconSelectorWindow/IconSelectorWindow';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _isEqual = require('lodash/isEqual');
@@ -77,6 +78,7 @@ export interface RuleProps extends Partial<RuleDefaultProps> {
   filterUiProps?: Partial<ComparisonFilterProps>;
   /** Properties that will be passed to the RuleNameField */
   ruleNameProps?: Partial<NameFieldProps>;
+  iconLibraries?: IconLibrary[];
 }
 
 // state
@@ -259,7 +261,8 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       rendererType,
       oLRendererProps,
       sldRendererProps,
-      locale
+      locale,
+      iconLibraries
     } = this.props;
 
     const {
@@ -308,6 +311,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
                   onClose={this.onEditorWindowClose}
                   symbolizers={rule.symbolizers}
                   onSymbolizersChange={this.onSymbolizersChange}
+                  iconLibraries={iconLibraries}
                 />
             }
           </div>

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -21,7 +21,7 @@ import Fieldset from '../FieldSet/FieldSet';
 import FilterTree from '../Filter/FilterTree/FilterTree';
 import Renderer, { RendererProps } from '../Symbolizer/Renderer/Renderer';
 import SymbolizerEditorWindow from '../Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow';
-import { IconLibrary } from '../Symbolizer/IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _isEqual = require('lodash/isEqual');

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -36,7 +36,7 @@ import { TableProps } from 'antd/lib/table';
 import FilterUtil from '../../Util/FilterUtil';
 import { SLDRendererProps, SLDRenderer } from '../Symbolizer/SLDRenderer/SLDRenderer';
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
-import { IconLibrary } from '../Symbolizer/IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 
 // i18n
 export interface RuleTableLocale {

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -36,6 +36,7 @@ import { TableProps } from 'antd/lib/table';
 import FilterUtil from '../../Util/FilterUtil';
 import { SLDRendererProps, SLDRenderer } from '../Symbolizer/SLDRenderer/SLDRenderer';
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
+import { IconLibrary } from '../Symbolizer/IconSelectorWindow/IconSelectorWindow';
 
 // i18n
 export interface RuleTableLocale {
@@ -65,6 +66,7 @@ export interface RuleTableProps extends Partial<RuleTableDefaultProps> {
   onSelectionChange?: (selectedRowKeys: string[], selectedRows: any[]) => void;
   /** Properties that will be passed to the Comparison Filters */
   filterUiProps?: Partial<ComparisonFilterProps>;
+  iconLibraries?: IconLibrary[];
 }
 
 // state
@@ -358,6 +360,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
       rules,
       filterUiProps,
       data,
+      iconLibraries,
       ...restProps
     } = this.props;
     const {
@@ -421,6 +424,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
               internalDataDef={data}
               symbolizers={rules[ruleEditIndex].symbolizers}
               onSymbolizersChange={this.onSymbolizersChange}
+              iconLibraries={iconLibraries}
             />
         }
         {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -32,6 +32,7 @@ import SymbolizerUtil from '../../Util/SymbolizerUtil';
 import RuleTable from '../RuleTable/RuleTable';
 import RuleGeneratorWindow from '../RuleGenerator/RuleGeneratorWindow';
 import { SLDRendererProps } from '../Symbolizer/SLDRenderer/SLDRenderer';
+import { IconLibrary } from '../Symbolizer/IconSelectorWindow/IconSelectorWindow';
 
 import './Style.css';
 
@@ -68,6 +69,7 @@ export interface StyleProps extends Partial<StyleDefaultProps> {
   ruleProps?: Partial<RuleProps>;
   ruleRendererType?: 'SLD' | 'OpenLayers';
   sldRendererProps?: SLDRendererProps;
+  iconLibraries?: IconLibrary[];
 }
 
 // state
@@ -393,7 +395,8 @@ export class Style extends React.Component<StyleProps, StyleState> {
       sldRendererProps,
       enableClassification,
       locale,
-      data
+      data,
+      iconLibraries
     } = this.props;
 
     const {
@@ -451,6 +454,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
             filterUiProps={filterUiProps}
             data={data}
             footer={this.createFooter}
+            iconLibraries={iconLibraries}
           />
           : rules.map((rule, idx) => <Rule
             key={'rule_' + idx}
@@ -463,6 +467,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
             ruleNameProps={ruleNameProps}
             rendererType={ruleRendererType}
             sldRendererProps={sldRendererProps}
+            iconLibraries={iconLibraries}
           />)
         }
         {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -245,11 +245,17 @@ export class Style extends React.Component<StyleProps, StyleState> {
       return this.state.selectedRowKeys.includes(index);
     });
     selectedRules.forEach((rule: GsRule) => {
-      rule.symbolizers.forEach((sym: GsSymbolizer) => {
+      rule.symbolizers.forEach((sym: any) => {
         updates.forEach((upd: any) => {
           const property = upd.property;
           const value = upd.value;
           sym[property] = value;
+          if (property === 'kind' && value === 'Icon' && sym.wellKnownName) {
+            delete sym.wellKnownName;
+          }
+          if (property === 'kind' && value === 'Mark' && sym.image) {
+            delete sym.image;
+          }
         });
       });
     });

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.css
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.css
@@ -1,0 +1,3 @@
+.gs-bulk-edit-modals-icon-selector {
+  padding-top: 10px;
+}

--- a/src/Component/Symbolizer/Editor/Editor.css
+++ b/src/Component/Symbolizer/Editor/Editor.css
@@ -1,7 +1,6 @@
 .editor-field {
   display: flex;
   align-items: center;
-  justify-content: center;
   margin-top: 5px;
 }
 

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -20,7 +20,7 @@ const _cloneDeep = require('lodash/cloneDeep');
 import KindField from '../Field/KindField/KindField';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
-import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../IconSelector/IconSelector';
 
 // default props
 interface EditorDefaultProps {

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -20,6 +20,7 @@ const _cloneDeep = require('lodash/cloneDeep');
 import KindField from '../Field/KindField/KindField';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
 
 // default props
 interface EditorDefaultProps {
@@ -32,6 +33,7 @@ export interface EditorProps extends Partial<EditorDefaultProps> {
   internalDataDef?: Data;
   iconEditorProps?: Partial<IconEditorProps>;
   onSymbolizerChange?: (symbolizer: Symbolizer) => void;
+  iconLibraries?: IconLibrary[];
 }
 
 // state
@@ -77,6 +79,11 @@ export class Editor extends React.Component<EditorProps, EditorState> {
   }
 
   getUiFromSymbolizer = (symbolizer: Symbolizer): React.ReactNode => {
+    const {
+      iconEditorProps,
+      iconLibraries
+    } = this.props;
+
     switch (symbolizer.kind) {
       case 'Mark':
         return (
@@ -90,7 +97,8 @@ export class Editor extends React.Component<EditorProps, EditorState> {
           <IconEditor
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
-            {...this.props.iconEditorProps}
+            iconLibraries={iconLibraries}
+            {...iconEditorProps}
           />
         );
       case 'Line':

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.css
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.css
@@ -1,0 +1,3 @@
+.gs-image-field-gallery-icon {
+  cursor: pointer;
+}

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.css
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.css
@@ -1,3 +1,11 @@
 .gs-image-field-gallery-icon {
   cursor: pointer;
 }
+
+.gs-image-field > .ant-input-group-wrapper {
+  width: auto;
+}
+
+.gs-image-field-gallery-addon {
+  width: calc(200px - 37px) !important;
+}

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
 
 import {
-  Input
+  Input,
+  Icon,
+  Tooltip
 } from 'antd';
+
+import IconSelectorWindow, { IconLibrary } from '../../IconSelectorWindow/IconSelectorWindow';
+
+import './ImageField.css';
 
 // default props
 interface ImageFieldDefaultProps {
   label: string;
+  tooltipLabel: string;
   placeholder: string;
 }
 
@@ -14,39 +21,109 @@ interface ImageFieldDefaultProps {
 export interface ImageFieldProps extends Partial<ImageFieldDefaultProps> {
   value?: string;
   onChange?: (image: string) => void;
+  iconLibraries?: IconLibrary[];
+}
+
+interface ImageFieldState {
+  windowVisible: boolean;
 }
 
 /**
  * ImageField
  */
-export class ImageField extends React.PureComponent<ImageFieldProps> {
+export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldState> {
 
   public static defaultProps: ImageFieldDefaultProps = {
     label: 'Image',
+    tooltipLabel: 'Open Gallery',
     placeholder: 'URL to image'
   };
+
+  constructor(props: ImageFieldProps) {
+    super(props);
+    this.state = {
+      windowVisible: false
+    };
+  }
+
+  getIconSelectorButton = () => {
+    const {
+      tooltipLabel
+    } = this.props;
+
+    return (
+      <Tooltip title={tooltipLabel}>
+        <Icon className="gs-image-field-gallery-icon" type="picture" onClick={this.openWindow}/>
+      </Tooltip>
+    );
+  }
+
+  openWindow = () => {
+    this.setState({
+      windowVisible: true
+    });
+  }
+
+  closeWindow = () => {
+    this.setState({
+      windowVisible: false
+    });
+  }
 
   render() {
     const {
       value,
       label,
       placeholder,
-      onChange
+      onChange,
+      iconLibraries
     } = this.props;
+
+    const {
+      windowVisible
+    } = this.state;
 
     return (
       <div className="editor-field image-field">
         <span className="label">{`${label}:`}</span>
-        <Input
-          value={value}
-          placeholder={placeholder}
-          defaultValue={value}
-          onChange={(evt: any) => {
-            if (onChange) {
-              onChange(evt.target.value);
-            }
-          }}
-        />
+        {
+          iconLibraries ?
+            (<Input
+              value={value}
+              placeholder={placeholder}
+              defaultValue={value}
+              addonAfter={this.getIconSelectorButton()}
+              onChange={(evt: any) => {
+                if (onChange) {
+                  onChange(evt.target.value);
+                }
+              }}
+            />)
+          :
+            (<Input
+              value={value}
+              placeholder={placeholder}
+              defaultValue={value}
+              onChange={(evt: any) => {
+                if (onChange) {
+                  onChange(evt.target.value);
+                }
+              }}
+            />)
+        }
+        {
+          !windowVisible ? null :
+          <IconSelectorWindow
+            onClose={this.closeWindow}
+            iconLibraries={iconLibraries}
+            selectedIconSrc={value}
+            onIconSelect={(src: string) => {
+              if (onChange) {
+                onChange(src);
+              }
+            }}
+          />
+        }
       </div>
     );
   }

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -84,11 +84,12 @@ export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldS
     } = this.state;
 
     return (
-      <div className="editor-field image-field">
+      <div className="editor-field gs-image-field">
         <span className="label">{`${label}:`}</span>
         {
           iconLibraries ?
             (<Input
+              className="gs-image-field-gallery-addon"
               value={value}
               placeholder={placeholder}
               defaultValue={value}

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -6,7 +6,8 @@ import {
   Tooltip
 } from 'antd';
 
-import IconSelectorWindow, { IconLibrary } from '../../IconSelectorWindow/IconSelectorWindow';
+import IconSelectorWindow from '../../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../../IconSelector/IconSelector';
 
 import './ImageField.css';
 
@@ -86,32 +87,18 @@ export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldS
     return (
       <div className="editor-field gs-image-field">
         <span className="label">{`${label}:`}</span>
-        {
-          iconLibraries ?
-            (<Input
-              className="gs-image-field-gallery-addon"
-              value={value}
-              placeholder={placeholder}
-              defaultValue={value}
-              addonAfter={this.getIconSelectorButton()}
-              onChange={(evt: any) => {
-                if (onChange) {
-                  onChange(evt.target.value);
-                }
-              }}
-            />)
-          :
-            (<Input
-              value={value}
-              placeholder={placeholder}
-              defaultValue={value}
-              onChange={(evt: any) => {
-                if (onChange) {
-                  onChange(evt.target.value);
-                }
-              }}
-            />)
-        }
+        <Input
+          className={iconLibraries ? 'gs-image-field-gallery-addon' : undefined}
+          value={value}
+          placeholder={placeholder}
+          defaultValue={value}
+          addonAfter={iconLibraries ? this.getIconSelectorButton() : undefined}
+          onChange={(evt: any) => {
+            if (onChange) {
+              onChange(evt.target.value);
+            }
+          }}
+        />
         {
           !windowVisible ? null :
           <IconSelectorWindow

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -9,7 +9,7 @@ import MarkEditor from '../MarkEditor/MarkEditor';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import GraphicTypeField, { GraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
-import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../IconSelector/IconSelector';
 
 const _get = require('lodash/get');
 

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -9,6 +9,7 @@ import MarkEditor from '../MarkEditor/MarkEditor';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import GraphicTypeField, { GraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
 
 const _get = require('lodash/get');
 
@@ -29,6 +30,7 @@ export interface GraphicEditorProps extends Partial<GraphicEditorDefaultProps> {
   graphicTypeFieldProps?: GraphicTypeFieldProps;
   /** Default IconEditorProps */
   iconEditorProps?: Partial<IconEditorProps>;
+  iconLibraries?: IconLibrary[];
 }
 
 /** GraphicEditor to select between different graphic options */
@@ -47,7 +49,8 @@ export class GraphicEditor extends React.Component <GraphicEditorProps> {
    */
   getGraphicFields = (graphic: PointSymbolizer, iconEditorProps?: any): React.ReactNode => {
     const {
-      onGraphicChange
+      onGraphicChange,
+      iconLibraries
     } = this.props;
     if (_get(graphic, 'kind') === 'Mark') {
       let markGraphic: MarkSymbolizer = graphic as MarkSymbolizer;
@@ -62,6 +65,7 @@ export class GraphicEditor extends React.Component <GraphicEditorProps> {
         <IconEditor
           symbolizer={graphic}
           onSymbolizerChange={onGraphicChange}
+          iconLibraries={iconLibraries}
           {...iconEditorProps}
         />
       );

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -7,7 +7,7 @@ import {
 
 import OpacityField from '../Field/OpacityField/OpacityField';
 import ImageField from '../Field/ImageField/ImageField';
-import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../IconSelector/IconSelector';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _isEmpty = require('lodash/isEmpty');
@@ -24,6 +24,7 @@ export interface IconEditorLocale {
   sizeLabel?: string;
   rotateLabel?: string;
   opacityLabel?: string;
+  iconTooltipLabel?: string;
 }
 
 // default props
@@ -120,6 +121,7 @@ export class IconEditor extends React.Component<IconEditorProps> {
           value={imageSrc}
           label={locale.imageLabel}
           iconLibraries={iconLibraries}
+          tooltipLabel={locale.iconTooltipLabel}
           onChange={this.onImageSrcChange}
         />
         <SizeField

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -7,6 +7,7 @@ import {
 
 import OpacityField from '../Field/OpacityField/OpacityField';
 import ImageField from '../Field/ImageField/ImageField';
+import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _isEmpty = require('lodash/isEmpty');
@@ -34,6 +35,7 @@ export interface IconEditorDefaultProps {
 export interface IconEditorProps extends Partial<IconEditorDefaultProps> {
   symbolizer: IconSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
+  iconLibraries?: IconLibrary[];
 }
 
 export class IconEditor extends React.Component<IconEditorProps> {
@@ -99,7 +101,8 @@ export class IconEditor extends React.Component<IconEditorProps> {
     } = this.props;
 
     const {
-      symbolizer
+      symbolizer,
+      iconLibraries
     } = this.props;
 
     const {
@@ -116,6 +119,7 @@ export class IconEditor extends React.Component<IconEditorProps> {
         <ImageField
           value={imageSrc}
           label={locale.imageLabel}
+          iconLibraries={iconLibraries}
           onChange={this.onImageSrcChange}
         />
         <SizeField

--- a/src/Component/Symbolizer/IconSelector/IconSelector.css
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.css
@@ -1,0 +1,45 @@
+.gs-icon-selector-grid {
+  cursor: pointer;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.gs-icon-selector-grid:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  /* box-shadow: 1px 0px 3px 1px rgba(0, 0, 0, 0.5); */
+}
+
+.gs-icon-selector-grid-selected {
+  background-color: rgba(0, 0, 0, 0);
+  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
+}
+
+.gs-icon-selector-grid-selected:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
+}
+
+.gs-icon-selector > .gs-lib-row {
+  display: flex;
+  padding: 3px 0 3px 3px;
+}
+
+.gs-icon-selector > .gs-lib-row > .gs-label {
+  padding-right: 10px;
+  vertical-align: middle;
+  line-height: 30px;
+}
+
+.gs-icon-selector > .gs-lib-row > .gs-select {
+  flex: 1;
+}
+
+.gs-icon-selector-grid-avatar {
+  align-self: center;
+}
+
+.gs-icon-selector-grid-description {
+  text-align: center;
+  padding-top: 5px;
+}

--- a/src/Component/Symbolizer/IconSelector/IconSelector.spec.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.spec.tsx
@@ -1,23 +1,20 @@
-import { IconSelectorWindow, IconSelectorWindowProps, IconLibrary } from './IconSelectorWindow';
-// import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import { IconSelector, IconSelectorProps, IconLibrary } from './IconSelector';
 import TestUtil from '../../../Util/TestUtil';
-// import { IconSymbolizer } from 'geostyler-style';
 
-describe('IconSelectorWindow', () => {
+describe('IconSelector', () => {
 
   let wrapper: any;
   let dummyLibraries: IconLibrary[] = TestUtil.getDummyGsIconLibraries();
-  // let dummySymbolizer: IconSymbolizer = SymbolizerUtil.generateSymbolizer('Icon') as IconSymbolizer;
 
   beforeEach(() => {
-    const props: IconSelectorWindowProps = {
+    const props: IconSelectorProps = {
       iconLibraries: dummyLibraries
     };
-    wrapper = TestUtil.shallowRenderComponent(IconSelectorWindow, props);
+    wrapper = TestUtil.shallowRenderComponent(IconSelector, props);
   });
 
   it('is defined', () => {
-    expect(IconSelectorWindow).toBeDefined();
+    expect(IconSelector).toBeDefined();
   });
 
   it('renders correctly', () => {
@@ -27,7 +24,7 @@ describe('IconSelectorWindow', () => {
   describe('getSelectedIconFromSrc', () => {
     it('returns an object with undefined vals if no match was found', () => {
       const nonMatchSrc = 'not.included';
-      const match = IconSelectorWindow.getSelectedIconFromSrc(nonMatchSrc, dummyLibraries);
+      const match = IconSelector.getSelectedIconFromSrc(nonMatchSrc, dummyLibraries);
       expect(match.libIndex).toBeUndefined();
       expect(match.iconIndex).toBeUndefined();
     });
@@ -36,7 +33,7 @@ describe('IconSelectorWindow', () => {
       const expecLibIndex = 0;
       const expecIconIndex = 1;
       const matchSrc = dummyLibraries[expecLibIndex].icons[expecIconIndex].src;
-      const match = IconSelectorWindow.getSelectedIconFromSrc(matchSrc, dummyLibraries);
+      const match = IconSelector.getSelectedIconFromSrc(matchSrc, dummyLibraries);
       expect(match.libIndex).toBeCloseTo(expecLibIndex);
       expect(match.iconIndex).toBeCloseTo(expecIconIndex);
     });

--- a/src/Component/Symbolizer/IconSelector/IconSelector.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+
+import {
+  Avatar,
+  Card,
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+
+import './IconSelector.css';
+
+const _isEqual = require('lodash/isEqual');
+
+// i18n
+export interface IconSelectorLocale {
+  librarySelectLabel?: string;
+}
+
+// default props
+export interface IconSelectorDefaultProps {
+  locale: IconSelectorLocale;
+}
+
+export type IconLibrary = {
+  name: string;
+  icons: {
+    src: string;
+    caption: string;
+  }[];
+};
+
+interface IconSelectorState {
+  selectedIcon?: {libIndex: number; iconIndex: number; };
+  selectedLibIndex: number;
+}
+
+// non default props
+export interface IconSelectorProps extends Partial<IconSelectorDefaultProps> {
+  iconLibraries: IconLibrary[];
+  selectedIconSrc?: string;
+  onIconSelect?: (iconSrc: string) => void;
+}
+
+export class IconSelector extends React.Component<IconSelectorProps, IconSelectorState> {
+
+  public static defaultProps: IconSelectorDefaultProps = {
+    locale: en_US.GsIconSelector
+  };
+
+  constructor (props: IconSelectorProps) {
+    super(props);
+
+    let selection: any = {};
+    if (props.selectedIconSrc) {
+      selection = IconSelector.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
+    }
+
+    this.state = {
+      selectedLibIndex: selection.libIndex || 0
+    };
+  }
+
+  public shouldComponentUpdate(nextProps: IconSelectorProps, nextState: IconSelectorState): boolean {
+    const diffProps = !_isEqual(this.props, nextProps);
+    const diffState = !_isEqual(this.state, nextState);
+    return diffProps || diffState;
+  }
+
+  static getDerivedStateFromProps (props: IconSelectorProps, state: IconSelectorState)
+    : IconSelectorState {
+      if (props.selectedIconSrc) {
+        const selection =  IconSelector.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
+        return {
+          selectedIcon: selection,
+          selectedLibIndex: state.selectedLibIndex
+        };
+      } else {
+        return {
+          selectedLibIndex: state.selectedLibIndex
+        };
+      }
+  }
+
+  static componentName: string = 'IconSelector';
+
+  static getSelectedIconFromSrc (src: string, iconLibraries: IconLibrary[])
+    : { libIndex: number; iconIndex: number; } {
+    let libIndex: number;
+    let iconIndex: number;
+    let found: boolean = false;
+
+    for (let i = 0; i < iconLibraries.length; i++) {
+      const lib = iconLibraries[i];
+      if (found) {
+        break;
+      }
+      for (let j = 0; j < lib.icons.length; j++) {
+        const icon = lib.icons[j];
+        if (icon.src === src) {
+          libIndex = i;
+          iconIndex = j;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    return {
+      libIndex,
+      iconIndex
+    };
+  }
+
+  libChange = (value: number) => {
+    this.setState({
+      selectedLibIndex: value
+    });
+  }
+
+  getGallery = (icon: any, index: number): React.ReactNode => {
+    const {
+      selectedLibIndex,
+      selectedIcon
+    } = this.state;
+
+    const {
+      onIconSelect
+    } = this.props;
+
+    let gridClassName = 'gs-icon-selector-grid';
+    if (selectedIcon && selectedIcon.libIndex === selectedLibIndex && selectedIcon.iconIndex === index) {
+      gridClassName += ' gs-icon-selector-grid-selected';
+    }
+    return (
+      <Card.Grid
+        key={index.toString()}
+        className={gridClassName}
+        // @ts-ignore
+        onClick={() => {
+          if (onIconSelect) {
+            onIconSelect(icon.src);
+          }
+        }}
+      >
+        <Avatar
+          className="gs-icon-selector-grid-avatar"
+          size="default"
+          src={icon.src}
+          alt={icon.caption}
+          shape="square"
+          />
+        <Card.Meta
+          className="gs-icon-selector-grid-description"
+          description={icon.caption}
+        />
+      </Card.Grid>
+    );
+  }
+
+  render() {
+    const {
+      locale,
+      iconLibraries
+    } = this.props;
+
+    const {
+      selectedLibIndex
+    } = this.state;
+
+    return (
+      <div className="gs-icon-selector">
+        <div className="gs-lib-row">
+          <span className="gs-label">{`${locale.librarySelectLabel}:`}</span>
+          <Select
+            className="gs-select"
+            allowClear={false}
+            defaultValue={selectedLibIndex}
+            onChange={this.libChange}
+            >
+            {
+              iconLibraries.map((lib: IconLibrary, index: number) => {
+                return (
+                  <Option value={index} key={index.toString()}>{lib.name}</Option>
+                  );
+                })
+              }
+          </Select>
+        </div>
+        <Card className="gs-icon-selector-card">
+          {
+            iconLibraries[selectedLibIndex].icons.map((icon: any, index: number) => {
+              return this.getGallery(icon, index);
+            })
+          }
+        </Card>
+      </div>
+    );
+  }
+}
+
+export default localize(IconSelector, IconSelector.componentName);

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
@@ -25,14 +25,52 @@
 
 .gs-icon-selector-window-grid {
   cursor: pointer;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.gs-icon-selector-window-grid:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  /* box-shadow: 1px 0px 3px 1px rgba(0, 0, 0, 0.5); */
 }
 
 .gs-icon-selector-window-grid-selected {
-  background-color: rgba(0, 0, 0, 0.25);
+  background-color: rgba(0, 0, 0, 0);
+  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
+}
+
+.gs-icon-selector-window-grid-selected:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
 }
 
 .gs-icon-selector-window-body {
   overflow-y: auto;
   /* TODO proper height detection so that cards don't overflow window */
   height: calc(100% - 30px);
+}
+
+.gs-icon-selector-window-body > .gs-lib-row {
+  display: flex;
+  padding: 3px 0 3px 3px;
+}
+
+.gs-icon-selector-window-body > .gs-lib-row > .gs-label {
+  padding-right: 10px;
+  vertical-align: middle;
+  line-height: 30px;
+}
+
+.gs-icon-selector-window-body > .gs-lib-row > .gs-select {
+  flex: 1;
+}
+
+.gs-icon-selector-window-grid-avatar {
+  align-self: center;
+}
+
+.gs-icon-selector-window-grid-description {
+  text-align: center;
+  padding-top: 5px;
 }

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
@@ -1,0 +1,38 @@
+.gs-icon-selector-window {
+  background-color: white;
+  border: 3px solid grey;
+  border-radius: 3px;
+  z-index: 11;
+}
+
+.gs-icon-selector-window .header {
+  background-color: lightgrey;
+  padding: 3px;
+  display: flex;
+}
+
+.gs-icon-selector-window .header .title {
+  flex: 1;
+}
+
+.gs-icon-selector-window-header:hover {
+  cursor: grab;
+}
+
+.gs-icon-selector-window-header:active {
+  cursor: grabbing;
+}
+
+.gs-icon-selector-window-grid {
+  cursor: pointer;
+}
+
+.gs-icon-selector-window-grid-selected {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+.gs-icon-selector-window-body {
+  overflow-y: auto;
+  /* TODO proper height detection so that cards don't overflow window */
+  height: calc(100% - 30px);
+}

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.css
@@ -23,54 +23,8 @@
   cursor: grabbing;
 }
 
-.gs-icon-selector-window-grid {
-  cursor: pointer;
-  box-shadow: none;
-  display: flex;
-  flex-direction: column;
-}
-
-.gs-icon-selector-window-grid:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-  /* box-shadow: 1px 0px 3px 1px rgba(0, 0, 0, 0.5); */
-}
-
-.gs-icon-selector-window-grid-selected {
-  background-color: rgba(0, 0, 0, 0);
-  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
-}
-
-.gs-icon-selector-window-grid-selected:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0px 0px 2px 2px rgba(24, 144, 255, 0.8);
-}
-
 .gs-icon-selector-window-body {
   overflow-y: auto;
   /* TODO proper height detection so that cards don't overflow window */
   height: calc(100% - 30px);
-}
-
-.gs-icon-selector-window-body > .gs-lib-row {
-  display: flex;
-  padding: 3px 0 3px 3px;
-}
-
-.gs-icon-selector-window-body > .gs-lib-row > .gs-label {
-  padding-right: 10px;
-  vertical-align: middle;
-  line-height: 30px;
-}
-
-.gs-icon-selector-window-body > .gs-lib-row > .gs-select {
-  flex: 1;
-}
-
-.gs-icon-selector-window-grid-avatar {
-  align-self: center;
-}
-
-.gs-icon-selector-window-grid-description {
-  text-align: center;
-  padding-top: 5px;
 }

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.spec.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.spec.tsx
@@ -1,0 +1,44 @@
+import { IconSelectorWindow, IconSelectorWindowProps, IconLibrary } from './IconSelectorWindow';
+// import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import TestUtil from '../../../Util/TestUtil';
+// import { IconSymbolizer } from 'geostyler-style';
+
+describe('IconSelectorWindow', () => {
+
+  let wrapper: any;
+  let dummyLibraries: IconLibrary[] = TestUtil.getDummyGsIconLibraries();
+  // let dummySymbolizer: IconSymbolizer = SymbolizerUtil.generateSymbolizer('Icon') as IconSymbolizer;
+
+  beforeEach(() => {
+    const props: IconSelectorWindowProps = {
+      iconLibraries: dummyLibraries
+    };
+    wrapper = TestUtil.shallowRenderComponent(IconSelectorWindow, props);
+  });
+
+  it('is defined', () => {
+    expect(IconSelectorWindow).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  describe('getSelectedIconFromSrc', () => {
+    it('returns an object with undefined vals if no match was found', () => {
+      const nonMatchSrc = 'not.included';
+      const match = IconSelectorWindow.getSelectedIconFromSrc(nonMatchSrc, dummyLibraries);
+      expect(match.libIndex).toBeUndefined();
+      expect(match.iconIndex).toBeUndefined();
+    });
+
+    it('returns the index of the matching object', () => {
+      const expecLibIndex = 0;
+      const expecIconIndex = 1;
+      const matchSrc = dummyLibraries[expecLibIndex].icons[expecIconIndex].src;
+      const match = IconSelectorWindow.getSelectedIconFromSrc(matchSrc, dummyLibraries);
+      expect(match.libIndex).toBeCloseTo(expecLibIndex);
+      expect(match.iconIndex).toBeCloseTo(expecIconIndex);
+    });
+  });
+});

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -21,6 +21,7 @@ const _isEqual = require('lodash/isEqual');
 // i18n
 export interface IconSelectorWindowLocale {
   windowLabel?: string;
+  librarySelectLabel?: string;
 }
 
 // default props
@@ -155,12 +156,14 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps,
         }}
       >
         <Avatar
+          className="gs-icon-selector-window-grid-avatar"
           size="default"
           src={icon.src}
           alt={icon.caption}
           shape="square"
           />
         <Card.Meta
+          className="gs-icon-selector-window-grid-description"
           description={icon.caption}
         />
       </Card.Grid>
@@ -216,19 +219,23 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps,
             />
           </div>
           <div className="gs-icon-selector-window-body">
-            <Select
-              allowClear={false}
-              defaultValue={selectedLibIndex}
-              onChange={this.libChange}
-            >
-              {
-                iconLibraries.map((lib: IconLibrary, index: number) => {
-                  return (
-                    <Option value={index} key={index.toString()}>{lib.name}</Option>
-                  );
-                })
-              }
-            </Select>
+            <div className="gs-lib-row">
+              <span className="gs-label">{`${locale.librarySelectLabel}:`}</span>
+              <Select
+                className="gs-select"
+                allowClear={false}
+                defaultValue={selectedLibIndex}
+                onChange={this.libChange}
+                >
+                {
+                  iconLibraries.map((lib: IconLibrary, index: number) => {
+                    return (
+                      <Option value={index} key={index.toString()}>{lib.name}</Option>
+                      );
+                    })
+                  }
+              </Select>
+            </div>
             <Card className="gs-icon-selector-window-card">
               {
                 iconLibraries[selectedLibIndex].icons.map((icon: any, index: number) => {

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import {
+  Avatar,
+  Button,
+  Card,
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+import { Rnd } from 'react-rnd';
+
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+
+import './IconSelectorWindow.css';
+
+const _isEqual = require('lodash/isEqual');
+
+// i18n
+export interface IconSelectorWindowLocale {
+  windowLabel?: string;
+}
+
+// default props
+export interface IconSelectorWindowDefaultProps {
+  locale: IconSelectorWindowLocale;
+  x?: number;
+  y?: number;
+  width?: number|string;
+  height?: number|string;
+}
+
+export type IconLibrary = {
+  name: string;
+  icons: {
+    src: string;
+    caption: string;
+  }[];
+};
+
+interface IconSelectorWindowState {
+  selectedIcon?: {libIndex: number; iconIndex: number; };
+  selectedLibIndex: number;
+}
+
+// non default props
+export interface IconSelectorWindowProps extends Partial<IconSelectorWindowDefaultProps> {
+  iconLibraries: IconLibrary[];
+  selectedIconSrc?: string;
+  onIconSelect?: (iconSrc: string) => void;
+  onClose?: () => void;
+}
+
+export class IconSelectorWindow extends React.Component<IconSelectorWindowProps, IconSelectorWindowState> {
+
+  public static defaultProps: IconSelectorWindowDefaultProps = {
+    locale: en_US.GsIconSelectorWindow
+  };
+
+  constructor (props: IconSelectorWindowProps) {
+    super(props);
+
+    let selection: any = {};
+    if (props.selectedIconSrc) {
+      selection = IconSelectorWindow.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
+    }
+
+    this.state = {
+      selectedLibIndex: selection.libIndex || 0
+    };
+  }
+
+  public shouldComponentUpdate(nextProps: IconSelectorWindowProps, nextState: IconSelectorWindowState): boolean {
+    const diffProps = !_isEqual(this.props, nextProps);
+    const diffState = !_isEqual(this.state, nextState);
+    return diffProps || diffState;
+  }
+
+  static getDerivedStateFromProps (props: IconSelectorWindowProps, state: IconSelectorWindowState)
+    : IconSelectorWindowState {
+      if (props.selectedIconSrc) {
+        const selection =  IconSelectorWindow.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
+        return {
+          selectedIcon: selection,
+          selectedLibIndex: state.selectedLibIndex
+        };
+      } else {
+        return {
+          selectedLibIndex: state.selectedLibIndex
+        };
+      }
+  }
+
+  static componentName: string = 'IconSelectorWindow';
+
+  static getSelectedIconFromSrc (src: string, iconLibraries: IconLibrary[])
+    : { libIndex: number; iconIndex: number; } {
+    let libIndex: number;
+    let iconIndex: number;
+    let found: boolean = false;
+
+    for (let i = 0; i < iconLibraries.length; i++) {
+      const lib = iconLibraries[i];
+      if (found) {
+        break;
+      }
+      for (let j = 0; j < lib.icons.length; j++) {
+        const icon = lib.icons[j];
+        if (icon.src === src) {
+          libIndex = i;
+          iconIndex = j;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    return {
+      libIndex,
+      iconIndex
+    };
+  }
+
+  libChange = (value: number) => {
+    this.setState({
+      selectedLibIndex: value
+    });
+  }
+
+  getGallery = (icon: any, index: number): React.ReactNode => {
+    const {
+      selectedLibIndex,
+      selectedIcon
+    } = this.state;
+
+    const {
+      onIconSelect
+    } = this.props;
+
+    let gridClassName = 'gs-icon-selector-window-grid';
+    if (selectedIcon && selectedIcon.libIndex === selectedLibIndex && selectedIcon.iconIndex === index) {
+      gridClassName += ' gs-icon-selector-window-grid-selected';
+    }
+    return (
+      <Card.Grid
+        key={index.toString()}
+        className={gridClassName}
+        // @ts-ignore
+        onClick={() => {
+          if (onIconSelect) {
+            onIconSelect(icon.src);
+          }
+        }}
+      >
+        <Avatar
+          size="default"
+          src={icon.src}
+          alt={icon.caption}
+          shape="square"
+          />
+        <Card.Meta
+          description={icon.caption}
+        />
+      </Card.Grid>
+    );
+  }
+
+  render() {
+    const {
+      locale,
+      iconLibraries,
+      x,
+      y,
+      width,
+      height,
+      onClose
+    } = this.props;
+
+    const {
+      selectedLibIndex
+    } = this.state;
+
+    return (
+      ReactDOM.createPortal(
+        <Rnd
+          className="gs-icon-selector-window"
+          default={{
+            x: x || window.innerWidth / 2,
+            y: y || window.innerHeight / 2,
+            width: width || '50%',
+            height: height || '50%'
+          }}
+          enableResizing={{
+            bottom: false,
+            bottomLeft: false,
+            bottomRight: false,
+            left: false,
+            right: false,
+            top: false,
+            topLeft: false,
+            topRight: false
+          }}
+          bounds="window"
+          dragHandleClassName="gs-icon-selector-window-header"
+        >
+          <div className="header gs-icon-selector-window-header">
+            <span className="title">
+              {locale.windowLabel}
+            </span>
+            <Button
+              icon="close"
+              size="small"
+              onClick={onClose}
+            />
+          </div>
+          <div className="gs-icon-selector-window-body">
+            <Select
+              allowClear={false}
+              defaultValue={selectedLibIndex}
+              onChange={this.libChange}
+            >
+              {
+                iconLibraries.map((lib: IconLibrary, index: number) => {
+                  return (
+                    <Option value={index} key={index.toString()}>{lib.name}</Option>
+                  );
+                })
+              }
+            </Select>
+            <Card className="gs-icon-selector-window-card">
+              {
+                iconLibraries[selectedLibIndex].icons.map((icon: any, index: number) => {
+                  return this.getGallery(icon, index);
+                })
+              }
+            </Card>
+          </div>
+        </Rnd>,
+        document.body
+      )
+    );
+  }
+}
+
+export default localize(IconSelectorWindow, IconSelectorWindow.componentName);

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -2,18 +2,15 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import {
-  Avatar,
-  Button,
-  Card,
-  Select
+  Button
 } from 'antd';
-const Option = Select.Option;
 
 import { Rnd } from 'react-rnd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 
+import IconSelector, { IconLibrary } from '../IconSelector/IconSelector';
 import './IconSelectorWindow.css';
 
 const _isEqual = require('lodash/isEqual');
@@ -21,7 +18,6 @@ const _isEqual = require('lodash/isEqual');
 // i18n
 export interface IconSelectorWindowLocale {
   windowLabel?: string;
-  librarySelectLabel?: string;
 }
 
 // default props
@@ -33,19 +29,6 @@ export interface IconSelectorWindowDefaultProps {
   height?: number|string;
 }
 
-export type IconLibrary = {
-  name: string;
-  icons: {
-    src: string;
-    caption: string;
-  }[];
-};
-
-interface IconSelectorWindowState {
-  selectedIcon?: {libIndex: number; iconIndex: number; };
-  selectedLibIndex: number;
-}
-
 // non default props
 export interface IconSelectorWindowProps extends Partial<IconSelectorWindowDefaultProps> {
   iconLibraries: IconLibrary[];
@@ -54,121 +37,18 @@ export interface IconSelectorWindowProps extends Partial<IconSelectorWindowDefau
   onClose?: () => void;
 }
 
-export class IconSelectorWindow extends React.Component<IconSelectorWindowProps, IconSelectorWindowState> {
+export class IconSelectorWindow extends React.Component<IconSelectorWindowProps> {
 
   public static defaultProps: IconSelectorWindowDefaultProps = {
     locale: en_US.GsIconSelectorWindow
   };
 
-  constructor (props: IconSelectorWindowProps) {
-    super(props);
-
-    let selection: any = {};
-    if (props.selectedIconSrc) {
-      selection = IconSelectorWindow.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
-    }
-
-    this.state = {
-      selectedLibIndex: selection.libIndex || 0
-    };
-  }
-
-  public shouldComponentUpdate(nextProps: IconSelectorWindowProps, nextState: IconSelectorWindowState): boolean {
+  public shouldComponentUpdate(nextProps: IconSelectorWindowProps): boolean {
     const diffProps = !_isEqual(this.props, nextProps);
-    const diffState = !_isEqual(this.state, nextState);
-    return diffProps || diffState;
-  }
-
-  static getDerivedStateFromProps (props: IconSelectorWindowProps, state: IconSelectorWindowState)
-    : IconSelectorWindowState {
-      if (props.selectedIconSrc) {
-        const selection =  IconSelectorWindow.getSelectedIconFromSrc(props.selectedIconSrc, props.iconLibraries);
-        return {
-          selectedIcon: selection,
-          selectedLibIndex: state.selectedLibIndex
-        };
-      } else {
-        return {
-          selectedLibIndex: state.selectedLibIndex
-        };
-      }
+    return diffProps;
   }
 
   static componentName: string = 'IconSelectorWindow';
-
-  static getSelectedIconFromSrc (src: string, iconLibraries: IconLibrary[])
-    : { libIndex: number; iconIndex: number; } {
-    let libIndex: number;
-    let iconIndex: number;
-    let found: boolean = false;
-
-    for (let i = 0; i < iconLibraries.length; i++) {
-      const lib = iconLibraries[i];
-      if (found) {
-        break;
-      }
-      for (let j = 0; j < lib.icons.length; j++) {
-        const icon = lib.icons[j];
-        if (icon.src === src) {
-          libIndex = i;
-          iconIndex = j;
-          found = true;
-          break;
-        }
-      }
-    }
-
-    return {
-      libIndex,
-      iconIndex
-    };
-  }
-
-  libChange = (value: number) => {
-    this.setState({
-      selectedLibIndex: value
-    });
-  }
-
-  getGallery = (icon: any, index: number): React.ReactNode => {
-    const {
-      selectedLibIndex,
-      selectedIcon
-    } = this.state;
-
-    const {
-      onIconSelect
-    } = this.props;
-
-    let gridClassName = 'gs-icon-selector-window-grid';
-    if (selectedIcon && selectedIcon.libIndex === selectedLibIndex && selectedIcon.iconIndex === index) {
-      gridClassName += ' gs-icon-selector-window-grid-selected';
-    }
-    return (
-      <Card.Grid
-        key={index.toString()}
-        className={gridClassName}
-        // @ts-ignore
-        onClick={() => {
-          if (onIconSelect) {
-            onIconSelect(icon.src);
-          }
-        }}
-      >
-        <Avatar
-          className="gs-icon-selector-window-grid-avatar"
-          size="default"
-          src={icon.src}
-          alt={icon.caption}
-          shape="square"
-          />
-        <Card.Meta
-          className="gs-icon-selector-window-grid-description"
-          description={icon.caption}
-        />
-      </Card.Grid>
-    );
-  }
 
   render() {
     const {
@@ -178,12 +58,10 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps,
       y,
       width,
       height,
-      onClose
+      onClose,
+      selectedIconSrc,
+      onIconSelect
     } = this.props;
-
-    const {
-      selectedLibIndex
-    } = this.state;
 
     return (
       ReactDOM.createPortal(
@@ -219,30 +97,11 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps,
             />
           </div>
           <div className="gs-icon-selector-window-body">
-            <div className="gs-lib-row">
-              <span className="gs-label">{`${locale.librarySelectLabel}:`}</span>
-              <Select
-                className="gs-select"
-                allowClear={false}
-                defaultValue={selectedLibIndex}
-                onChange={this.libChange}
-                >
-                {
-                  iconLibraries.map((lib: IconLibrary, index: number) => {
-                    return (
-                      <Option value={index} key={index.toString()}>{lib.name}</Option>
-                      );
-                    })
-                  }
-              </Select>
-            </div>
-            <Card className="gs-icon-selector-window-card">
-              {
-                iconLibraries[selectedLibIndex].icons.map((icon: any, index: number) => {
-                  return this.getGallery(icon, index);
-                })
-              }
-            </Card>
+            <IconSelector
+              iconLibraries={iconLibraries}
+              onIconSelect={onIconSelect}
+              selectedIconSrc={selectedIconSrc}
+            />
           </div>
         </Rnd>,
         document.body

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -37,7 +37,7 @@ export interface MultiEditorProps extends Partial<MultiEditorDefaultProps> {
   editorProps?: any;
   symbolizers: Symbolizer[];
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
-  iconLibraries: IconLibrary[];
+  iconLibraries?: IconLibrary[];
 }
 
 export class MultiEditor extends React.Component<MultiEditorProps> {

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -16,6 +16,7 @@ const TabPane = Tabs.TabPane;
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
 
 const _isEqual = require('lodash/isEqual');
 
@@ -36,6 +37,7 @@ export interface MultiEditorProps extends Partial<MultiEditorDefaultProps> {
   editorProps?: any;
   symbolizers: Symbolizer[];
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
+  iconLibraries: IconLibrary[];
 }
 
 export class MultiEditor extends React.Component<MultiEditorProps> {
@@ -93,6 +95,7 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
       editorProps,
       locale,
       internalDataDef,
+      iconLibraries,
       ...passThroughProps
     } = this.props;
 
@@ -110,6 +113,7 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
                 this.onSymbolizerChange(sym, idx);
               }}
               internalDataDef={internalDataDef}
+              iconLibraries={iconLibraries}
               {...editorProps}
             />
             {symbolizers.length === 1 ? null :

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -16,7 +16,7 @@ const TabPane = Tabs.TabPane;
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
-import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../IconSelector/IconSelector';
 
 const _isEqual = require('lodash/isEqual');
 

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -6,7 +6,7 @@ import { Rnd } from 'react-rnd';
 import { Symbolizer } from 'geostyler-style';
 
 import MultiEditor from '../MultiEditor/MultiEditor';
-import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../IconSelector/IconSelector';
 
 import { Data } from 'geostyler-data';
 

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -6,6 +6,7 @@ import { Rnd } from 'react-rnd';
 import { Symbolizer } from 'geostyler-style';
 
 import MultiEditor from '../MultiEditor/MultiEditor';
+import { IconLibrary } from '../IconSelectorWindow/IconSelectorWindow';
 
 import { Data } from 'geostyler-data';
 
@@ -34,6 +35,7 @@ export interface SymbolizerEditorWindowProps extends Partial<SymbolizerEditorWin
   y?: number;
   onClose?: () => void;
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
+  iconLibraries?: IconLibrary[];
 }
 
 /**
@@ -59,7 +61,8 @@ export class SymbolizerEditorWindow extends React.Component<SymbolizerEditorWind
       symbolizers,
       onSymbolizersChange,
       locale,
-      internalDataDef
+      internalDataDef,
+      iconLibraries
     } = this.props;
 
     return (
@@ -98,6 +101,7 @@ export class SymbolizerEditorWindow extends React.Component<SymbolizerEditorWind
             internalDataDef={internalDataDef}
             symbolizers={symbolizers}
             onSymbolizersChange={onSymbolizersChange}
+            iconLibraries={iconLibraries}
           />
         </Rnd>,
         document.body

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -4,6 +4,7 @@ import { Style, Filter } from 'geostyler-style';
 import { LocaleProvider } from 'antd';
 import en_US from '../locale/en_US';
 import { Data } from 'geostyler-data';
+import { IconLibrary } from '../Component/Symbolizer/IconSelectorWindow/IconSelectorWindow';
 
 /**
  * A set of some useful static helper methods.
@@ -87,6 +88,30 @@ export class TestUtil {
         }]
       }
     };
+  }
+
+  static getDummyGsIconLibraries  = (): IconLibrary[] => {
+    return ([
+      {
+        name: 'lib 1',
+        icons: [
+          {
+            src: 'foo.bar/image.png',
+            caption: 'foobar'
+          },
+          {
+            src: 'heinz.de/erhardt.jpg',
+            caption: 'Heinz'
+          }
+        ]
+      }, {
+        name: 'lib 2',
+        icons: [{
+          src: 'walter.com/frosch.jpg',
+          caption: 'Walter'
+        }]
+      }
+    ]);
   }
 
   static getDummyGsFilter = (): Filter  => {

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -4,7 +4,7 @@ import { Style, Filter } from 'geostyler-style';
 import { LocaleProvider } from 'antd';
 import en_US from '../locale/en_US';
 import { Data } from 'geostyler-data';
-import { IconLibrary } from '../Component/Symbolizer/IconSelectorWindow/IconSelectorWindow';
+import { IconLibrary } from '../Component/Symbolizer/IconSelector/IconSelector';
 
 /**
  * A set of some useful static helper methods.

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import FontPicker from './Component/Symbolizer/Field/FontPicker/FontPicker';
 import GraphicEditor from './Component/Symbolizer/GraphicEditor/GraphicEditor';
 import GraphicTypeField from './Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
+import IconSelector from './Component/Symbolizer/IconSelector/IconSelector';
 import IconSelectorWindow from './Component/Symbolizer/IconSelectorWindow/IconSelectorWindow';
 import ImageField from './Component/Symbolizer/Field/ImageField/ImageField';
 import KindField from './Component/Symbolizer/Field/KindField/KindField';
@@ -79,6 +80,7 @@ export {
   GraphicEditor,
   GraphicTypeField,
   IconEditor,
+  IconSelector,
   IconSelectorWindow,
   ImageField,
   KindField,

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import FontPicker from './Component/Symbolizer/Field/FontPicker/FontPicker';
 import GraphicEditor from './Component/Symbolizer/GraphicEditor/GraphicEditor';
 import GraphicTypeField from './Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField';
 import IconEditor from './Component/Symbolizer/IconEditor/IconEditor';
+import IconSelectorWindow from './Component/Symbolizer/IconSelectorWindow/IconSelectorWindow';
 import ImageField from './Component/Symbolizer/Field/ImageField/ImageField';
 import KindField from './Component/Symbolizer/Field/KindField/KindField';
 import LineCapField from './Component/Symbolizer/Field/LineCapField/LineCapField';
@@ -78,6 +79,7 @@ export {
   GraphicEditor,
   GraphicTypeField,
   IconEditor,
+  IconSelectorWindow,
   ImageField,
   KindField,
   LineCapField,

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -205,7 +205,8 @@ export default {
       ruleGenerator: 'Klassifizierung'
     },
     GsIconSelectorWindow: {
-        windowLabel: 'Wähle Icon'
+        windowLabel: 'Wähle Icon',
+        librarySelectLabel: 'Wähle Bibliothek'
     },
     ...de_DE
 };

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -204,5 +204,8 @@ export default {
     GsRuleGeneratorWindow: {
       ruleGenerator: 'Klassifizierung'
     },
+    GsIconSelectorWindow: {
+        windowLabel: 'Wähle Icon'
+    },
     ...de_DE
 };

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -10,7 +10,9 @@ export default {
         colorLabel: 'Farbe wählen',
         radiusLabel: 'Radius festlegen',
         opacityLabel: 'Deckkraft festlegen',
-        symbolLabel: 'Symbol wählen'
+        symbolLabel: 'Symbol wählen',
+        imageFieldLabel: 'Quelle',
+        imageFieldTooltipLabel: 'Öffne Galerie'
     },
     GsRule: {
         removeRuleBtnText: 'Regel entfernen',
@@ -73,7 +75,8 @@ export default {
         imageLabel: 'Quelle',
         sizeLabel: 'Größe',
         rotateLabel: 'Drehung',
-        opacityLabel: 'Deckkraft'
+        opacityLabel: 'Deckkraft',
+        iconTooltipLabel: 'Öffne Galerie'
     },
     GsLineEditor: {
         colorLabel: 'Farbe',
@@ -205,7 +208,9 @@ export default {
       ruleGenerator: 'Klassifizierung'
     },
     GsIconSelectorWindow: {
-        windowLabel: 'Wähle Icon',
+        windowLabel: 'Wähle Icon'
+    },
+    GsIconSelector: {
         librarySelectLabel: 'Wähle Bibliothek'
     },
     ...de_DE

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -10,7 +10,9 @@ export default {
         colorLabel: 'Select color',
         radiusLabel: 'Select radius',
         opacityLabel: 'Select opacity',
-        symbolLabel: 'Select symbol'
+        symbolLabel: 'Select symbol',
+        imageFieldLabel: 'Source',
+        imageFieldTooltipLabel: 'Open Gallery'
     },
     GsRule: {
         removeRuleBtnText: 'Remove Rule',
@@ -74,7 +76,8 @@ export default {
         imageLabel: 'Source',
         sizeLabel: 'Size',
         rotateLabel: 'Rotation',
-        opacityLabel: 'Opacity'
+        opacityLabel: 'Opacity',
+        iconTooltipLabel: 'Open Gallery'
     },
     GsLineEditor: {
         colorLabel: 'Color',
@@ -208,7 +211,9 @@ export default {
       ruleGenerator: 'Classification'
     },
     GsIconSelectorWindow: {
-        windowLabel: 'Select Icon',
+        windowLabel: 'Select Icon'
+    },
+    GsIconSelector: {
         librarySelectLabel: 'Select Library'
     },
     ...en_US

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -208,7 +208,8 @@ export default {
       ruleGenerator: 'Classification'
     },
     GsIconSelectorWindow: {
-        windowLabel: 'Select Icon'
+        windowLabel: 'Select Icon',
+        librarySelectLabel: 'Select Library'
     },
     ...en_US
 };

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -207,5 +207,8 @@ export default {
     GsRuleGeneratorWindow: {
       ruleGenerator: 'Classification'
     },
+    GsIconSelectorWindow: {
+        windowLabel: 'Select Icon'
+    },
     ...en_US
 };


### PR DESCRIPTION
Introduces `IconSelectorWindow` and `IconSelector`. Allows selecting icons from multiple libraries. Libraries can be set through `iconLibraries` prop on every relevant component (e.g. `Style`, `IconEditor`, etc.). Type definition of IconLibrary can be found in *src/Components/.../IconSelector.tsx* and looks as follows:

```js
export type IconLibrary = {
  name: string;
  icons: {
    src: string;
    caption: string;
  }[];
};
```

Example:
```js
var library = [{
    name: 'lib 1',
    icons: [{
      src: 'https://upload.wikimedia.org/.../128px-Parking_icon.svg.png',
      caption: 'first image'
    }, {
      src: 'https://upload.wikimedia.org/.../128px-Parking_icon2.svg.png',
      caption: 'second image'
    }]
  }, {
    name: 'lib 2',
    icons: [{
      src: 'https://upload.wikimedia.org/.../128px-Parking_icon3.svg.png',
      caption: 'first image second library'
    }]
  }];
```

`IconSelectorWindow` was integrated into `ImageField`. If property `iconLibraries` is undefined, `ImageField` behaves as before. If property `iconLibraries` is defined, a Button behind the input field appears that opens the `IconSelectorWindow`.

The selected Icon will be highlighted with a blue border. Hovering over an Icon sets the background color greyish.

**Update:** Added Image Source to BulkEditModals and included IconSelector (see last image).

![image](https://user-images.githubusercontent.com/12186477/49223187-55a58400-f3de-11e8-94e1-09ad975e4253.png)

![image](https://user-images.githubusercontent.com/12186477/49223312-b6cd5780-f3de-11e8-9702-73ad2595da21.png)

![image](https://user-images.githubusercontent.com/12186477/49229062-031f9400-f3ed-11e8-9a34-65fc686f4d91.png)
