### PR TITLE
Removes already declared onChange prop

### DIFF
--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -10,7 +10,6 @@ interface OffsetFieldDefaultProps {
 
 // non default props
 export interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps>, Partial<InputNumberProps> {
-  onChange?: (radius: number) => void;
   offset?: number;
 }
 


### PR DESCRIPTION
This removes the `onChange` prop from `OffsetField` props as it is already declared by the partially extended `InputNumberProps` of antd.

This caused an TypeScript-Error when using geostyler.