### PR TITLE
Revert "Update np to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jest": "24.7.1",
     "jest-canvas-mock": "2.0.0",
     "mini-css-extract-plugin": "0.6.0",
-    "np": "5.0.0",
+    "np": "4.0.2",
     "ol": "5.3.2",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION
Reverts terrestris/geostyler#973

This reverts the major upgrade of np as v5 requires npm >6.8.0 which comes only with node 12 via nvm.
But node 12 seems to conflict with the canvas package.