### PR TITLE
Deactivate duplicates column

### DIFF
--- a/src/Component/RuleTable/RuleTable.css
+++ b/src/Component/RuleTable/RuleTable.css
@@ -13,10 +13,6 @@
   border-radius: 0;
 }
 
-.gs-rule-table .ant-table-body .ant-input {
-  padding: 0 10;
-}
-
 .gs-rule-table .ant-table-body .ant-input-search .ant-input-search-button {
   border-radius: 0;
   display: none;
@@ -28,7 +24,7 @@
 
 .gs-rule-table .ant-table-body .gs-symbolizer-renderer {
   height: 32px;
-  width: 32px;
+  width: 48px;
 }
 
 .gs-rule-table .ant-table-body .gs-symbolizer-sldrenderer,

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -396,14 +396,18 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
             title: (<Tooltip title={locale.amountColumnTitle}>Σ</Tooltip>),
             dataIndex: 'amount',
             render: this.amountRenderer
-          }, {
-            title: (
-              <Tooltip title={locale.duplicatesColumnTitle}>
-                <Icon type="block" />
-              </Tooltip>),
-            dataIndex: 'duplicates',
-            render: this.duplicatesRenderer
-          }]}
+          }
+          // TODO This breaks the app (due to performance). Reactivate when
+          // FilterUtil.getNumberOfDuplicates is optimised.
+          // , {
+          //   title: (
+          //     <Tooltip title={locale.duplicatesColumnTitle}>
+          //       <Icon type="block" />
+          //     </Tooltip>),
+          //   dataIndex: 'duplicates',
+          //   render: this.duplicatesRenderer
+          // }
+        ]}
           dataSource={this.getRuleRecords()}
           pagination={false}
           {...restProps}

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -373,7 +373,10 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
         <Table
           className="gs-rule-table"
           columns={[{
-            title: locale.symbolizersColumnTitle,
+            title: (
+              <Tooltip title={locale.symbolizersColumnTitle}>
+                <Icon type="bg-colors" />
+              </Tooltip>),
             dataIndex: 'symbolizers',
             render: this.symbolizerRenderer
           }, {

--- a/src/Component/Symbolizer/Renderer/Renderer.css
+++ b/src/Component/Symbolizer/Renderer/Renderer.css
@@ -3,5 +3,6 @@
   border: 1px solid lightgrey;
   border-radius: 4px;
   background-color: white;
+  cursor: pointer;
 }
 

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.css
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.css
@@ -1,8 +1,6 @@
 .gs-symbolizer-sldrenderer {
   position: relative;
   border: 1px solid lightgrey;
-  border-radius: 4px;
   background-color: white;
   cursor: pointer;
 }
-


### PR DESCRIPTION
This deactivates the `duplicates` column in the `RuleTable` as the calculation is currently very inperformant and this is likely to crash the browser.

There are still some further performance issues regarding the `RuleTable` but this one was causing the biggest problems.