### PR TITLE
Add data to Renderer

### DIFF
--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -203,6 +203,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
 
   symbolizerRenderer = (text: string, record: RuleRecord) => {
     const {
+      data,
       rendererType,
       sldRendererProps
     } = this.props;
@@ -223,6 +224,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
           <Renderer
             symbolizers={record.symbolizers}
             onClick={onSymbolizerClick}
+            data={data}
           />
         )
     );

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -17,7 +17,7 @@ import './Renderer.css';
 
 import 'ol/ol.css';
 import './Renderer.css';
-import { Data, VectorData } from 'geostyler-data';
+import { Data } from 'geostyler-data';
 
 const _isEqual = require('lodash/isEqual');
 const _get = require('lodash/get');
@@ -82,18 +82,14 @@ export class Renderer extends React.Component<RendererProps> {
   }
 
   updateFeature() {
-    const vectorData = this.props.data as VectorData;
-    let featureProperties = {};
-
-    if (vectorData.exampleFeatures) {
-      featureProperties = vectorData.exampleFeatures.features[0].properties;
-    }
+    const data = this.props.data;
+    const exampleFeatureProps = _get(data, 'exampleFeatures.features[0].properties');
 
     this._layer.getSource().clear();
     const sampleFeature = new OlFeature({
       geometry: this.getSampleGeomFromSymbolizer(),
       Name: 'Sample Feature',
-      ...featureProperties
+      ...exampleFeatureProps
     });
     this._layer.getSource().addFeature(sampleFeature);
     // zoom to feature extent

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
 
-const _isEqual = require('lodash/isEqual');
-const _get = require('lodash/get');
-const _uniqueId = require('lodash/uniqueId');
-
 import OlMap from 'ol/Map';
 import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
@@ -21,9 +17,15 @@ import './Renderer.css';
 
 import 'ol/ol.css';
 import './Renderer.css';
+import { Data, VectorData } from 'geostyler-data';
+
+const _isEqual = require('lodash/isEqual');
+const _get = require('lodash/get');
+const _uniqueId = require('lodash/uniqueId');
 
 // non default props
 export interface RendererProps {
+  data?: Data;
   symbolizers: Symbolizer[];
   symbolizerKind?: SymbolizerKind;
   onClick?: (symbolizers: Symbolizer[], event: any) => void;
@@ -80,10 +82,18 @@ export class Renderer extends React.Component<RendererProps> {
   }
 
   updateFeature() {
+    const vectorData = this.props.data as VectorData;
+    let featureProperties = {};
+
+    if (vectorData.exampleFeatures) {
+      featureProperties = vectorData.exampleFeatures.features[0].properties;
+    }
+
     this._layer.getSource().clear();
     const sampleFeature = new OlFeature({
       geometry: this.getSampleGeomFromSymbolizer(),
-      Name: 'Sample Feature'
+      Name: 'Sample Feature',
+      ...featureProperties
     });
     this._layer.getSource().addFeature(sampleFeature);
     // zoom to feature extent

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
@@ -16,7 +16,7 @@ interface SLDRendererDefaultProps {
 export interface SLDRendererAdditonalProps extends Partial<SLDRendererDefaultProps> {
   wmsBaseUrl: string;
   layer: string;
-  rasterLayer: string;
+  rasterLayer?: string;
   additionalHeaders?: any;
   wmsParams?: any;
 }
@@ -115,7 +115,7 @@ export class SLDRenderer extends React.Component<SLDRendererProps, SLDRendererSt
       // as wms cannot return a mixed legendGraphic
       // TODO
       if (symbolizers.some((symbolizer: Symbolizer) => symbolizer.kind === 'Raster')) {
-        lyr = rasterLayer;
+        lyr = rasterLayer || layer;
       } else {
         lyr = layer;
       }


### PR DESCRIPTION
With this change the internal data gets passed to the `Renderer` so we can preview template strings with curly brackets: e.g:

![image](https://user-images.githubusercontent.com/1849416/56791753-24ec3e00-6808-11e9-82dd-8365e8b27367.png)

This also makes the `rasterLayer` prop of the `SLDRenderer` optional.
