### PR TITLE
Replaces UglifyJS with Terser

### DIFF
--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,4 +1,4 @@
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
@@ -22,9 +22,7 @@ module.exports = {
   },
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
-        parallel: true
-      }),
+      new TerserPlugin(),
       new OptimizeCSSAssetsPlugin({})
     ]
   },

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "react-styleguidist": "8.0.6",
     "rimraf": "2.6.2",
     "source-map-loader": "0.2.4",
+    "terser-webpack-plugin": "1.1.0",
     "ts-jest": "23.10.5",
     "ts-loader": "5.3.0",
     "tsconfig-paths-webpack-plugin": "3.2.0",


### PR DESCRIPTION
This replaces UglifyJS with Terser as Terser can handle ES6.
Terser will be used in future releases of webpack: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/362#issuecomment-425849160