### PR TITLE
Improves performance of duplicates detection

### DIFF
--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -60,4 +60,32 @@ describe('RuleTable', () => {
     });
   });
 
+  describe('calculateCountAndDuplicates', () => {
+    it('returns the right number of duplicates', () => {
+      let dummyData = TestUtil.getComplexGsDummyData();
+      let filter2 = TestUtil.getDummyGsFilter();
+
+      dummyData.exampleFeatures.features[0].properties.state = 'germany';
+      dummyData.exampleFeatures.features[0].properties.population = 150000;
+      dummyData.exampleFeatures.features[0].properties.name = 'NotSchalke';
+
+      const rules: Rule[] = [{
+        name: 'rule1',
+        symbolizers: [],
+        filter: []
+      }, {
+        name: 'rule2',
+        symbolizers: [],
+        filter: filter2
+      }];
+
+      const result = RuleTable.calculateCountAndDuplicates(rules, dummyData);
+
+      expect(result.counts[0]).toBeCloseTo(10);
+      expect(result.counts[1]).toBeCloseTo(1);
+      expect(result.duplicates[0]).toBeCloseTo(1);
+      expect(result.duplicates[1]).toBeCloseTo(1);
+    });
+  });
+
 });

--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -60,32 +60,4 @@ describe('RuleTable', () => {
     });
   });
 
-  describe('calculateCountAndDuplicates', () => {
-    it('returns the right number of duplicates', () => {
-      let dummyData = TestUtil.getComplexGsDummyData();
-      let filter2 = TestUtil.getDummyGsFilter();
-
-      dummyData.exampleFeatures.features[0].properties.state = 'germany';
-      dummyData.exampleFeatures.features[0].properties.population = 150000;
-      dummyData.exampleFeatures.features[0].properties.name = 'NotSchalke';
-
-      const rules: Rule[] = [{
-        name: 'rule1',
-        symbolizers: [],
-        filter: []
-      }, {
-        name: 'rule2',
-        symbolizers: [],
-        filter: filter2
-      }];
-
-      const result = RuleTable.calculateCountAndDuplicates(rules, dummyData);
-
-      expect(result.counts[0]).toBeCloseTo(10);
-      expect(result.counts[1]).toBeCloseTo(1);
-      expect(result.duplicates[0]).toBeCloseTo(1);
-      expect(result.duplicates[1]).toBeCloseTo(1);
-    });
-  });
-
 });

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -1,5 +1,5 @@
 import FilterUtil from './FilterUtil';
-import { Filter } from 'geostyler-style';
+import { Filter, Rule } from 'geostyler-style';
 import TestUtil from './TestUtil';
 
 describe('FilterUtil', () => {
@@ -55,6 +55,34 @@ describe('FilterUtil', () => {
       let dummyData = TestUtil.getComplexGsDummyData();
       const matches = FilterUtil.getMatches(filter, dummyData);
       expect(matches).toHaveLength(0);
+    });
+  });
+
+  describe('calculateCountAndDuplicates', () => {
+    it('returns the right number of duplicates', () => {
+      let dummyData = TestUtil.getComplexGsDummyData();
+      let filter2 = TestUtil.getDummyGsFilter();
+
+      dummyData.exampleFeatures.features[0].properties.state = 'germany';
+      dummyData.exampleFeatures.features[0].properties.population = 150000;
+      dummyData.exampleFeatures.features[0].properties.name = 'NotSchalke';
+
+      const rules: Rule[] = [{
+        name: 'rule1',
+        symbolizers: [],
+        filter: []
+      }, {
+        name: 'rule2',
+        symbolizers: [],
+        filter: filter2
+      }];
+
+      const result = FilterUtil.calculateCountAndDuplicates(rules, dummyData);
+
+      expect(result.counts[0]).toBeCloseTo(10);
+      expect(result.counts[1]).toBeCloseTo(1);
+      expect(result.duplicates[0]).toBeCloseTo(1);
+      expect(result.duplicates[1]).toBeCloseTo(1);
     });
   });
 

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -1,5 +1,5 @@
 import FilterUtil from './FilterUtil';
-import { Filter, Rule } from 'geostyler-style';
+import { Filter } from 'geostyler-style';
 import TestUtil from './TestUtil';
 
 describe('FilterUtil', () => {
@@ -58,38 +58,4 @@ describe('FilterUtil', () => {
     });
   });
 
-  describe('getNumberOfMatches', () => {
-    it('returns the right number of matched features', () => {
-      let dummyData = TestUtil.getComplexGsDummyData();
-      dummyData.exampleFeatures.features[0].properties.state = 'germany';
-      dummyData.exampleFeatures.features[0].properties.population = 150000;
-      dummyData.exampleFeatures.features[0].properties.name = 'NotSchalke';
-      const numberMatches = FilterUtil.getNumberOfMatches(filter, dummyData);
-      expect(numberMatches).toBeCloseTo(1);
-    });
-  });
-
-  describe('getNumberOfDuplicates', () => {
-    it('returns the right number of duplicates', () => {
-      let dummyData = TestUtil.getComplexGsDummyData();
-      let filter2 = TestUtil.getDummyGsFilter();
-
-      dummyData.exampleFeatures.features[0].properties.state = 'germany';
-      dummyData.exampleFeatures.features[0].properties.population = 150000;
-      dummyData.exampleFeatures.features[0].properties.name = 'NotSchalke';
-
-      const dummyRules: Rule[] = [{
-        name: 'rule1',
-        symbolizers: [],
-        filter: filter
-      }, {
-        name: 'rule2',
-        symbolizers: [],
-        filter: filter2
-      }];
-
-      const numberDuplicates = FilterUtil.getNumberOfDuplicates(dummyRules, dummyData, 0);
-      expect(numberDuplicates).toBeCloseTo(1);
-    });
-  });
 });

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -2,7 +2,8 @@ import {
   Filter,
   Operator,
   CombinationOperator,
-  NegationOpertaor
+  NegationOpertaor,
+  Rule
 } from 'geostyler-style';
 
 import {
@@ -174,6 +175,57 @@ class FilterUtil {
       }
     });
     return matches;
+  }
+
+  static calculateDuplicates(matches: any[][]): number[] {
+    const duplicates: number[] = [];
+    const ids: object[] = [];
+
+    matches.forEach((features) => {
+      const idMap = {};
+      features.forEach(feat => idMap[feat.id] = true);
+      ids.push(idMap);
+    });
+
+    matches.forEach((features, index) => {
+      let counter = 0;
+      ids.forEach((idMap, idIndex) => {
+        if (index !== idIndex) {
+          features.forEach(feat => {
+            if (idMap[feat.id]) {
+              ++counter;
+            }
+          });
+        }
+      });
+      duplicates.push(counter);
+    });
+
+    return duplicates;
+  }
+
+  static calculateCountAndDuplicates(rules: Rule[], data: Data): {
+    counts?: number[],
+    duplicates?: number[]
+  } {
+    if (!rules || !data) {
+      return {};
+    }
+    const result: {
+      counts: number[],
+      duplicates: number[]
+    } = {
+      counts: [],
+      duplicates: []
+    };
+    const matches: any[][] = [];
+    rules.forEach((rule, index) => {
+      const currentMatches = rule.filter ? FilterUtil.getMatches(rule.filter, data) : data.exampleFeatures.features;
+      result.counts.push(currentMatches.length);
+      matches[index] = currentMatches;
+    });
+    result.duplicates = FilterUtil.calculateDuplicates(matches);
+    return result;
   }
 
 }

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -2,8 +2,7 @@ import {
   Filter,
   Operator,
   CombinationOperator,
-  NegationOpertaor,
-  Rule
+  NegationOpertaor
 } from 'geostyler-style';
 
 import {
@@ -11,8 +10,6 @@ import {
 } from 'geostyler-data';
 
 const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
-const _cloneDeep = require('lodash/cloneDeep');
 
 /**
  * @class SymbolizerUtil
@@ -171,86 +168,14 @@ class FilterUtil {
   static getMatches = (filter: Filter, data: Data): any[] => {
     const matches: any[] = [];
     data.exampleFeatures.features.forEach(feature => {
-      try {
-        const match = FilterUtil.featureMatchesFilter(filter, feature);
-        if (match) {
-          matches.push(feature);
-        }
-      } catch (error) {
-        throw error;
+      const match = FilterUtil.featureMatchesFilter(filter, feature);
+      if (match) {
+        matches.push(feature);
       }
     });
     return matches;
   }
 
-  /**
-   * Returns the number of features that match a given filter.
-   */
-  static getNumberOfMatches = (filter: Filter, data: Data): number => {
-    let matches: any[];
-    try {
-      matches = FilterUtil.getMatches(filter, data);
-    } catch (error) {
-      throw error;
-    }
-    return matches.length;
-  }
-
-  /**
-   * Returns the number of features that match the filter at a given rulekey
-   * as well as any other rule's filter.
-   */
-  static getNumberOfDuplicates = (rules: Rule[], data: Data, rulekey: number): number => {
-    try {
-      // create filters array
-      // if a rule does not have a filter, an empty array will be pushed instead
-      const filters: Filter[] = [];
-      rules.forEach((rule: Rule) => {
-        if (rule.filter) {
-          filters.push(rule.filter);
-        } else {
-          filters.push([]);
-        }
-      });
-
-      // get all matches of all filters
-      const allFiltersMatches: any[][] = [];
-      filters.forEach((filter: Filter) => {
-        try {
-          const matches: any[] = FilterUtil.getMatches(filter, data);
-          allFiltersMatches.push(matches);
-        } catch (error) {
-          throw error;
-        }
-      });
-
-      // check for duplicates
-      let duplicates: number = 0;
-
-      // create flat array of all matches except the ones of currently checked filter results
-      const restFiltersMatches = _cloneDeep(allFiltersMatches);
-      restFiltersMatches.splice(rulekey, 1);
-      const flatRestMatches: any[] = restFiltersMatches.reduce((acc: any, val: any) => acc.concat(val), []);
-
-      // check for each match if it also exists in other filters matches
-      // if so, increase counter
-      allFiltersMatches[rulekey].forEach((match: any) => {
-        let contained: boolean = false;
-        for (let i = 0; i < flatRestMatches.length; i++) {
-          if (_isEqual(match, flatRestMatches[i])) {
-            contained = true;
-            break;
-          }
-        }
-        if (contained) {
-          duplicates++;
-        }
-      });
-      return duplicates;
-    } catch (error) {
-      throw error;
-    }
-  }
 }
 
 export default FilterUtil;


### PR DESCRIPTION
This now only calculates the amount and duplicates if the data or a filter change. Also, the duplicates detection now uses the results of calculating the matches while determining the count, so the features are only matched once against the filters.

@terrestris/devs Please review.