### PR TITLE
Mapbox RasterSymbolizer

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.spec.tsx
+++ b/src/Component/CodeEditor/CodeEditor.spec.tsx
@@ -175,7 +175,7 @@ describe('CodeEditor', () => {
     it('calls "updateValueFromStyle"', () => {
       const updateValueFromStyleDummy = wrapper.instance().updateValueFromStyle = jest.fn();
       const onSelect = wrapper.instance().onSelect;
-      onSelect(SldStyleParser.title);
+      onSelect(sldStyleParser.title);
       expect(updateValueFromStyleDummy).toBeCalledWith(dummyStyle);
     });
   });

--- a/src/Component/CodeEditor/CodeEditor.spec.tsx
+++ b/src/Component/CodeEditor/CodeEditor.spec.tsx
@@ -175,7 +175,7 @@ describe('CodeEditor', () => {
     it('calls "updateValueFromStyle"', () => {
       const updateValueFromStyleDummy = wrapper.instance().updateValueFromStyle = jest.fn();
       const onSelect = wrapper.instance().onSelect;
-      onSelect(sldStyleParser.title);
+      onSelect(sldParser.title);
       expect(updateValueFromStyleDummy).toBeCalledWith(dummyStyle);
     });
   });

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -295,6 +295,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
     if (hasError) {
       return <h1>An error occured in the CodeEditor UI.</h1>;
     }
+
     return (
       <div className="gs-code-editor">
         <div className="gs-code-editor-toolbar" >

--- a/src/Component/DataInput/StyleLoader/StyleLoader.spec.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.spec.tsx
@@ -1,12 +1,14 @@
 import { StyleLoader, StyleLoaderProps } from './StyleLoader';
 import SldStyleParser from 'geostyler-sld-parser';
+import { StyleParser } from 'geostyler-style';
 import TestUtil from '../../../Util/TestUtil';
 
 describe('StyleLoader', () => {
   let wrapper: any;
+  const sldStyleParser: StyleParser = new SldStyleParser();
   beforeEach(() => {
     const props: StyleLoaderProps = {
-      parsers: [SldStyleParser]
+      parsers: [sldStyleParser]
     };
     wrapper = TestUtil.shallowRenderComponent(StyleLoader, props);
   });
@@ -26,7 +28,7 @@ describe('StyleLoader', () => {
     });
     it('calls readFile and onError with the expected arguments', async () => {
       wrapper.setState({
-        activeParser: SldStyleParser
+        activeParser: sldStyleParser
       });
       wrapper.instance().readFile = jest.fn();
       const onErrorMock = jest.fn();
@@ -58,7 +60,7 @@ describe('StyleLoader', () => {
       const parserTitle = 'SLD Style Parser';
       expect(wrapper.state('activeParser')).toBeUndefined();
       wrapper.instance().onSelect(parserTitle);
-      expect(wrapper.state('activeParser')).toBe(SldStyleParser);
+      expect(wrapper.state('activeParser')).toBe(sldStyleParser);
     });
   });
 });

--- a/src/Component/Symbolizer/Editor/Editor.css
+++ b/src/Component/Symbolizer/Editor/Editor.css
@@ -1,3 +1,7 @@
 .gs-symbolizer-editor .editor-field {
   width: 200px;
 }
+
+.gs-symbolizer-editor .ant-form-item {
+  margin: 0;
+}

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -24,6 +24,7 @@ import { IconLibrary } from '../IconSelector/IconSelector';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { Form } from 'antd';
+import RasterEditor from '../RasterEditor/RasterEditor';
 
 // i18n
 export interface EditorLocale {
@@ -133,6 +134,13 @@ export class Editor extends React.Component<EditorProps, EditorState> {
             symbolizer={symbolizer}
             onSymbolizerChange={this.onSymbolizerChange}
             internalDataDef={this.props.internalDataDef}
+          />
+        );
+      case 'Raster':
+        return (
+          <RasterEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={this.onSymbolizerChange}
           />
         );
       default:

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.example.md
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.example.md
@@ -1,0 +1,38 @@
+This demonstrates the use of `BrightnessField`.
+
+```jsx
+import * as React from 'react';
+
+class BrightnessFieldExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      brightness: 10
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(brightness) {
+    this.setState({
+      brightness: brightness
+    });
+  }
+
+  render() {
+    const {
+      brightness
+    } = this.state;
+
+    return (
+      <BrightnessField
+        brightness={brightness}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+<BrightnessFieldExample />
+```

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.spec.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.spec.tsx
@@ -1,0 +1,20 @@
+import { BrightnessField, BrightnessFieldProps } from './BrightnessField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('BrightnessField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const props: BrightnessFieldProps = {};
+    wrapper = TestUtil.shallowRenderComponent(BrightnessField, props);
+  });
+
+  it('is defined', () => {
+    expect(BrightnessField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// non default props
+export interface BrightnessFieldProps {
+  onChange?: (opacity: number) => void;
+  brightness?: number;
+}
+
+/**
+ * Brightness Field
+ */
+export class BrightnessField extends React.PureComponent<BrightnessFieldProps> {
+
+  render() {
+    const {
+      onChange,
+      brightness
+    } = this.props;
+
+    return (
+      <InputNumber
+        className="editor-field brightness-field"
+        min={0}
+        max={1}
+        step={0.1}
+        value={brightness}
+        onChange={onChange}
+      />
+    );
+  }
+}
+
+export default BrightnessField;

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -102,7 +102,7 @@ export class ColorField extends React.Component<ColorFieldProps, ColorFieldState
       <div className="editor-field color-field">
         <div className="color-preview-wrapper">
           <Button
-            className="color-preview"
+            className="color-preview editor-field"
             style={{
               backgroundColor: color,
               color: textColor

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.example.md
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.example.md
@@ -1,0 +1,38 @@
+This demonstrates the use of `ContrastField`.
+
+```jsx
+import * as React from 'react';
+
+class ContrastFieldExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      contrast: 0
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(contrast) {
+    this.setState({
+      contrast: contrast
+    });
+  }
+
+  render() {
+    const {
+      contrast
+    } = this.state;
+
+    return (
+      <ContrastField
+        contrast={contrast}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+<ContrastFieldExample />
+```

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.spec.tsx
@@ -1,0 +1,20 @@
+import { ContrastField, ContrastFieldProps } from './ContrastField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('ContrastField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const props: ContrastFieldProps = {};
+    wrapper = TestUtil.shallowRenderComponent(ContrastField, props);
+  });
+
+  it('is defined', () => {
+    expect(ContrastField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// non default props
+export interface ContrastFieldProps {
+  onChange?: (opacity: number) => void;
+  contrast?: number;
+}
+
+/**
+ * ContrastField
+ */
+export class ContrastField extends React.PureComponent<ContrastFieldProps> {
+
+  render() {
+    const {
+      onChange,
+      contrast
+    } = this.props;
+
+    return (
+      <InputNumber
+        className="editor-field contrast-field"
+        min={-1}
+        max={1}
+        step={0.1}
+        value={contrast}
+        onChange={onChange}
+      />
+    );
+  }
+}
+
+export default ContrastField;

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.example.md
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.example.md
@@ -1,0 +1,38 @@
+This demonstrates the use of `FadeDurationField`.
+
+```jsx
+import * as React from 'react';
+
+class FadeDurationFieldExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      fadeDuration: 300
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(fadeDuration) {
+    this.setState({
+      fadeDuration: fadeDuration
+    });
+  }
+
+  render() {
+    const {
+      fadeDuration
+    } = this.state;
+
+    return (
+      <FadeDurationField
+        contrast={contrast}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+<FadeDurationFieldExample />
+```

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.spec.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.spec.tsx
@@ -1,0 +1,20 @@
+import { FadeDurationField, FadeDurationFieldProps } from './FadeDurationField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('FadeDurationField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const props: FadeDurationFieldProps = {};
+    wrapper = TestUtil.shallowRenderComponent(FadeDurationField, props);
+  });
+
+  it('is defined', () => {
+    expect(FadeDurationField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// non default props
+export interface FadeDurationFieldProps {
+  onChange?: (opacity: number) => void;
+  fadeDuration?: number;
+}
+
+/**
+ * FadeDurationField
+ */
+export class FadeDurationField extends React.PureComponent<FadeDurationFieldProps> {
+
+  render() {
+    const {
+      onChange,
+      fadeDuration
+    } = this.props;
+
+    return (
+      <InputNumber
+        className="editor-field fadeDuration-field"
+        min={0}
+        step={10}
+        value={fadeDuration}
+        onChange={onChange}
+      />
+    );
+  }
+}
+
+export default FadeDurationField;

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -20,6 +20,7 @@ export interface KindFieldLocale {
     Icon: string;
     Line: string;
     Text: string;
+    Raster: string;
   };
 }
 
@@ -43,7 +44,7 @@ export class KindField extends React.Component<KindFieldProps> {
   public static defaultProps: KindFieldDefaultProps = {
     locale: en_US.GsKindField,
     kind: 'Mark',
-    symbolizerKinds: ['Mark', 'Fill', 'Icon', 'Line', 'Text']
+    symbolizerKinds: ['Mark', 'Fill', 'Icon', 'Line', 'Text', 'Raster']
   };
 
   public shouldComponentUpdate(nextProps: KindFieldProps): boolean {

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 import {
   InputNumber
 } from 'antd';
+import { InputNumberProps } from 'antd/lib/input-number';
 
 // non default props
-export interface OpacityFieldProps {
+export interface OpacityFieldProps extends Partial<InputNumberProps> {
   onChange?: (opacity: number) => void;
   opacity?: number;
 }
@@ -18,7 +19,8 @@ export class OpacityField extends React.PureComponent<OpacityFieldProps> {
   render() {
     const {
       onChange,
-      opacity
+      opacity,
+      ...inputProps
     } = this.props;
 
     return (
@@ -29,6 +31,7 @@ export class OpacityField extends React.PureComponent<OpacityFieldProps> {
         step={0.01}
         value={opacity}
         onChange={onChange}
+        {...inputProps}
       />
     );
   }

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.example.md
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.example.md
@@ -1,0 +1,39 @@
+This demonstrates the use of `ResamplingField`.
+
+```jsx
+import * as React from 'react';
+
+class ResamplingFieldExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      resampling: 'linear'
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(resampling) {
+    this.setState({
+      resampling: resampling
+    });
+  }
+
+  render() {
+    const {
+      resampling
+    } = this.state;
+
+    return (
+      <ResamplingField
+        resampling={resampling}
+        resamplingOptions={['linear', 'nearest']}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+<ResamplingFieldExample />
+```

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.spec.tsx
@@ -1,0 +1,20 @@
+import { ResamplingField, ResamplingFieldProps } from './ResamplingField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('ResamplingField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const props: ResamplingFieldProps = {};
+    wrapper = TestUtil.shallowRenderComponent(ResamplingField, props);
+  });
+
+  it('is defined', () => {
+    expect(ResamplingField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import {
+  Select
+} from 'antd';
+const Option = Select.Option;
+
+import {
+    RasterSymbolizer
+} from 'geostyler-style';
+
+// default props
+interface ResamplingFieldDefaultProps {
+  resamplingOptions: RasterSymbolizer['resampling'][];
+}
+
+// non default props
+export interface ResamplingFieldProps extends Partial<ResamplingFieldDefaultProps> {
+  onChange?: (resamplings: RasterSymbolizer['resampling']) => void;
+  resampling?: RasterSymbolizer['resampling'];
+}
+
+/**
+ * ResamplingField to select between different resampling options
+ */
+export class ResamplingField extends React.Component<ResamplingFieldProps> {
+
+  public static defaultProps: ResamplingFieldDefaultProps = {
+    resamplingOptions: ['linear', 'nearest']
+  };
+
+  getResamplingSelectOptions = () => {
+    return this.props.resamplingOptions.map(resamplingOpt => {
+        return (
+            <Option
+                key={resamplingOpt}
+                value={resamplingOpt}
+            >
+            {resamplingOpt}
+            </Option>
+        );
+    });
+  }
+
+  render() {
+    const {
+      resampling,
+      onChange
+    } = this.props;
+
+    return (
+      <Select
+        className="editor-field resampling-field"
+        allowClear={true}
+        value={resampling}
+        onChange={onChange}
+      >
+        {this.getResamplingSelectOptions()}
+      </Select>
+    );
+  }
+}
+
+export default ResamplingField;

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.example.md
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.example.md
@@ -1,0 +1,38 @@
+This demonstrates the use of `SaturationField`.
+
+```jsx
+import * as React from 'react';
+
+class SaturationFieldExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      saturation: 0
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(saturation) {
+    this.setState({
+      saturation: saturation
+    });
+  }
+
+  render() {
+    const {
+      saturation
+    } = this.state;
+
+    return (
+      <SaturationField
+        saturation={saturation}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+<SaturationFieldExample />
+```

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.spec.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.spec.tsx
@@ -1,0 +1,20 @@
+import { SaturationField, SaturationFieldProps } from './SaturationField';
+import TestUtil from '../../../../Util/TestUtil';
+
+describe('SaturationField', () => {
+
+  let wrapper: any;
+  beforeEach(() => {
+    const props: SaturationFieldProps = {};
+    wrapper = TestUtil.shallowRenderComponent(SaturationField, props);
+  });
+
+  it('is defined', () => {
+    expect(SaturationField).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+});

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import {
+  InputNumber
+} from 'antd';
+
+// non default props
+export interface SaturationFieldProps {
+  onChange?: (opacity: number) => void;
+  saturation?: number;
+}
+
+/**
+ * SaturationField
+ */
+export class SaturationField extends React.PureComponent<SaturationFieldProps> {
+
+  render() {
+    const {
+      onChange,
+      saturation
+    } = this.props;
+
+    return (
+      <InputNumber
+        className="editor-field saturation-field"
+        min={-1}
+        max={1}
+        step={0.1}
+        value={saturation}
+        onChange={onChange}
+      />
+    );
+  }
+}
+
+export default SaturationField;

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
@@ -1,0 +1,42 @@
+This demonstrates the use of `RasterEditor`.
+
+```jsx
+const React = require('react');
+const { RasterEditor } = require('../../../index');
+require('antd/dist/antd.css');
+
+class RasterEditorExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      symbolizer: {
+        kind: 'Raster'
+      }
+    };
+
+    this.onSymbolizerChange = this.onSymbolizerChange.bind(this);
+  }
+
+  onSymbolizerChange(symbolizer) {
+    this.setState({
+      symbolizer: symbolizer
+    });
+  }
+
+  render() {
+    const {
+      symbolizer
+    } = this.state;
+
+    return (
+      <RasterEditor
+        symbolizer={symbolizer}
+        onSymbolizerChange={this.onSymbolizerChange}
+      />
+    );
+  }
+}
+
+<RasterEditorExample />
+```

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
@@ -1,0 +1,111 @@
+import { RasterEditor, RasterEditorProps } from './RasterEditor';
+import SymbolizerUtil from '../../../Util/SymbolizerUtil';
+import TestUtil from '../../../Util/TestUtil';
+import en_US from '../../../locale/en_US';
+import { RasterSymbolizer, MarkSymbolizer } from 'geostyler-style';
+
+describe('RasterEditor', () => {
+
+  let wrapper: any;
+  let dummySymbolizer: RasterSymbolizer = SymbolizerUtil.generateSymbolizer('Raster') as RasterSymbolizer;
+  let onSymbolizerChangeDummy: jest.Mock;
+
+  beforeEach(() => {
+    onSymbolizerChangeDummy = jest.fn();
+    const props: RasterEditorProps = {
+      symbolizer: dummySymbolizer,
+      locale: en_US.GsRasterEditor,
+      onSymbolizerChange: onSymbolizerChangeDummy
+    };
+    wrapper = TestUtil.shallowRenderComponent(RasterEditor, props);
+  });
+
+  it('is defined', () => {
+    expect(RasterEditor).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  describe('onOpacityChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onOpacityChange = wrapper.instance().onOpacityChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.opacity = 0.5;
+      onOpacityChange(0.5);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onHueRotateChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onHueRotateChange = wrapper.instance().onHueRotateChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.hueRotate = 90;
+      onHueRotateChange(90);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onBrightnessMinChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onBrightnessMinChange = wrapper.instance().onBrightnessMinChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.brightnessMin = 0;
+      onBrightnessMinChange(0);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onBrightnessMaxChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onBrightnessMaxChange = wrapper.instance().onBrightnessMaxChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.brightnessMax = 1;
+      onBrightnessMaxChange(1);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onSaturationChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onSaturationChange = wrapper.instance().onSaturationChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.saturation = 1;
+      onSaturationChange(1);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onContrastChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onContrastChange = wrapper.instance().onContrastChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.contrast = 1;
+      onContrastChange(1);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onFadeDurationChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onFadeDurationChange = wrapper.instance().onFadeDurationChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.fadeDuration = 400;
+      onFadeDurationChange(400);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onResamplingChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onResamplingChange = wrapper.instance().onResamplingChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.resampling = 'linear';
+      onResamplingChange('linear');
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+});

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
@@ -2,7 +2,7 @@ import { RasterEditor, RasterEditorProps } from './RasterEditor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import TestUtil from '../../../Util/TestUtil';
 import en_US from '../../../locale/en_US';
-import { RasterSymbolizer, MarkSymbolizer } from 'geostyler-style';
+import { RasterSymbolizer } from 'geostyler-style';
 
 describe('RasterEditor', () => {
 
@@ -37,75 +37,4 @@ describe('RasterEditor', () => {
       expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
     });
   });
-
-  describe('onHueRotateChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onHueRotateChange = wrapper.instance().onHueRotateChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.hueRotate = 90;
-      onHueRotateChange(90);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onBrightnessMinChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onBrightnessMinChange = wrapper.instance().onBrightnessMinChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.brightnessMin = 0;
-      onBrightnessMinChange(0);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onBrightnessMaxChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onBrightnessMaxChange = wrapper.instance().onBrightnessMaxChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.brightnessMax = 1;
-      onBrightnessMaxChange(1);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onSaturationChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onSaturationChange = wrapper.instance().onSaturationChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.saturation = 1;
-      onSaturationChange(1);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onContrastChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onContrastChange = wrapper.instance().onContrastChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.contrast = 1;
-      onContrastChange(1);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onFadeDurationChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onFadeDurationChange = wrapper.instance().onFadeDurationChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.fadeDuration = 400;
-      onFadeDurationChange(400);
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
-  describe('onResamplingChange', () => {
-    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
-      const onResamplingChange = wrapper.instance().onResamplingChange;
-      const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.resampling = 'linear';
-      onResamplingChange('linear');
-      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
-    });
-  });
-
 });

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -9,12 +9,6 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { Form } from 'antd';
 import OpacityField from '../Field/OpacityField/OpacityField';
-import RotateField from '../Field/RotateField/RotateField';
-import BrightnessField from '../Field/BrightnessField/BrightnessField';
-import SaturationField from '../Field/SaturationField/SaturationField';
-import ContrastField from '../Field/ContrastField/ContrastField';
-import FadeDurationField from '../Field/FadeDurationField/FadeDurationField';
-import ResamplingField from '../Field/ResamplingField/ResamplingField';
 import { Data } from 'geostyler-data';
 
 const _cloneDeep = require('lodash/cloneDeep');
@@ -64,83 +58,6 @@ export class RasterEditor extends React.Component<RasterEditorProps> {
     }
   }
 
-  onHueRotateChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.hueRotate = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onBrightnessMinChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.brightnessMin = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onBrightnessMaxChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.brightnessMax = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onSaturationChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.saturation = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onContrastChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.contrast = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onFadeDurationChange = (value: number) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.fadeDuration = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
-  onResamplingChange = (value: RasterSymbolizer['resampling']) => {
-    const {
-      onSymbolizerChange
-    } = this.props;
-    const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.resampling = value;
-    if (onSymbolizerChange) {
-      onSymbolizerChange(symbolizer);
-    }
-  }
-
   render() {
     const {
       locale,
@@ -148,14 +65,7 @@ export class RasterEditor extends React.Component<RasterEditorProps> {
     } = this.props;
 
     const {
-      opacity,
-      hueRotate,
-      brightnessMin,
-      brightnessMax,
-      saturation,
-      contrast,
-      fadeDuration,
-      resampling
+      opacity
     } = symbolizer;
 
     const formItemLayout = {
@@ -172,69 +82,6 @@ export class RasterEditor extends React.Component<RasterEditorProps> {
           <OpacityField
             opacity={opacity}
             onChange={this.onOpacityChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.hueRotateLabel}
-          {...formItemLayout}
-        >
-          <RotateField
-            rotate={hueRotate}
-            onChange={this.onHueRotateChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.brightnessMinLabel}
-          {...formItemLayout}
-        >
-          <BrightnessField
-            brightness={brightnessMin}
-            onChange={this.onBrightnessMinChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.brightnessMaxLabel}
-          {...formItemLayout}
-        >
-          <BrightnessField
-            brightness={brightnessMax}
-            onChange={this.onBrightnessMaxChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.saturationLabel}
-          {...formItemLayout}
-        >
-          <SaturationField
-            saturation={saturation}
-            onChange={this.onSaturationChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.contrastLabel}
-          {...formItemLayout}
-        >
-          <ContrastField
-            contrast={contrast}
-            onChange={this.onContrastChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.fadeDurationLabel}
-          {...formItemLayout}
-        >
-          <FadeDurationField
-            fadeDuration={fadeDuration}
-            onChange={this.onFadeDurationChange}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.resamplingLabel}
-          {...formItemLayout}
-        >
-          <ResamplingField
-            resampling={resampling}
-            onChange={this.onResamplingChange}
           />
         </Form.Item>
       </div>

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+
+import {
+  Symbolizer,
+  RasterSymbolizer
+} from 'geostyler-style';
+
+import { localize } from '../../LocaleWrapper/LocaleWrapper';
+import en_US from '../../../locale/en_US';
+import { Form } from 'antd';
+import OpacityField from '../Field/OpacityField/OpacityField';
+import RotateField from '../Field/RotateField/RotateField';
+import BrightnessField from '../Field/BrightnessField/BrightnessField';
+import SaturationField from '../Field/SaturationField/SaturationField';
+import ContrastField from '../Field/ContrastField/ContrastField';
+import FadeDurationField from '../Field/FadeDurationField/FadeDurationField';
+import ResamplingField from '../Field/ResamplingField/ResamplingField';
+import { Data } from 'geostyler-data';
+
+const _cloneDeep = require('lodash/cloneDeep');
+
+// i18n
+export interface RasterEditorLocale {
+  opacityLabel?: string;
+  hueRotateLabel?: string;
+  brightnessMinLabel?: string;
+  brightnessMaxLabel?: string;
+  saturationLabel?: string;
+  contrastLabel?: string;
+  fadeDurationLabel?: string;
+  resamplingLabel?: string;
+  contrastEnhancementLabel?: string;
+  gammaValueLabel?: string;
+}
+
+// default props
+interface RasterEditorDefaultProps {
+  locale: RasterEditorLocale;
+}
+
+// non default props
+export interface RasterEditorProps extends Partial<RasterEditorDefaultProps> {
+  symbolizer: RasterSymbolizer;
+  onSymbolizerChange?: (changedSymb: Symbolizer) => void;
+  internalDataDef?: Data;
+}
+
+export class RasterEditor extends React.Component<RasterEditorProps> {
+
+  static componentName: string = 'RasterEditor';
+
+  public static defaultProps: RasterEditorDefaultProps = {
+    locale: en_US.GsRasterEditor
+  };
+
+  onOpacityChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.opacity = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onHueRotateChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.hueRotate = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onBrightnessMinChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.brightnessMin = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onBrightnessMaxChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.brightnessMax = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onSaturationChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.saturation = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onContrastChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.contrast = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onFadeDurationChange = (value: number) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.fadeDuration = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  onResamplingChange = (value: RasterSymbolizer['resampling']) => {
+    const {
+      onSymbolizerChange
+    } = this.props;
+    const symbolizer = _cloneDeep(this.props.symbolizer);
+    symbolizer.resampling = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizer);
+    }
+  }
+
+  render() {
+    const {
+      locale,
+      symbolizer
+    } = this.props;
+
+    const {
+      opacity,
+      hueRotate,
+      brightnessMin,
+      brightnessMax,
+      saturation,
+      contrast,
+      fadeDuration,
+      resampling
+    } = symbolizer;
+
+    const formItemLayout = {
+      labelCol: { span: 8 },
+      wrapperCol: { span: 16 }
+    };
+
+    return (
+      <div className="gs-raster-symbolizer-editor" >
+        <Form.Item
+          label={locale.opacityLabel}
+          {...formItemLayout}
+        >
+          <OpacityField
+            opacity={opacity}
+            onChange={this.onOpacityChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.hueRotateLabel}
+          {...formItemLayout}
+        >
+          <RotateField
+            rotate={hueRotate}
+            onChange={this.onHueRotateChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.brightnessMinLabel}
+          {...formItemLayout}
+        >
+          <BrightnessField
+            brightness={brightnessMin}
+            onChange={this.onBrightnessMinChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.brightnessMaxLabel}
+          {...formItemLayout}
+        >
+          <BrightnessField
+            brightness={brightnessMax}
+            onChange={this.onBrightnessMaxChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.saturationLabel}
+          {...formItemLayout}
+        >
+          <SaturationField
+            saturation={saturation}
+            onChange={this.onSaturationChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.contrastLabel}
+          {...formItemLayout}
+        >
+          <ContrastField
+            contrast={contrast}
+            onChange={this.onContrastChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.fadeDurationLabel}
+          {...formItemLayout}
+        >
+          <FadeDurationField
+            fadeDuration={fadeDuration}
+            onChange={this.onFadeDurationChange}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.resamplingLabel}
+          {...formItemLayout}
+        >
+          <ResamplingField
+            resampling={resampling}
+            onChange={this.onResamplingChange}
+          />
+        </Form.Item>
+      </div>
+    );
+  }
+}
+
+export default localize(RasterEditor, RasterEditor.componentName);

--- a/src/Util/SymbolizerUtil.ts
+++ b/src/Util/SymbolizerUtil.ts
@@ -5,7 +5,8 @@ import {
   SymbolizerKind,
   TextSymbolizer,
   LineSymbolizer,
-  FillSymbolizer
+  FillSymbolizer,
+  RasterSymbolizer
 } from 'geostyler-style';
 
 /**
@@ -41,6 +42,10 @@ class SymbolizerUtil {
     size: 12
   };
 
+  static rasterSymbolizer: RasterSymbolizer = {
+    kind: 'Raster'
+  };
+
   static defaultSymbolizer: Symbolizer = SymbolizerUtil.markSymbolizer;
 
   /**
@@ -73,6 +78,11 @@ class SymbolizerUtil {
       case 'Text':
         return {
           ...SymbolizerUtil.textSymbolizer,
+          ...values
+        };
+      case 'Raster':
+        return {
+          ...SymbolizerUtil.rasterSymbolizer,
           ...values
         };
       default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,19 @@
   Copyright (c) 2018 terrestris GmbH & Co. KG
   Licensed under the BSD 2-Clause "Simplified" License, see
   https://github.com/terrestris/geostyler/blob/master/LICENSE
-*/
+  */
 import AttributeCombo from './Component/Filter/AttributeCombo/AttributeCombo';
 import BoolFilterField from './Component/Filter/BoolFilterField/BoolFilterField';
+import BrightnessField from './Component/Symbolizer/Field/BrightnessField/BrightnessField';
 import BulkEditModals from './Component/Symbolizer/BulkEditModals/BulkEditModals';
 import CodeEditor from './Component/CodeEditor/CodeEditor';
 import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
 import ComparisonFilter from './Component/Filter/ComparisonFilter/ComparisonFilter';
+import ContrastField from './Component/Symbolizer/Field/ContrastField/ContrastField';
 import DataLoader from './Component/DataInput/DataLoader/DataLoader';
 import DataProvider from './DataProvider/DataProvider';
 import Editor from './Component/Symbolizer/Editor/Editor';
+import FadeDurationField from './Component/Symbolizer/Field/FadeDurationField/FadeDurationField';
 import FieldSet from './Component/FieldSet/FieldSet';
 import FillEditor from './Component/Symbolizer/FillEditor/FillEditor';
 import FilterEditorWindow from './Component/Filter/FilterEditorWindow/FilterEditorWindow';
@@ -39,10 +42,13 @@ import OperatorCombo from './Component/Filter/OperatorCombo/OperatorCombo';
 import Preview from './Component/Symbolizer/Preview/Preview';
 import PropTextEditor from './Component/Symbolizer/PropTextEditor/PropTextEditor';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
+import RasterEditor from './Component/Symbolizer/RasterEditor/RasterEditor';
 import RemoveButton from './Component/Rule/RemoveButton/RemoveButton';
 import Renderer from './Component/Symbolizer/Renderer/Renderer';
+import ResamplingField from './Component/Symbolizer/Field/ResamplingField/ResamplingField';
 import RotateField from './Component/Symbolizer/Field/RotateField/RotateField';
 import Rule from './Component/Rule/Rule';
+import SaturationField from './Component/Symbolizer/Field/SaturationField/SaturationField';
 import ScaleDenominator from './Component/ScaleDenominator/ScaleDenominator';
 import SizeField from './Component/Symbolizer/Field/SizeField/SizeField';
 import SLDRenderer from './Component/Symbolizer/SLDRenderer/SLDRenderer';
@@ -74,13 +80,16 @@ const locale = {
 export {
   AttributeCombo,
   BoolFilterField,
+  BrightnessField,
   BulkEditModals,
   CodeEditor,
   ColorField,
   ComparisonFilter,
+  ContrastField,
   DataLoader,
   DataProvider,
   Editor,
+  FadeDurationField,
   FieldSet,
   FillEditor,
   FilterEditorWindow,
@@ -111,10 +120,13 @@ export {
   Preview,
   PropTextEditor,
   RadiusField,
+  RasterEditor,
   RemoveButton,
   Renderer,
+  ResamplingField,
   RotateField,
   Rule,
+  SaturationField,
   ScaleDenominator,
   SizeField,
   SLDRenderer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
   Copyright (c) 2018 terrestris GmbH & Co. KG
   Licensed under the BSD 2-Clause "Simplified" License, see
   https://github.com/terrestris/geostyler/blob/master/LICENSE
-  */
+*/
 import AttributeCombo from './Component/Filter/AttributeCombo/AttributeCombo';
 import BoolFilterField from './Component/Filter/BoolFilterField/BoolFilterField';
 import BrightnessField from './Component/Symbolizer/Field/BrightnessField/BrightnessField';

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -118,6 +118,16 @@ export default {
         attributeComboPlaceholder: 'Feld wählen',
         rotateLabel: 'Drehung'
     },
+    GsRasterEditor: {
+        opacityLabel: 'Deckkraft',
+        hueRotateLabel: 'Farbtonrotation',
+        brightnessMinLabel: 'Min. Helligkeit',
+        brightnessMaxLabel: 'Max. Helligkeit',
+        saturationLabel: 'Sättigung',
+        contrastLabel: 'Kontrast',
+        fadeDurationLabel: 'Überblendzeit',
+        resamplingLabel: 'Resampling'
+    },
     GsPreview: {
         openEditorText: 'Symbolisierung editieren',
         closeEditorText: 'Editor schließen'
@@ -133,7 +143,8 @@ export default {
             Fill: 'Füllung',
             Icon: 'Bilddatei',
             Line: 'Linie',
-            Text: 'Text'
+            Text: 'Text',
+            Raster: 'Raster'
         }
     },
     GsScaleDenominator: {

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -121,6 +121,16 @@ export default {
         haloColorLabel: 'Halo-Color',
         haloWidthLabel: 'Halo-Width'
     },
+    GsRasterEditor: {
+        opacityLabel: 'Opacity',
+        hueRotateLabel: 'Hue Rotation',
+        brightnessMinLabel: 'Min. Brightness',
+        brightnessMaxLabel: 'Max. Brightness',
+        saturationLabel: 'Saturation',
+        contrastLabel: 'Contrast',
+        fadeDurationLabel: 'Fade Duration',
+        resamplingLabel: 'Resampling'
+    },
     GsPreview: {
         openEditorText: 'Edit Symbolizer',
         closeEditorText: 'Close Editor'
@@ -136,7 +146,8 @@ export default {
             Fill: 'Fill',
             Icon: 'Icon',
             Line: 'Line',
-            Text: 'Text'
+            Text: 'Text',
+            Raster: 'Raster'
         }
     },
     GsGraphicTypeField: {


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR](https://github.com/terrestris/geostyler-style/pull/113) in geostyler-style
- [x] [this PR](https://github.com/terrestris/geostyler-style/pull/116) in geostyler-style
- [ ] ~~[this PR](https://github.com/terrestris/geostyler-mapbox-parser/pull/25) in geostyler-mapbox-parser~~
was merged and released.

Created UI Components for RasterSymbolizer. Currently, only handles mapbox related properties. Those for SLD will be added in a separate PR.

This is how it looks, if all mapbox related UI Components are included:
![grafik](https://user-images.githubusercontent.com/12186477/55384711-b62f0400-552b-11e9-9be0-500fcf286184.png)

However, **only those components are included that comply with the SLD specification**
![image](https://user-images.githubusercontent.com/12186477/55790684-2a821e00-5abd-11e9-843b-81cc07ba79d0.png)

**Update:** geostyler-mapbox-parser is not necessarily needed. UI Components also work without it. But keep in mind that when parsing to other external formats, information might/will get lost. 