### PR TITLE
Fixes import of URLSearchParams polyfill

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,17 +5,15 @@
       "name": "Debug Jest Tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/jest",
       "port": 9230,
-      "args": [
+      "runtimeArgs": [
+        "--inspect-brk=9230",
+        "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
-        "--no-cache",
-        "--watchAll"
+        "--watch"
       ],
-      "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "runtimeExecutable": null,
+      "console": "integratedTerminal"
     },
     {
       "type": "node",

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -7,3 +7,4 @@ declare module 'ol/Map';
 declare module 'ol/View';
 declare module 'ol/geom/LineString';
 declare module 'ol/geom/Polygon';
+declare module '@ungap/url-search-params';

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
+    "@ungap/url-search-params": "0.1.2",
     "@types/chroma-js": "1.4.1",
     "@types/codemirror": "0.0.71",
     "@types/color": "3.0.0",
@@ -65,8 +66,7 @@
     "moment": "2.23.0",
     "react-codemirror2": "5.1.0",
     "react-color": "2.17.0",
-    "react-rnd": "9.0.4",
-    "@ungap/url-search-params": "0.1.2"
+    "react-rnd": "9.0.4"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/src/Util/HTTPUtil.ts
+++ b/src/Util/HTTPUtil.ts
@@ -1,4 +1,4 @@
-const URLSearchParams = require('@ungap/url-search-params');
+import URLSearchParams from '@ungap/url-search-params';
 
 type PostOptions = {
   url: string;


### PR DESCRIPTION
This fixes the import of `@ungap/url-search-params` polyfill in the `HTTPUtil` which lead to a broken `SLDRenderer`.

Also adapts the launch.json.

Closes #759 