### PR TITLE
Fix gh-pages (travis-ci.org)

### DIFF
--- a/.ci/update-gh-pages.sh
+++ b/.ci/update-gh-pages.sh
@@ -12,12 +12,7 @@ if [ $TRAVIS_PULL_REQUEST != "false" ]; then
   return 0;
 fi
 
-if [ $TRAVIS_BRANCH != "master" ]; then
-  # Only update when the target branch is master.
-  return 0;
-fi
-
-if ! [ -n "$TRAVIS_TAG" ]; then
+if [ -z "$TRAVIS_TAG" ]; then
   # Only update when a tag was pushed / a new release was published
   return 0;
 fi


### PR DESCRIPTION
This fixes updating gh-pages when pushing tags.

gh-pages was not updated due to paradox if statements in the script. Previously, we checked if a tag was pushed AND branch is master. Now, we are only checking if a tag was pushed as the travis environment variable `$TRAVIS_BRANCH` equals the tagname when pushing tags. (=> never could be branch `master` AND tag).

The rest of the script was not changed as it should still work properly.