### PR TITLE
Adapts typing for onChange method to antd changes

### DIFF
--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -7,7 +7,7 @@ import { InputNumberProps } from 'antd/lib/input-number';
 
 // non default props
 export interface OpacityFieldProps extends Partial<InputNumberProps> {
-  onChange?: (opacity: number) => void;
+  onChange?: (opacity: number | undefined) => void;
   opacity?: number;
 }
 


### PR DESCRIPTION
This adapts the typing of the `onChange` method to the typings of `InputNumberProps` from antd.