### PR TITLE
Changes label handling of EditorFields

### DIFF
--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -8,7 +8,6 @@ import './NameField.css';
 
 // default props
 export interface NameFieldDefaultProps {
-  label: string;
   placeholder: string;
 }
 // non default props
@@ -22,7 +21,6 @@ export interface NameFieldProps extends Partial<NameFieldDefaultProps> {
  */
 export class NameField extends React.PureComponent<NameFieldProps> {
   public static defaultProps: NameFieldDefaultProps = {
-    label: 'Name',
     placeholder: 'Enter Name'
   };
 
@@ -42,15 +40,12 @@ export class NameField extends React.PureComponent<NameFieldProps> {
   render() {
 
     return (
-      <div className="gs-namefield" >
-        {this.props.label}:
-        <Input
-          className="gs-namefield-input"
-          value={this.props.value}
-          onChange={this.onChange}
-          placeholder={this.props.placeholder}
-        />
-      </div>
+      <Input
+        className="gs-namefield"
+        value={this.props.value}
+        onChange={this.onChange}
+        placeholder={this.props.placeholder}
+      />
     );
   }
 }

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -296,10 +296,10 @@ export class Rule extends React.Component<RuleProps, RuleState> {
       <div className="gs-rule" >
         <div className="gs-rule-fields" >
           <div className="gs-rule-left-fields" >
+            {locale.nameFieldLabel}
             <RuleNameField
               value={rule.name}
               onChange={this.onNameChange}
-              label={locale.nameFieldLabel}
               placeholder={locale.nameFieldPlaceholder}
               {...this.props.ruleNameProps}
             />

--- a/src/Component/Style/Style.css
+++ b/src/Component/Style/Style.css
@@ -1,14 +1,14 @@
-.gs-style-name-classification-row {
+.gs-style .gs-style-name-classification-row {
   display: flex;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.gs-namefield {
-  flex: 1;
-}
-
-.gs-rule-table .ant-table-footer {
+.gs-style .gs-rule-table .ant-table-footer {
   margin-top: 1px;
   padding: 0;
+}
+
+.gs-style .gs-style-rulegenerator {
+  margin-left: auto;
 }

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -9,7 +9,8 @@ import { InterpolationMode } from 'chroma-js';
 import {
   Button,
   Menu,
-  Icon
+  Icon,
+  Form
 } from 'antd';
 
 import {
@@ -446,15 +447,24 @@ export class Style extends React.Component<StyleProps, StyleState> {
       rules = style.rules;
     }
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-style" >
         <div className="gs-style-name-classification-row">
-          {locale.nameFieldLabel}
-          <NameField
-            value={this.state.style.name}
-            onChange={this.onNameChange}
-            placeholder={locale.nameFieldPlaceholder}
-          />
+          <Form.Item
+            label={locale.nameFieldLabel}
+            {...formItemLayout}
+          >
+            <NameField
+              value={this.state.style.name}
+              onChange={this.onNameChange}
+              placeholder={locale.nameFieldPlaceholder}
+            />
+          </Form.Item>
           {
             enableClassification ?
               <Button

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -449,10 +449,10 @@ export class Style extends React.Component<StyleProps, StyleState> {
     return (
       <div className="gs-style" >
         <div className="gs-style-name-classification-row">
+          {locale.nameFieldLabel}
           <NameField
             value={this.state.style.name}
             onChange={this.onNameChange}
-            label={locale.nameFieldLabel}
             placeholder={locale.nameFieldPlaceholder}
           />
           {

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -159,9 +159,9 @@ export class BulkEditModals extends React.Component<BulkEditModalsProps, BulkEdi
           footer={null}
           onCancel={() => this.props.modalsClosed()}
         >
+          {locale.colorLabel}
           <ColorField
             color={color}
-            label={locale.colorLabel}
             onChange={this.props.updateMultiColors}
           />
         </Modal>
@@ -172,9 +172,9 @@ export class BulkEditModals extends React.Component<BulkEditModalsProps, BulkEdi
           footer={null}
           onCancel={() => this.props.modalsClosed()}
         >
+          {locale.radiusLabel}
           <RadiusField
             radius={size}
-            label={locale.radiusLabel}
             onChange={this.props.updateMultiSizes}
           />
         </Modal>
@@ -185,9 +185,9 @@ export class BulkEditModals extends React.Component<BulkEditModalsProps, BulkEdi
           footer={null}
           onCancel={() => this.props.modalsClosed()}
         >
+          {locale.opacityLabel}
           <OpacityField
             opacity={opacity}
-            label={locale.opacityLabel}
             onChange={this.props.updateMultiOpacities}
           />
         </Modal>
@@ -213,8 +213,8 @@ export class BulkEditModals extends React.Component<BulkEditModalsProps, BulkEdi
               />
             ) : (
               <div>
+                {locale.imageFieldLabel}
                 <ImageField
-                  label={locale.imageFieldLabel}
                   value={symbol}
                   onChange={(val: string) => {
                     this.props.updateMultiSymbols(val, kind);

--- a/src/Component/Symbolizer/Editor/Editor.css
+++ b/src/Component/Symbolizer/Editor/Editor.css
@@ -1,18 +1,3 @@
-.editor-field {
-  display: flex;
-  align-items: center;
-  margin-top: 5px;
-}
-
-.editor-field > .label {
-  margin-right: 10px;
-  width: 140px;
-  text-align: right;
-}
-
-.editor-field .ant-input-number,
-.editor-field .ant-select-selection,
-.editor-field .ant-input,
-.editor-field .color-preview {
+.gs-symbolizer-editor .editor-field {
   width: 200px;
 }

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -21,9 +21,18 @@ import KindField from '../Field/KindField/KindField';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { IconLibrary } from '../IconSelector/IconSelector';
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+import { Form } from 'antd';
+
+// i18n
+export interface EditorLocale {
+  kindFieldLabel: string;
+}
 
 // default props
 interface EditorDefaultProps {
+  locale: EditorLocale;
   unknownSymbolizerText?: string;
 }
 
@@ -51,7 +60,10 @@ export class Editor extends React.Component<EditorProps, EditorState> {
     };
   }
 
+  static componentName: string = 'SymbolizerEditor';
+
   public static defaultProps: EditorDefaultProps = {
+    locale: en_US.GsSymbolizerEditor,
     unknownSymbolizerText: 'Unknown Symbolizer!'
   };
 
@@ -137,17 +149,31 @@ export class Editor extends React.Component<EditorProps, EditorState> {
     if (this.state.hasError) {
       return <h1>An error occured in the Symbolizer Editor UI.</h1>;
     }
+    const {
+      locale
+    } = this.props;
+
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     const symbolizer = _cloneDeep(this.state.symbolizer);
     return (
       <div className="gs-symbolizer-editor" >
-        <KindField
-          kind={symbolizer.kind}
-          onChange={this.onKindFieldChange}
-        />
+        <Form.Item
+          label={locale.kindFieldLabel}
+          {...formItemLayout}
+        >
+          <KindField
+            kind={symbolizer.kind}
+            onChange={this.onKindFieldChange}
+          />
+        </Form.Item>
         {this.getUiFromSymbolizer(this.props.symbolizer)}
       </div>
     );
   }
 }
 
-export default Editor;
+export default localize(Editor, Editor.componentName);

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -25,7 +25,6 @@ export interface ColorFieldLocale {
 
 // default props
 interface ColorFieldDefaultProps {
-  label: string;
   locale: ColorFieldLocale;
 }
 
@@ -46,8 +45,7 @@ interface ColorFieldState {
 export class ColorField extends React.Component<ColorFieldProps, ColorFieldState> {
 
   public static defaultProps: ColorFieldDefaultProps = {
-    locale: en_US.GsColorField,
-    label: 'Color'
+    locale: en_US.GsColorField
   };
 
   constructor(props: ColorFieldProps) {
@@ -77,7 +75,6 @@ export class ColorField extends React.Component<ColorFieldProps, ColorFieldState
     } = this.state;
     const {
       color,
-      label,
       locale,
       onChange
     } = this.props;
@@ -95,7 +92,6 @@ export class ColorField extends React.Component<ColorFieldProps, ColorFieldState
 
     return (
       <div className="editor-field color-field">
-        <span className="label">{`${label}:`}</span>
         <div className="color-preview-wrapper">
           <Button
             className="color-preview"

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -7,7 +7,6 @@ const Option = Select.Option;
 
 // default props
 interface FontPickerDefaultProps {
-  label: string;
   fontOptions: string[];
 }
 
@@ -23,7 +22,6 @@ export interface FontPickerProps extends Partial<FontPickerDefaultProps> {
 export class FontPicker extends React.Component<FontPickerProps> {
 
   public static defaultProps: FontPickerDefaultProps = {
-    label: 'Font',
     fontOptions: [
       'Arial', 'Verdana', 'Sans-serif',
       'Courier New', 'Lucida Console', 'Monospace',
@@ -35,7 +33,6 @@ export class FontPicker extends React.Component<FontPickerProps> {
     const {
       font,
       onChange,
-      label,
       fontOptions
     } = this.props;
 
@@ -47,16 +44,14 @@ export class FontPicker extends React.Component<FontPickerProps> {
     }
 
     return (
-      <div className="editor-field font-picker">
-        <span className="label">{`${label}:`}</span>
-        <Select
-          mode="tags"
-          value={font}
-          onChange={onChange}
-        >
-          {children}
-        </Select>
-      </div>
+      <Select
+        className="editor-field font-picker"
+        mode="tags"
+        value={font}
+        onChange={onChange}
+      >
+        {children}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -21,8 +21,6 @@ interface GraphicTypeFieldLocale {
 export interface GraphicTypeFieldDefaultProps {
   /** List of selectable GraphicTypes for Select */
   graphicTypes: GraphicType[];
-  /** Label rendered next to Select */
-  label: String;
   /** Language package */
   locale: GraphicTypeFieldLocale;
   /** If true GraphicTypeField can be cleared  */
@@ -44,7 +42,6 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps> {
   public static defaultProps: GraphicTypeFieldDefaultProps = {
     locale: en_US.GsGraphicTypeField,
     graphicTypes: ['Mark', 'Icon'],
-    label: 'Graphic',
     clearable: true
   };
 
@@ -75,7 +72,6 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps> {
 
   render() {
     const {
-      label,
       locale,
       graphicType,
       graphicTypes,
@@ -85,17 +81,15 @@ export class GraphicTypeField extends React.Component <GraphicTypeFieldProps> {
     } = this.props;
 
     return (
-      <div className="editor-field graphictype-field">
-        <span className="label">{`${label}:`}</span>
-        <Select
-          value={graphicType}
-          onChange={onChange}
-          allowClear={clearable}
-          {...passThroughProps}
-        >
-          {this.getTypeSelectOptions(locale)}
-        </Select>
-      </div>
+      <Select
+        className="editor-field graphictype-field"
+        value={graphicType}
+        onChange={onChange}
+        allowClear={clearable}
+        {...passThroughProps}
+      >
+        {this.getTypeSelectOptions(locale)}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -13,7 +13,6 @@ import './ImageField.css';
 
 // default props
 interface ImageFieldDefaultProps {
-  label: string;
   tooltipLabel: string;
   placeholder: string;
 }
@@ -35,7 +34,6 @@ interface ImageFieldState {
 export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldState> {
 
   public static defaultProps: ImageFieldDefaultProps = {
-    label: 'Image',
     tooltipLabel: 'Open Gallery',
     placeholder: 'URL to image'
   };
@@ -74,7 +72,6 @@ export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldS
   render() {
     const {
       value,
-      label,
       placeholder,
       onChange,
       iconLibraries
@@ -86,7 +83,6 @@ export class ImageField extends React.PureComponent<ImageFieldProps, ImageFieldS
 
     return (
       <div className="editor-field gs-image-field">
-        <span className="label">{`${label}:`}</span>
         <Input
           className={iconLibraries ? 'gs-image-field-gallery-addon' : undefined}
           value={value}

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -14,7 +14,6 @@ const Option = Select.Option;
 
 // i18n
 export interface KindFieldLocale {
-  label: string;
   symbolizerKinds: {
     Mark: string;
     Fill: string;
@@ -75,15 +74,13 @@ export class KindField extends React.Component<KindFieldProps> {
     } = this.props;
 
     return (
-      <div className="editor-field kind-field">
-        <span className="label">{`${locale.label}:`}</span>
-        <Select
-          value={kind}
-          onChange={onChange}
-        >
-          {this.getKindSelectOptions(locale)}
-        </Select>
-      </div>
+      <Select
+        className="editor-field kind-field"
+        value={kind}
+        onChange={onChange}
+      >
+        {this.getKindSelectOptions(locale)}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
@@ -11,7 +11,6 @@ import {
 
 // default props
 interface LineCapFieldDefaultProps {
-  label: string;
   capOptions: LineSymbolizer['cap'][];
 }
 
@@ -27,7 +26,6 @@ export interface LineCapFieldProps extends Partial<LineCapFieldDefaultProps> {
 export class LineCapField extends React.Component<LineCapFieldProps> {
 
   public static defaultProps: LineCapFieldDefaultProps = {
-    label: 'Line-Cap',
     capOptions: ['butt', 'round', 'square']
   };
 
@@ -47,20 +45,17 @@ export class LineCapField extends React.Component<LineCapFieldProps> {
   render() {
     const {
       cap,
-      label,
       onChange
     } = this.props;
 
     return (
-      <div className="editor-field line-cap">
-        <span className="label">{`${label}:`}</span>
-        <Select
-          value={cap}
-          onChange={onChange}
-        >
-          {this.getCapSelectOptions()}
-        </Select>
-      </div>
+      <Select
+        className="editor-field line-cap"
+        value={cap}
+        onChange={onChange}
+      >
+        {this.getCapSelectOptions()}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
@@ -8,7 +8,6 @@ import './LineDashField.css';
 
 // default props
 interface LineDashFieldDefaultProps {
-  label: string;
   dashArray: number[];
 }
 
@@ -23,20 +22,17 @@ export interface LineDashFieldProps extends Partial<LineDashFieldDefaultProps> {
 export class LineDashField extends React.Component<LineDashFieldProps> {
 
   public static defaultProps: LineDashFieldDefaultProps = {
-    label: 'Dash Pattern',
     dashArray: []
   };
 
   render() {
     const {
-      label,
       onChange,
       dashArray
     } = this.props;
 
     return (
       <div className="editor-field linedash-field">
-        <span className="label">{`${label}:`}</span>
         {
           dashArray.map((dash, idx) => <InputNumber
             key={idx}

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
@@ -11,7 +11,6 @@ import {
 
 // default props
 interface LineJoinFieldDefaultProps {
-  label: string;
   joinOptions: LineSymbolizer['join'][];
 }
 
@@ -27,7 +26,6 @@ export interface LineJoinFieldProps extends Partial<LineJoinFieldDefaultProps> {
 export class LineJoinField extends React.Component<LineJoinFieldProps> {
 
   public static defaultProps: LineJoinFieldDefaultProps = {
-    label: 'Line-Join',
     joinOptions: ['bevel', 'round', 'miter']
   };
 
@@ -47,20 +45,17 @@ export class LineJoinField extends React.Component<LineJoinFieldProps> {
   render() {
     const {
       join,
-      label,
       onChange
     } = this.props;
 
     return (
-      <div className="editor-field line-join">
-        <span className="label">{`${label}:`}</span>
-        <Select
-          value={join}
-          onChange={onChange}
-        >
-          {this.getJoinSelectOptions()}
-        </Select>
-      </div>
+      <Select
+        className="editor-field line-join"
+        value={join}
+        onChange={onChange}
+      >
+        {this.getJoinSelectOptions()}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -3,13 +3,8 @@ import * as React from 'react';
 import { InputNumber } from 'antd';
 import { InputNumberProps } from 'antd/lib/input-number';
 
-// default props
-interface OffsetFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps>, Partial<InputNumberProps> {
+export interface OffsetFieldProps extends Partial<InputNumberProps> {
   offset?: number;
 }
 
@@ -18,28 +13,21 @@ export interface OffsetFieldProps extends Partial<OffsetFieldDefaultProps>, Part
  */
 export class OffsetField extends React.PureComponent<OffsetFieldProps> {
 
-  public static defaultProps: OffsetFieldDefaultProps = {
-    label: ''
-  };
-
   render() {
     const {
       offset,
-      label,
       onChange,
       ...inputProps
     } = this.props;
 
     return (
-      <div className="editor-field offset-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          value={offset}
-          step={1}
-          onChange={onChange}
-          {...inputProps}
-        />
-      </div>
+      <InputNumber
+        className="editor-field offset-field"
+        value={offset}
+        step={1}
+        onChange={onChange}
+        {...inputProps}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -4,13 +4,8 @@ import {
   InputNumber
 } from 'antd';
 
-// default props
-interface OpacityFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface OpacityFieldProps extends Partial<OpacityFieldDefaultProps> {
+export interface OpacityFieldProps {
   onChange?: (opacity: number) => void;
   opacity?: number;
 }
@@ -20,28 +15,21 @@ export interface OpacityFieldProps extends Partial<OpacityFieldDefaultProps> {
  */
 export class OpacityField extends React.PureComponent<OpacityFieldProps> {
 
-  public static defaultProps: OpacityFieldDefaultProps = {
-    label: 'Opacity'
-  };
-
   render() {
     const {
       onChange,
-      opacity,
-      label
+      opacity
     } = this.props;
 
     return (
-      <div className="editor-field opacity-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          min={0}
-          max={1}
-          step={0.01}
-          value={opacity}
-          onChange={onChange}
-        />
-      </div>
+      <InputNumber
+        className="editor-field opacity-field"
+        min={0}
+        max={1}
+        step={0.01}
+        value={opacity}
+        onChange={onChange}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -4,13 +4,8 @@ import {
   InputNumber
 } from 'antd';
 
-// default props
-interface RadiusFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface RadiusFieldProps extends Partial<RadiusFieldDefaultProps> {
+export interface RadiusFieldProps {
   onChange?: (radius: number) => void;
   radius?: number;
 }
@@ -20,26 +15,19 @@ export interface RadiusFieldProps extends Partial<RadiusFieldDefaultProps> {
  */
 export class RadiusField extends React.PureComponent<RadiusFieldProps> {
 
-  public static defaultProps: RadiusFieldDefaultProps = {
-    label: 'Radius'
-  };
-
   render() {
     const {
       onChange,
-      radius,
-      label
+      radius
     } = this.props;
 
     return (
-      <div className="editor-field radius-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          min={0}
-          value={radius}
-          onChange={onChange}
-        />
-      </div>
+      <InputNumber
+        className="editor-field radius-field"
+        min={0}
+        value={radius}
+        onChange={onChange}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -4,13 +4,8 @@ import {
   InputNumber
 } from 'antd';
 
-// default props
-interface RotateFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface RotateFieldProps extends Partial<RotateFieldDefaultProps> {
+export interface RotateFieldProps {
   onChange?: (radius: number) => void;
   rotate?: number;
 }
@@ -20,27 +15,20 @@ export interface RotateFieldProps extends Partial<RotateFieldDefaultProps> {
  */
 export class RotateField extends React.PureComponent<RotateFieldProps> {
 
-  public static defaultProps: RotateFieldDefaultProps = {
-    label: 'Rotate'
-  };
-
   render() {
     const {
       onChange,
-      rotate,
-      label
+      rotate
     } = this.props;
 
     return (
-      <div className="editor-field rotate-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          min={-360}
-          max={360}
-          value={rotate}
-          onChange={onChange}
-        />
-      </div>
+      <InputNumber
+        className="editor-field rotate-field"
+        min={-360}
+        max={360}
+        value={rotate}
+        onChange={onChange}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
@@ -4,13 +4,8 @@ import {
   InputNumber
 } from 'antd';
 
-// default props
-interface SizeFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface SizeFieldProps extends Partial<SizeFieldDefaultProps> {
+export interface SizeFieldProps {
   size?: number;
   onChange?: (radius: number) => void;
 }
@@ -20,26 +15,19 @@ export interface SizeFieldProps extends Partial<SizeFieldDefaultProps> {
  */
 export class SizeField extends React.PureComponent<SizeFieldProps> {
 
-  public static defaultProps: SizeFieldDefaultProps = {
-    label: 'Size'
-  };
-
   render() {
     const {
       onChange,
-      size,
-      label
+      size
     } = this.props;
 
     return (
-      <div className="editor-field size-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          step={0.1}
-          value={size}
-          onChange={onChange}
-        />
-      </div>
+      <InputNumber
+        className="editor-field size-field"
+        step={0.1}
+        value={size}
+        onChange={onChange}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -14,7 +14,6 @@ const Option = Select.Option;
 
 // i18n
 export interface WellKnownNameFieldLocale {
-  label: string;
   wellKnownNames: {
     Circle: string;
     Square: string;
@@ -81,15 +80,13 @@ export class WellKnownNameField extends React.Component<WellKnownNameFieldProps>
     } = this.props;
 
     return (
-      <div className="editor-field wellknownname-field">
-        <span className="label">{`${_get(locale, 'label')}:`}</span>
-        <Select
-          value={wellKnownName}
-          onChange={onChange}
-        >
-          {this.getWKNSelectOptions(locale)}
-        </Select>
-      </div>
+      <Select
+        className="editor-field wellknownname-field"
+        value={wellKnownName}
+        onChange={onChange}
+      >
+        {this.getWKNSelectOptions(locale)}
+      </Select>
     );
   }
 }

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
@@ -4,13 +4,8 @@ import {
   InputNumber
 } from 'antd';
 
-// default props
-interface WidthFieldDefaultProps {
-  label: string;
-}
-
 // non default props
-export interface WidthFieldProps extends Partial<WidthFieldDefaultProps> {
+export interface WidthFieldProps {
   onChange?: (radius: number) => void;
   width?: number;
 }
@@ -20,26 +15,19 @@ export interface WidthFieldProps extends Partial<WidthFieldDefaultProps> {
  */
 export class WidthField extends React.PureComponent<WidthFieldProps> {
 
-  public static defaultProps: WidthFieldDefaultProps = {
-    label: 'Width'
-  };
-
   render() {
     const {
       onChange,
-      width,
-      label
+      width
     } = this.props;
 
     return (
-      <div className="editor-field width-field">
-        <span className="label">{`${label}:`}</span>
-        <InputNumber
-          min={0}
-          value={width}
-          onChange={onChange}
-        />
-      </div>
+      <InputNumber
+        className="editor-field width-field"
+        min={0}
+        value={width}
+        onChange={onChange}
+      />
     );
   }
 }

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -143,29 +143,29 @@ export class FillEditor extends React.Component<FillEditorProps> {
       <div className="gs-fill-symbolizer-editor" >
         <Collapse bordered={false} defaultActiveKey={['1']}>
           <Panel header="General" key="1">
+            {locale.fillColorLabel}
             <ColorField
               color={color}
-              label={locale.fillColorLabel}
               onChange={this.onFillColorChange}
             />
+            {locale.fillOpacityLabel}
             <OpacityField
               opacity={opacity}
-              label={locale.fillOpacityLabel}
               onChange={this.onFillOpacityChange}
             />
+            {locale.outlineColorLabel}
             <ColorField
               color={outlineColor}
-              label={locale.outlineColorLabel}
               onChange={this.onOutlineColorChange}
             />
+            {locale.outlineWidthLabel}
             <WidthField
               width={outlineWidth}
-              label={locale.outlineWidthLabel}
               onChange={this.onOutlineWidthChange}
             />
+            {locale.outlineDasharrayLabel}
             <LineDashField
               dashArray={outlineDasharray}
-              label={locale.outlineDasharrayLabel}
               onChange={this.onOutlineDasharrayChange}
             />
           </Panel>

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { Collapse } from 'antd';
+import {
+  Collapse,
+  Form
+} from 'antd';
 
 import {
   Symbolizer,
@@ -139,35 +142,60 @@ export class FillEditor extends React.Component<FillEditorProps> {
       locale
     } = this.props;
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-fill-symbolizer-editor" >
         <Collapse bordered={false} defaultActiveKey={['1']}>
           <Panel header="General" key="1">
-            {locale.fillColorLabel}
-            <ColorField
-              color={color}
-              onChange={this.onFillColorChange}
-            />
-            {locale.fillOpacityLabel}
-            <OpacityField
-              opacity={opacity}
-              onChange={this.onFillOpacityChange}
-            />
-            {locale.outlineColorLabel}
-            <ColorField
-              color={outlineColor}
-              onChange={this.onOutlineColorChange}
-            />
-            {locale.outlineWidthLabel}
-            <WidthField
-              width={outlineWidth}
-              onChange={this.onOutlineWidthChange}
-            />
-            {locale.outlineDasharrayLabel}
-            <LineDashField
-              dashArray={outlineDasharray}
-              onChange={this.onOutlineDasharrayChange}
-            />
+            <Form.Item
+              label={locale.fillColorLabel}
+              {...formItemLayout}
+            >
+              <ColorField
+                color={color}
+                onChange={this.onFillColorChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.fillOpacityLabel}
+              {...formItemLayout}
+            >
+              <OpacityField
+                opacity={opacity}
+                onChange={this.onFillOpacityChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.outlineColorLabel}
+              {...formItemLayout}
+            >
+              <ColorField
+                color={outlineColor}
+                onChange={this.onOutlineColorChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.outlineWidthLabel}
+              {...formItemLayout}
+            >
+              <WidthField
+                width={outlineWidth}
+                onChange={this.onOutlineWidthChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.outlineDasharrayLabel}
+              {...formItemLayout}
+            >
+              <LineDashField
+                dashArray={outlineDasharray}
+                onChange={this.onOutlineDasharrayChange}
+              />
+            </Form.Item>
           </Panel>
           <Panel header="Graphic Fill" key="2">
               <GraphicEditor

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -107,8 +107,8 @@ export class GraphicEditor extends React.Component <GraphicEditorProps> {
 
     return (
       <div>
+      {graphicTypeFieldLabel}
       <GraphicTypeField
-        label={graphicTypeFieldLabel}
         graphicType={graphicType}
         onChange={this.onGraphicTypeChange}
         {...graphicTypeFieldProps}

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -10,6 +10,7 @@ import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';
 import GraphicTypeField, { GraphicTypeFieldProps } from '../Field/GraphicTypeField/GraphicTypeField';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { IconLibrary } from '../IconSelector/IconSelector';
+import { Form } from 'antd';
 
 const _get = require('lodash/get');
 
@@ -105,15 +106,24 @@ export class GraphicEditor extends React.Component <GraphicEditorProps> {
       iconEditorProps
     } = this.props;
 
+    const formItemLayout = {
+      labelCol: { span: 10 },
+      wrapperCol: { span: 14 }
+    };
+
     return (
       <div>
-      {graphicTypeFieldLabel}
-      <GraphicTypeField
-        graphicType={graphicType}
-        onChange={this.onGraphicTypeChange}
-        {...graphicTypeFieldProps}
-      />
-      {this.getGraphicFields(graphic, iconEditorProps)}
+        <Form.Item
+          label={graphicTypeFieldLabel}
+          {...formItemLayout}
+        >
+          <GraphicTypeField
+            graphicType={graphicType}
+            onChange={this.onGraphicTypeChange}
+            {...graphicTypeFieldProps}
+          />
+        </Form.Item>
+        {this.getGraphicFields(graphic, iconEditorProps)}
     </div>
     );
   }

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -117,26 +117,26 @@ export class IconEditor extends React.Component<IconEditorProps> {
 
     return (
       <div className="gs-icon-symbolizer-editor" >
+        {locale.imageLabel}
         <ImageField
           value={imageSrc}
-          label={locale.imageLabel}
           iconLibraries={iconLibraries}
           tooltipLabel={locale.iconTooltipLabel}
           onChange={this.onImageSrcChange}
         />
+        {locale.sizeLabel}
         <SizeField
           size={size}
-          label={locale.sizeLabel}
           onChange={this.onSizeChange}
         />
+        {locale.rotateLabel}
         <RotateField
           rotate={rotate}
-          label={locale.rotateLabel}
           onChange={this.onRotateChange}
         />
+        {locale.opacityLabel}
         <OpacityField
           opacity={opacity}
-          label={locale.opacityLabel}
           onChange={this.onOpacityChange}
         />
       </div>

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -17,6 +17,7 @@ import SizeField from '../Field/SizeField/SizeField';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
+import { Form } from 'antd';
 
 // i18n
 export interface IconEditorLocale {
@@ -115,30 +116,52 @@ export class IconEditor extends React.Component<IconEditorProps> {
 
     const imageSrc = !_isEmpty(image) ? image : 'URL to Icon';
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-icon-symbolizer-editor" >
-        {locale.imageLabel}
-        <ImageField
-          value={imageSrc}
-          iconLibraries={iconLibraries}
-          tooltipLabel={locale.iconTooltipLabel}
-          onChange={this.onImageSrcChange}
-        />
-        {locale.sizeLabel}
-        <SizeField
-          size={size}
-          onChange={this.onSizeChange}
-        />
-        {locale.rotateLabel}
-        <RotateField
-          rotate={rotate}
-          onChange={this.onRotateChange}
-        />
-        {locale.opacityLabel}
-        <OpacityField
-          opacity={opacity}
-          onChange={this.onOpacityChange}
-        />
+        <Form.Item
+          label={locale.imageLabel}
+          {...formItemLayout}
+        >
+          <ImageField
+            value={imageSrc}
+            iconLibraries={iconLibraries}
+            tooltipLabel={locale.iconTooltipLabel}
+            onChange={this.onImageSrcChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.sizeLabel}
+          {...formItemLayout}
+        >
+          <SizeField
+            size={size}
+            onChange={this.onSizeChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.rotateLabel}
+          {...formItemLayout}
+        >
+          <RotateField
+            rotate={rotate}
+            onChange={this.onRotateChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label=
+          {locale.opacityLabel}
+          {...formItemLayout}
+        >
+          <OpacityField
+            opacity={opacity}
+            onChange={this.onOpacityChange}
+          />
+        </Form.Item>
       </div>
     );
   }

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { Collapse } from 'antd';
+import {
+  Collapse,
+  Form
+} from 'antd';
 
 import {
   Symbolizer,
@@ -185,46 +188,79 @@ export class LineEditor extends React.Component<LineEditorProps> {
       locale
     } = this.props;
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-line-symbolizer-editor" >
         <Collapse bordered={false} defaultActiveKey={['1']} onChange={(key: string) => (null)}>
           <Panel header="General" key="1">
-            {locale.colorLabel}
-            <ColorField
-              color={color}
-              onChange={this.onColorChange}
-            />
-            {locale.widthLabel}
-            <WidthField
-              width={width}
-              onChange={this.onWidthChange}
-            />
-            {locale.opacityLabel}
-            <OpacityField
-              opacity={opacity}
-              onChange={this.onOpacityChange}
-            />
-            {locale.dashLabel}
-            <LineDashField
-              dashArray={dasharray}
-              onChange={this.onDasharrayChange}
-            />
-            {locale.dashOffsetLabel}
-            <OffsetField
-              offset={dashOffset}
-              onChange={this.onDashOffsetChange}
-              disabled={symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0}
-            />
-            {locale.capLabel}
-            <LineCapField
-              cap={cap}
-              onChange={this.onCapChange}
+            <Form.Item
+              label={locale.colorLabel}
+              {...formItemLayout}
+            >
+              <ColorField
+                color={color}
+                onChange={this.onColorChange}
               />
-            {locale.joinLabel}
-            <LineJoinField
-              join={join}
-              onChange={this.onJoinChange}
-            />
+            </Form.Item>
+            <Form.Item
+              label={locale.widthLabel}
+              {...formItemLayout}
+            >
+              <WidthField
+                width={width}
+                onChange={this.onWidthChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.opacityLabel}
+              {...formItemLayout}
+            >
+              <OpacityField
+                opacity={opacity}
+                onChange={this.onOpacityChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.dashLabel}
+              {...formItemLayout}
+            >
+              <LineDashField
+                dashArray={dasharray}
+                onChange={this.onDasharrayChange}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.dashOffsetLabel}
+              {...formItemLayout}
+            >
+              <OffsetField
+                offset={dashOffset}
+                onChange={this.onDashOffsetChange}
+                disabled={symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0}
+              />
+            </Form.Item>
+            <Form.Item
+              label={locale.capLabel}
+              {...formItemLayout}
+            >
+              <LineCapField
+                cap={cap}
+                onChange={this.onCapChange}
+                />
+            </Form.Item>
+            <Form.Item
+              label={locale.joinLabel}
+              {...formItemLayout}
+            >
+              <LineJoinField
+                join={join}
+                onChange={this.onJoinChange}
+              />
+            </Form.Item>
           </Panel>
           <Panel header="Graphic Stroke" key="2">
             <GraphicEditor

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -189,40 +189,40 @@ export class LineEditor extends React.Component<LineEditorProps> {
       <div className="gs-line-symbolizer-editor" >
         <Collapse bordered={false} defaultActiveKey={['1']} onChange={(key: string) => (null)}>
           <Panel header="General" key="1">
+            {locale.colorLabel}
             <ColorField
               color={color}
-              label={locale.colorLabel}
               onChange={this.onColorChange}
             />
+            {locale.widthLabel}
             <WidthField
               width={width}
-              label={locale.widthLabel}
               onChange={this.onWidthChange}
             />
+            {locale.opacityLabel}
             <OpacityField
               opacity={opacity}
-              label={locale.opacityLabel}
               onChange={this.onOpacityChange}
             />
+            {locale.dashLabel}
             <LineDashField
               dashArray={dasharray}
-              label={locale.dashLabel}
               onChange={this.onDasharrayChange}
             />
+            {locale.dashOffsetLabel}
             <OffsetField
               offset={dashOffset}
-              label={locale.dashOffsetLabel}
               onChange={this.onDashOffsetChange}
               disabled={symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0}
             />
+            {locale.capLabel}
             <LineCapField
               cap={cap}
-              label={locale.capLabel}
               onChange={this.onCapChange}
-            />
+              />
+            {locale.joinLabel}
             <LineJoinField
               join={join}
-              label={locale.joinLabel}
               onChange={this.onJoinChange}
             />
           </Panel>

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -8,11 +8,24 @@ import {
 
 import WellKnownNameField from '../Field/WellKnownNameField/WellKnownNameField';
 import WellKnownNameEditor from '../WellKnownNameEditor/WellKnownNameEditor';
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+import { Form } from 'antd';
 
 const _cloneDeep = require('lodash/cloneDeep');
 
+// i18n
+export interface MarkEditorLocale {
+  wellKnownNameFieldLabel: string;
+}
+
+// default props
+interface MarkEditorDefaultProps {
+  locale: MarkEditorLocale;
+}
+
 // non default props
-export interface MarkEditorProps {
+export interface MarkEditorProps extends Partial<MarkEditorDefaultProps> {
   symbolizer: MarkSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
 }
@@ -32,6 +45,12 @@ export class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState
       }
     };
   }
+
+  static componentName: string = 'MarkEditor';
+
+  public static defaultProps: MarkEditorDefaultProps = {
+    locale: en_US.GsMarkEditor
+  };
 
   static getDerivedStateFromProps(
       nextProps: MarkEditorProps,
@@ -54,18 +73,29 @@ export class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState
 
   render() {
     const {
+      locale,
       onSymbolizerChange
     } = this.props;
     const {
       symbolizer
     } = this.state;
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-mark-symbolizer-editor" >
-        <WellKnownNameField
-          wellKnownName={symbolizer.wellKnownName}
-          onChange={this.onWellKnownNameChange}
-        />
+        <Form.Item
+          label={locale.wellKnownNameFieldLabel}
+          {...formItemLayout}
+        >
+          <WellKnownNameField
+            wellKnownName={symbolizer.wellKnownName}
+            onChange={this.onWellKnownNameChange}
+          />
+        </Form.Item>
         <WellKnownNameEditor
           symbolizer={symbolizer}
           onSymbolizerChange={onSymbolizerChange}
@@ -75,4 +105,4 @@ export class MarkEditor extends React.Component<MarkEditorProps, MarkEditorState
   }
 }
 
-export default MarkEditor;
+export default localize(MarkEditor, MarkEditor.componentName);

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -225,49 +225,49 @@ export class PropTextEditor extends React.Component<PropTextEditorProps> {
             onAttributeChange={this.onLabelChange}
           />
         </div>
+        {locale.colorLabel}
         <ColorField
           color={color}
-          label={locale.colorLabel}
           onChange={this.onColorChange}
         />
+        {locale.fontLabel}
         <FontPicker
           font={font}
-          label={locale.fontLabel}
           onChange={this.onFontChange}
         />
+        {locale.opacityLabel}
         <OpacityField
           opacity={opacity}
-          label={locale.opacityLabel}
           onChange={this.onOpacityChange}
         />
+        {locale.sizeLabel}
         <WidthField
           width={size}
-          label={locale.sizeLabel}
           onChange={this.onSizeChange}
         />
+        {locale.offsetXLabel}
         <OffsetField
           offset={offsetX}
-          label={locale.offsetXLabel}
           onChange={this.onOffsetXChange}
         />
+        {locale.offsetYLabel}
         <OffsetField
           offset={offsetY}
-          label={locale.offsetYLabel}
           onChange={this.onOffsetYChange}
         />
+        {locale.rotateLabel}
         <RotateField
           rotate={rotate}
-          label={locale.rotateLabel}
           onChange={this.onRotateChange}
         />
+        {locale.haloColorLabel}
         <ColorField
           color={haloColor}
-          label={locale.haloColorLabel}
           onChange={this.onHaloColorChange}
         />
+        {locale.haloWidthLabel}
         <WidthField
           width={haloWidth}
-          label={locale.haloWidthLabel}
           onChange={this.onHaloWidthChange}
         />
       </div>

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
@@ -3,6 +3,7 @@
   border: 3px solid grey;
   border-radius: 3px;
   z-index: 10;
+  min-width: 400px;
 }
 
 .symbolizer-editor-window .header {

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { Mention } from 'antd';
+import {
+  Mention,
+  Form
+} from 'antd';
 const { toString, toContentState } = Mention;
 
 import {
@@ -209,10 +212,17 @@ export class TextEditor extends React.Component<TextEditorProps> {
     }
     const properties = internalDataDef && internalDataDef.schema ? Object.keys(internalDataDef.schema.properties) : [];
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div className="gs-text-symbolizer-editor" >
-         <div className="editor-field attribute-field">
-          <span className="label">{locale.templateFieldLabel}:</span>
+        <Form.Item
+          label={locale.templateFieldLabel}
+          {...formItemLayout}
+        >
           <Mention
             placeholder={locale.templateFieldLabel}
             defaultValue={toContentState(symbolizer.label)}
@@ -221,52 +231,88 @@ export class TextEditor extends React.Component<TextEditorProps> {
             prefix="{{"
             notFoundContent={locale.attributeNotFound}
           />
-        </div>
-        {locale.colorLabel}
-        <ColorField
-          color={color}
-          onChange={this.onColorChange}
+        </Form.Item>
+        <Form.Item
+          label={locale.colorLabel}
+          {...formItemLayout}
+        >
+          <ColorField
+            color={color}
+            onChange={this.onColorChange}
           />
-        {locale.fontLabel}
-        <FontPicker
-          font={font}
-          onChange={this.onFontChange}
-        />
-        {locale.opacityLabel}
-        <OpacityField
-          opacity={opacity}
-          onChange={this.onOpacityChange}
+        </Form.Item>
+        <Form.Item
+          label={locale.fontLabel}
+          {...formItemLayout}
+        >
+          <FontPicker
+            font={font}
+            onChange={this.onFontChange}
           />
-        {locale.sizeLabel}
-        <WidthField
-          width={size}
-          onChange={this.onSizeChange}
-        />
-        {locale.offsetXLabel}
-        <OffsetField
-          offset={offsetX}
-          onChange={this.onOffsetXChange}
-        />
-        {locale.offsetYLabel}
-        <OffsetField
-          offset={offsetY}
-          onChange={this.onOffsetYChange}
-        />
-        {locale.rotateLabel}
-        <RotateField
-          rotate={rotate}
-          onChange={this.onRotateChange}
-        />
-        {locale.haloColorLabel}
-        <ColorField
-          color={haloColor}
-          onChange={this.onHaloColorChange}
+        </Form.Item>
+        <Form.Item
+          label={locale.opacityLabel}
+          {...formItemLayout}
+        >
+          <OpacityField
+            opacity={opacity}
+            onChange={this.onOpacityChange}
+            />
+        </Form.Item>
+        <Form.Item
+          label={locale.sizeLabel}
+          {...formItemLayout}
+        >
+          <WidthField
+            width={size}
+            onChange={this.onSizeChange}
           />
-        {locale.haloWidthLabel}
-        <WidthField
-          width={haloWidth}
-          onChange={this.onHaloWidthChange}
-        />
+        </Form.Item>
+        <Form.Item
+          label={locale.offsetXLabel}
+          {...formItemLayout}
+        >
+          <OffsetField
+            offset={offsetX}
+            onChange={this.onOffsetXChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.offsetYLabel}
+          {...formItemLayout}
+        >
+          <OffsetField
+            offset={offsetY}
+            onChange={this.onOffsetYChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.rotateLabel}
+          {...formItemLayout}
+        >
+          <RotateField
+            rotate={rotate}
+            onChange={this.onRotateChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.haloColorLabel}
+          {...formItemLayout}
+        >
+          <ColorField
+            color={haloColor}
+            onChange={this.onHaloColorChange}
+            />
+        </Form.Item>
+        <Form.Item
+          label={locale.haloWidthLabel}
+          {...formItemLayout}
+        >
+          <WidthField
+            width={haloWidth}
+            onChange={this.onHaloWidthChange}
+          />
+        </Form.Item>
       </div>
     );
   }

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -222,49 +222,49 @@ export class TextEditor extends React.Component<TextEditorProps> {
             notFoundContent={locale.attributeNotFound}
           />
         </div>
+        {locale.colorLabel}
         <ColorField
           color={color}
-          label={locale.colorLabel}
           onChange={this.onColorChange}
-        />
+          />
+        {locale.fontLabel}
         <FontPicker
           font={font}
-          label={locale.fontLabel}
           onChange={this.onFontChange}
         />
+        {locale.opacityLabel}
         <OpacityField
           opacity={opacity}
-          label={locale.opacityLabel}
           onChange={this.onOpacityChange}
-        />
+          />
+        {locale.sizeLabel}
         <WidthField
           width={size}
-          label={locale.sizeLabel}
           onChange={this.onSizeChange}
         />
+        {locale.offsetXLabel}
         <OffsetField
           offset={offsetX}
-          label={locale.offsetXLabel}
           onChange={this.onOffsetXChange}
         />
+        {locale.offsetYLabel}
         <OffsetField
           offset={offsetY}
-          label={locale.offsetYLabel}
           onChange={this.onOffsetYChange}
         />
+        {locale.rotateLabel}
         <RotateField
           rotate={rotate}
-          label={locale.rotateLabel}
           onChange={this.onRotateChange}
         />
+        {locale.haloColorLabel}
         <ColorField
           color={haloColor}
-          label={locale.haloColorLabel}
           onChange={this.onHaloColorChange}
-        />
+          />
+        {locale.haloWidthLabel}
         <WidthField
           width={haloWidth}
-          label={locale.haloWidthLabel}
           onChange={this.onHaloWidthChange}
         />
       </div>

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -13,7 +13,6 @@ import RotateField from '../Field/RotateField/RotateField';
 import en_US from '../../../locale/en_US';
 
 const _cloneDeep = require('lodash/cloneDeep');
-const _get = require('lodash/get');
 const _isEqual = require('lodash/isEqual');
 
 // i18n
@@ -148,39 +147,39 @@ export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProp
 
     return (
       <div>
+        {locale.radiusLabel}
         <RadiusField
-          label={_get(locale, 'radiusLabel')}
           radius={radius}
           onChange={this.onRadiusChange}
         />
+        {locale.fillColorLabel}
         <ColorField
           color={color}
-          label={_get(locale, 'fillColorLabel')}
           onChange={this.onColorChange}
         />
+        {locale.fillOpacityLabel}
         <OpacityField
           opacity={opacity}
-          label={_get(locale, 'fillOpacityLabel')}
           onChange={this.onOpacityChange}
         />
+        {locale.strokeColorLabel}
         <ColorField
           color={strokeColor}
-          label={_get(locale, 'strokeColorLabel')}
           onChange={this.onStrokeColorChange}
         />
+        {locale.strokeWidthLabel}
         <WidthField
           width={strokeWidth}
-          label={_get(locale, 'strokeWidthLabel')}
           onChange={this.onStrokeWidthChange}
         />
+        {locale.strokeOpacityLabel}
         <OpacityField
           opacity={strokeOpacity}
-          label={_get(locale, 'strokeOpacityLabel')}
           onChange={this.onStrokeOpacityChange}
         />
+        {locale.rotateLabel}
         <RotateField
           rotate={rotate}
-          label={_get(locale, 'rotateLabel')}
           onChange={this.onRotateChange}
         />
       </div>

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -11,6 +11,7 @@ import RadiusField from '../Field/RadiusField/RadiusField';
 import WidthField from '../Field/WidthField/WidthField';
 import RotateField from '../Field/RotateField/RotateField';
 import en_US from '../../../locale/en_US';
+import { Form } from 'antd';
 
 const _cloneDeep = require('lodash/cloneDeep');
 const _isEqual = require('lodash/isEqual');
@@ -145,43 +146,76 @@ export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProp
       locale
     } = this.props;
 
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
     return (
       <div>
-        {locale.radiusLabel}
-        <RadiusField
-          radius={radius}
-          onChange={this.onRadiusChange}
-        />
-        {locale.fillColorLabel}
-        <ColorField
-          color={color}
-          onChange={this.onColorChange}
-        />
-        {locale.fillOpacityLabel}
-        <OpacityField
-          opacity={opacity}
-          onChange={this.onOpacityChange}
-        />
-        {locale.strokeColorLabel}
-        <ColorField
-          color={strokeColor}
-          onChange={this.onStrokeColorChange}
-        />
-        {locale.strokeWidthLabel}
-        <WidthField
-          width={strokeWidth}
-          onChange={this.onStrokeWidthChange}
-        />
-        {locale.strokeOpacityLabel}
-        <OpacityField
-          opacity={strokeOpacity}
-          onChange={this.onStrokeOpacityChange}
-        />
-        {locale.rotateLabel}
-        <RotateField
-          rotate={rotate}
-          onChange={this.onRotateChange}
-        />
+        <Form.Item
+          label={locale.radiusLabel}
+          {...formItemLayout}
+        >
+          <RadiusField
+            radius={radius}
+            onChange={this.onRadiusChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.fillColorLabel}
+          {...formItemLayout}
+        >
+          <ColorField
+            color={color}
+            onChange={this.onColorChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.fillOpacityLabel}
+          {...formItemLayout}
+        >
+          <OpacityField
+            opacity={opacity}
+            onChange={this.onOpacityChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.strokeColorLabel}
+          {...formItemLayout}
+        >
+          <ColorField
+            color={strokeColor}
+            onChange={this.onStrokeColorChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.strokeWidthLabel}
+          {...formItemLayout}
+        >
+          <WidthField
+            width={strokeWidth}
+            onChange={this.onStrokeWidthChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.strokeOpacityLabel}
+          {...formItemLayout}
+        >
+          <OpacityField
+            opacity={strokeOpacity}
+            onChange={this.onStrokeOpacityChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.rotateLabel}
+          {...formItemLayout}
+        >
+          <RotateField
+            rotate={rotate}
+            onChange={this.onRotateChange}
+          />
+        </Form.Item>
       </div>
     );
   }

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -124,7 +124,6 @@ export default {
         chooseText: 'Wählen',
     },
     GsKindField: {
-        label: 'Art',
         symbolizerKinds: {
             Mark: 'Punktsymbol',
             Fill: 'Füllung',
@@ -140,7 +139,6 @@ export default {
         maxScaleDenominatorPlaceholderText: 'Max. Maßstabszahl eingeben (Optional)'
     },
     GsWellKnownNameField: {
-        label: 'Symbol',
         wellKnownNames: {
           Circle: 'Kreis',
           Square: 'Quadrat',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -91,6 +91,9 @@ export default {
         graphicStrokeTypeLabel: 'Graphic Stroke Type',
         graphicFillTypeLabel: 'Graphic Fill Type'
     },
+    GsMarkEditor: {
+      wellKnownNameFieldLabel: 'Symbol'
+    },
     GsTextEditor: {
         templateFieldLabel: 'Textvorlage',
         opacityLabel: 'Deckkraft',
@@ -151,6 +154,9 @@ export default {
     GsGraphicTypeField: {
         Mark: 'Punktsymbol',
         Icon: 'Bilddatei'
+    },
+    GsSymbolizerEditor: {
+      kindFieldLabel: 'Art'
     },
     GsSymbolizerEditorWindow: {
       symbolizersEditor: 'Symbolisierungseditor'

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -81,6 +81,9 @@ export default {
         opacityLabel: 'Opacity',
         iconTooltipLabel: 'Open Gallery'
     },
+    GsMarkEditor: {
+      wellKnownNameFieldLabel: 'Symbol'
+    },
     GsLineEditor: {
         colorLabel: 'Color',
         widthLabel: 'Width',
@@ -127,7 +130,6 @@ export default {
         chooseText: 'Pick',
     },
     GsKindField: {
-        label: 'Kind',
         symbolizerKinds: {
             Mark: 'Mark',
             Fill: 'Fill',
@@ -147,7 +149,6 @@ export default {
         maxScaleDenominatorPlaceholderText: 'Enter max. Scale (Optional)'
     },
     GsWellKnownNameField: {
-        label: 'Symbol',
         wellKnownNames: {
           Circle: 'Circle',
           Square: 'Square',
@@ -156,6 +157,9 @@ export default {
           Cross: 'Cross',
           X: 'X'
         }
+    },
+    GsSymbolizerEditor: {
+      kindFieldLabel: 'Kind'
     },
     GsSymbolizerEditorWindow: {
       symbolizersEditor: 'Symbolizer Editor'

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -92,6 +92,9 @@ export default {
         graphicStrokeTypeLabel: 'Tipo de gráfico de trazado',
         graphicFillTypeLabel: 'Tipo de gráfico de relleno'
     },
+    GsMarkEditor: {
+      wellKnownNameFieldLabel: 'Simbolo'
+    },
     GsTextEditor: {
         templateFieldLabel: 'Plantilla',
         opacityLabel: 'Texto-Transparencia',
@@ -127,7 +130,6 @@ export default {
         chooseText: 'Elegir',
     },
     GsKindField: {
-        label: 'Tipo',
         symbolizerKinds: {
             Mark: 'Marcador',
             Fill: 'Relleno',
@@ -147,7 +149,6 @@ export default {
         maxScaleDenominatorPlaceholderText: 'Ingrese escala max. (Opcionar)'
     },
     GsWellKnownNameField: {
-        label: 'Simbolo',
         wellKnownNames: {
           Circle: 'Círculo',
           Square: 'Cuadrado',
@@ -156,6 +157,9 @@ export default {
           Cross: 'Cruz',
           X: 'X'
         }
+    },
+    GsSymbolizerEditor: {
+      kindFieldLabel: 'Tipo'
     },
     GsSymbolizerEditorWindow: {
       symbolizersEditor: 'Editor de simbología'


### PR DESCRIPTION
**BREAKING CHANGE**


This changes the handling of EditorFields.

1. This removes all labels from the EditorFields
2. The labels are now added by the Editors via `Form.Item`s from antd.

TODOS:
  - [x] Check and fix styling via Demo
  - [x] Check transformation of Editors to antd forms. (Could be very useful for validation and/or disabling fields for `unsupportedProperties`)