### PR TITLE
Removes deprecated "browsers" config from webpackconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17263,9 +17263,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
   "bugs": {
     "url": "https://github.com/terrestris/geostyler/issues"
   },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "homepage": "https://github.com/terrestris/geostyler",
   "scripts": {
     "build": "npm run build:dist && npm run build:browser && npm run build:styleguide",
@@ -120,7 +126,7 @@
     "ts-loader": "^5.3.3",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5",
+    "typescript": "^3.5.2",
     "url-loader": "^2.0.0",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.4",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -47,7 +47,7 @@ module.exports = {
       '.jsx',
     ],
     alias: {
-      
+
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
@@ -96,7 +96,7 @@ module.exports = {
             include: paths.appSrc,
             loader: require.resolve('babel-loader'),
             options: {
-              
+
               compact: true,
             },
           },
@@ -139,13 +139,7 @@ module.exports = {
                   plugins: () => [
                     require('postcss-flexbugs-fixes'),
                     autoprefixer({
-                      browsers: [
-                        '>1%',
-                        'last 4 versions',
-                        'Firefox ESR',
-                        'not ie < 9', // React doesn't support IE8 anyway
-                      ],
-                      flexbox: 'no-2009',
+                      flexbox: 'no-2009'
                     }),
                   ],
                 },


### PR DESCRIPTION
This replaces the deprecated `"browsers"` config in the `autoprefixer` plugin in the `webpack.common.config` with the `"browserslist"` config in the package.json.

This probably fixes #1129 