### PR TITLE
Adds "Copy to Clipboard" to CodeEditor

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.css
+++ b/src/Component/CodeEditor/CodeEditor.css
@@ -22,13 +22,17 @@
   background-color: lightgray;
 }
 
-.gs-code-editor-toolbar {
+.gs-code-editor-toolbar,
+.gs-code-editor-bottombar {
   width: 100%;
-  padding: 5px;
+  padding: 5px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.gs-code-editor-download-button {
-  width: 150px;
-  margin-top: 10px;
+.gs-code-editor-download-button,
+.gs-code-editor-copy-button {
+  margin: 0 5px;
 }
 

--- a/src/locale/de_DE.js
+++ b/src/locale/de_DE.js
@@ -52,7 +52,9 @@ export default {
     },
     GsCodeEditor: {
         downloadButtonLabel: 'Als Datei speichern',
-        formatSelectLabel: 'Format'
+        copyButtonLabel: 'In Zwischenablage kopieren',
+        formatSelectLabel: 'Format',
+        styleCopied: 'Style in Zwischenablage kopiert!'
     },
     GsWellKnownNameEditor: {
         radiusLabel: 'Radius',

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -53,7 +53,9 @@ export default {
     },
     GsCodeEditor: {
         downloadButtonLabel: 'Save as File',
-        formatSelectLabel: 'Format'
+        copyButtonLabel: 'Copy to Clipboard',
+        formatSelectLabel: 'Format',
+        styleCopied: 'Style copied to clipboard!'
     },
     GsWellKnownNameEditor: {
         radiusLabel: 'Radius',


### PR DESCRIPTION
This adds a "Copy to Clipboard" Button to the `CodeEditor` component coming with a `showCopyButton` property.

`showSaveButton` and `showCopyButton` props are now set to `false` per default.

![localhost_3000_ 24](https://user-images.githubusercontent.com/1849416/49289919-a3d18a80-f4a5-11e8-9ddb-2a8a40737e9b.png)

This also changes the fileending for saved `SLD` files from `[Style.name].xml` to `[Style.name].sld`