### PR TITLE
Adds ids to features if not present

### DIFF
--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -218,6 +218,15 @@ class FilterUtil {
       counts: [],
       duplicates: []
     };
+
+    // Add id to feature if missing
+    data.exampleFeatures.features = data.exampleFeatures.features.map((feature, idx) => {
+      if (!feature.id) {
+        feature.id = idx;
+      }
+      return feature;
+    });
+
     const matches: any[][] = [];
     rules.forEach((rule, index) => {
       const currentMatches = rule.filter ? FilterUtil.getMatches(rule.filter, data) : data.exampleFeatures.features;


### PR DESCRIPTION
This fixes a bug in duplicates calculation.

As the calculation of duplicates relies on `feature.id` we use the index inside the `FeatureCollection` if the feature has no id.