### PR TITLE
Add buttons to re-order rules in RuleTable

### DIFF
--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
@@ -1,0 +1,87 @@
+import { RuleReorderButtons, RuleReorderButtonsProps } from './RuleReorderButtons';
+import TestUtil from '../../../Util/TestUtil';
+
+import {
+  Rule as GsRule,
+} from 'geostyler-style';
+
+const _cloneDeep = require('lodash/cloneDeep');
+
+describe('ReorderButtonGroup', () => {
+
+  let wrapper: any;
+  let onRulesMoveDummy: jest.Mock;
+  let dummyRules: any;
+  beforeEach(() => {
+    dummyRules = TestUtil.getTwoRulesStyle().rules;
+    onRulesMoveDummy = jest.fn();
+    const props: RuleReorderButtonsProps = {
+      ruleIndex: 1,
+      rules: dummyRules,
+      onRulesMove: onRulesMoveDummy
+    };
+    wrapper = TestUtil.shallowRenderComponent(RuleReorderButtons, props);
+  });
+
+  it('is defined', () => {
+    expect(RuleReorderButtons).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  describe('onRuleOrderChange', () => {
+    it('reorders the rules downwards', () => {
+      const ruleIndex = 0;
+      const rules = [...dummyRules];
+      let reorderRules: GsRule[];
+      const onRulesMove = (_reorderedRules) => {
+        reorderRules = _reorderedRules;
+      }
+      wrapper.setProps({
+        ruleIndex,
+        rules,
+        onRulesMove
+      });
+
+      // move first item downwards
+      wrapper.instance().onRuleOrderChange(true);
+      expect(reorderRules[0].name).toBe('rule1');
+    });
+
+    it('reorders the rules upwards', () => {
+      const ruleIndex = 1;
+      const rules = [...dummyRules];
+      let reorderRules: GsRule[];
+      const onRulesMove = (_reorderedRules) => {
+        reorderRules = _reorderedRules;
+      }
+      wrapper.setProps({
+        ruleIndex, 
+        rules,
+        onRulesMove
+      });
+      // move second item upwards
+      wrapper.instance().onRuleOrderChange(false);
+      expect(reorderRules[0].name).toBe('rule1');
+    });
+
+    it('calls the onRulesChange with the reordered rules ', () => {
+      const ruleIndex = 0;
+      const rules = [...dummyRules];
+      // re-order rules
+      const rulesClone = _cloneDeep(rules);
+      rulesClone.splice(1, 0, rulesClone.splice(0, 1)[0]);
+      const onRulesMove = jest.fn();
+      wrapper.setProps({
+        ruleIndex,
+        rules,
+        onRulesMove
+      });
+      wrapper.instance().onRuleOrderChange(true);
+      expect(onRulesMove).toHaveBeenCalledWith(rulesClone);
+    });
+  });
+
+});

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
@@ -36,7 +36,7 @@ export interface RuleReorderButtonsProps extends Partial<RuleReorderButtonsDefau
 export class RuleReorderButtons extends React.Component<RuleReorderButtonsProps> {
 
   public static defaultProps: RuleReorderButtonsDefaultProps = {
-    locale: en_US.GsReorderButtonGroup
+    locale: en_US.GsRuleReorderButtons
   };
 
   onRuleOrderChange = (moveDown: boolean) => {

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Button } from 'antd';
+
+import {
+  Rule as GsRule,
+} from 'geostyler-style';
+
+import en_US from '../../../locale/en_US';
+
+const ButtonGroup = Button.Group;
+const _cloneDeep = require('lodash/cloneDeep');
+
+// i18n
+export interface RuleReorderButtonsLocale {
+  ruleMoveUpTip: string;
+  ruleMoveDownTip: string;
+}
+
+// default props
+interface RuleReorderButtonsDefaultProps {
+  locale: RuleReorderButtonsLocale;
+}
+// non default props
+export interface RuleReorderButtonsProps extends Partial<RuleReorderButtonsDefaultProps> {
+  /** Index of the correspondig Rule object */
+  ruleIndex: number;
+  /** Callback for click = move a rule position */
+  onRulesMove?: (rules: GsRule[]) => void;
+  /** all rules */
+  rules: GsRule[];
+}
+
+/**
+ * Button to remove a rule.
+ */
+export class RuleReorderButtons extends React.Component<RuleReorderButtonsProps> {
+
+  public static defaultProps: RuleReorderButtonsDefaultProps = {
+    locale: en_US.GsReorderButtonGroup
+  };
+
+  onRuleOrderChange = (moveDown: boolean) => {
+    const {
+      ruleIndex,
+      rules,
+      onRulesMove
+    } = this.props;
+
+    const nextRuleIndex = moveDown ? ruleIndex + 1 : ruleIndex - 1;
+    const rulesClone = _cloneDeep(rules);
+    // shift rule one position up / down in rules array
+    rulesClone.splice(nextRuleIndex, 0, rulesClone.splice(ruleIndex, 1)[0]);
+
+    if (onRulesMove) {
+      onRulesMove(rulesClone);
+    }
+  }
+
+  render() {
+    const {
+      locale,
+      ruleIndex,
+      rules,
+    } = this.props;
+
+    return (
+      <ButtonGroup>
+        <Button icon="up"
+          disabled={ruleIndex === 0}
+          title={locale.ruleMoveUpTip}
+          onClick={() => {
+            this.onRuleOrderChange(false);
+          }}
+        />
+        <Button icon="down"
+          disabled={ruleIndex === rules.length - 1}
+          title={locale.ruleMoveDownTip}
+          onClick={() => {
+            this.onRuleOrderChange(true);
+          }}
+        />
+      </ButtonGroup>
+    );
+  }
+}
+
+export default RuleReorderButtons;

--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -4,6 +4,7 @@ import { Rule } from 'geostyler-style';
 import { Input, Popover, InputNumber, Button } from 'antd';
 import { mount } from 'enzyme';
 import { Data } from 'geostyler-data';
+import RuleReorderButtons from './RuleReorderButtons/RuleReorderButtons';
 
 const _cloneDeep = require('lodash/cloneDeep');
 
@@ -231,8 +232,8 @@ describe('RuleTable', () => {
     });
   });
 
-  describe('ruleOrderDownRenderer', () => {
-    it('returns a Button', () => {
+  describe('ruleOrderRenderer', () => {
+    it('returns a ReorderButtonGroup', () => {
       const record: RuleRecord = {
         key: 0,
         name: 'name',
@@ -242,28 +243,10 @@ describe('RuleTable', () => {
           max: 24
         }
       };
-      const got = wrapper.instance().ruleOrderUpRenderer(record);
+      const got = wrapper.instance().ruleReorderRenderer(record);
       const mountRenderer = mount(got);
       const instance = mountRenderer.instance();
-      expect(instance).toBeInstanceOf(Button);
-    });
-  });
-
-  describe('ruleOrderUpRenderer', () => {
-    it('returns a Button', () => {
-      const record: RuleRecord = {
-        key: 0,
-        name: 'name',
-        symbolizers: [],
-        scaleDenominator: {
-          min: 12,
-          max: 24
-        }
-      };
-      const got = wrapper.instance().ruleOrderUpRenderer(record);
-      const mountRenderer = mount(got);
-      const instance = mountRenderer.instance();
-      expect(instance).toBeInstanceOf(Button);
+      expect(instance).toBeInstanceOf(RuleReorderButtons);
     });
   });
 
@@ -315,52 +298,6 @@ describe('RuleTable', () => {
     it('sets filterEditorVisible to false ', () => {
       wrapper.instance().onFilterEditorWindowClose();
       expect(wrapper.state('filterEditorVisible')).toBe(false);
-    });
-  });
-
-  describe('onRuleOrderChange', () => {
-    it('reorders the rules downwards', () => {
-      const rules = [...dummyRules];
-      let reorderRules: Rule[];
-      const onRulesChange = (_reorderedRules) => {
-        reorderRules = _reorderedRules;
-      }
-      wrapper.setProps({
-        rules,
-        onRulesChange
-      });
-      // move first item downwards
-      wrapper.instance().onRuleOrderChange(0, true);
-      expect(reorderRules[0].name).toBe('rule1');
-    });
-
-    it('reorders the rules upwards', () => {
-      const rules = [...dummyRules];
-      let reorderRules: Rule[];
-      const onRulesChange = (_reorderedRules) => {
-        reorderRules = _reorderedRules;
-      }
-      wrapper.setProps({
-        rules,
-        onRulesChange
-      });
-      // move 2nd item upwards
-      wrapper.instance().onRuleOrderChange(1, false);
-      expect(reorderRules[0].name).toBe('rule1');
-    });
-
-    it('calls the onRulesChange with the reordered rules ', () => {
-      const rules = [...dummyRules];
-      // re-order rules
-      const rulesClone = _cloneDeep(rules);
-      rulesClone.splice(1, 0, rulesClone.splice(0, 1)[0]);
-      const onRulesChange = jest.fn();
-      wrapper.setProps({
-        rules,
-        onRulesChange
-      });
-      wrapper.instance().onRuleOrderChange(0, true);
-      expect(onRulesChange).toHaveBeenCalledWith(rulesClone);
     });
   });
 

--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -1,9 +1,11 @@
 import { RuleTable, RuleTableProps, RuleRecord } from './RuleTable';
 import TestUtil from '../../Util/TestUtil';
 import { Rule } from 'geostyler-style';
-import { Input, Popover, InputNumber } from 'antd';
+import { Input, Popover, InputNumber, Button } from 'antd';
 import { mount } from 'enzyme';
 import { Data } from 'geostyler-data';
+
+const _cloneDeep = require('lodash/cloneDeep');
 
 describe('RuleTable', () => {
   let wrapper: any;
@@ -229,6 +231,42 @@ describe('RuleTable', () => {
     });
   });
 
+  describe('ruleOrderDownRenderer', () => {
+    it('returns a Button', () => {
+      const record: RuleRecord = {
+        key: 0,
+        name: 'name',
+        symbolizers: [],
+        scaleDenominator: {
+          min: 12,
+          max: 24
+        }
+      };
+      const got = wrapper.instance().ruleOrderUpRenderer(record);
+      const mountRenderer = mount(got);
+      const instance = mountRenderer.instance();
+      expect(instance).toBeInstanceOf(Button);
+    });
+  });
+
+  describe('ruleOrderUpRenderer', () => {
+    it('returns a Button', () => {
+      const record: RuleRecord = {
+        key: 0,
+        name: 'name',
+        symbolizers: [],
+        scaleDenominator: {
+          min: 12,
+          max: 24
+        }
+      };
+      const got = wrapper.instance().ruleOrderUpRenderer(record);
+      const mountRenderer = mount(got);
+      const instance = mountRenderer.instance();
+      expect(instance).toBeInstanceOf(Button);
+    });
+  });
+
   describe('onSymbolizersChange', () => {
     it('calls the onSymbolizersChange prop function with the value', () => {
       const symbolizers = ['a'];
@@ -277,6 +315,52 @@ describe('RuleTable', () => {
     it('sets filterEditorVisible to false ', () => {
       wrapper.instance().onFilterEditorWindowClose();
       expect(wrapper.state('filterEditorVisible')).toBe(false);
+    });
+  });
+
+  describe('onRuleOrderChange', () => {
+    it('reorders the rules downwards', () => {
+      const rules = [...dummyRules];
+      let reorderRules: Rule[];
+      const onRulesChange = (_reorderedRules) => {
+        reorderRules = _reorderedRules;
+      }
+      wrapper.setProps({
+        rules,
+        onRulesChange
+      });
+      // move first item downwards
+      wrapper.instance().onRuleOrderChange(0, true);
+      expect(reorderRules[0].name).toBe('rule1');
+    });
+
+    it('reorders the rules upwards', () => {
+      const rules = [...dummyRules];
+      let reorderRules: Rule[];
+      const onRulesChange = (_reorderedRules) => {
+        reorderRules = _reorderedRules;
+      }
+      wrapper.setProps({
+        rules,
+        onRulesChange
+      });
+      // move 2nd item upwards
+      wrapper.instance().onRuleOrderChange(1, false);
+      expect(reorderRules[0].name).toBe('rule1');
+    });
+
+    it('calls the onRulesChange with the reordered rules ', () => {
+      const rules = [...dummyRules];
+      // re-order rules
+      const rulesClone = _cloneDeep(rules);
+      rulesClone.splice(1, 0, rulesClone.splice(0, 1)[0]);
+      const onRulesChange = jest.fn();
+      wrapper.setProps({
+        rules,
+        onRulesChange
+      });
+      wrapper.instance().onRuleOrderChange(0, true);
+      expect(onRulesChange).toHaveBeenCalledWith(rulesClone);
     });
   });
 

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -12,7 +12,8 @@ import {
   InputNumber,
   Icon,
   Popover,
-  Tooltip
+  Tooltip,
+  Button
 } from 'antd';
 
 import {
@@ -49,6 +50,8 @@ export interface RuleTableLocale {
   maxScaleColumnTitle: string;
   amountColumnTitle: string;
   duplicatesColumnTitle: string;
+  ruleMoveUpTip: string;
+  ruleMoveDownTip: string;
   // locale from antd
   filterConfirm?: string;
   filterReset?: string;
@@ -382,6 +385,53 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     );
   }
 
+  ruleOrderDownRenderer = (record: RuleRecord) => {
+    const disableOrderDown = record.key === this.props.rules.length - 1;
+    return this.ruleOrderRenderer(record.key, true, disableOrderDown);
+  }
+
+  ruleOrderUpRenderer = (record: RuleRecord) => {
+    const disableOrderUp = record.key === 0;
+    return this.ruleOrderRenderer(record.key, false, disableOrderUp);
+  }
+
+  ruleOrderRenderer = (ruleIndex: number, moveDown: boolean, disabled: boolean) => {
+    const {
+      locale,
+    } = this.props;
+    const icon = moveDown ? 'down' : 'up';
+    const tooltip = moveDown ? locale.ruleMoveDownTip : locale.ruleMoveUpTip;
+    return (
+      <Button
+        type="default"
+        shape="circle"
+        icon={icon}
+        size="small"
+        title={tooltip}
+        disabled={disabled}
+        onClick={() => {
+          this.onRuleOrderChange(ruleIndex, moveDown);
+        }}
+      />
+    );
+  }
+
+  onRuleOrderChange = (ruleIndex: number, moveDown: boolean) => {
+    const {
+      rules,
+      onRulesChange
+    } = this.props;
+
+    const nextRuleIndex = moveDown ? ruleIndex + 1 : ruleIndex - 1;
+    const rulesClone = _cloneDeep(rules);
+    // shift rule one position up / down in rules array
+    rulesClone.splice(nextRuleIndex, 0, rulesClone.splice(ruleIndex, 1)[0]);
+
+    if (onRulesChange) {
+      onRulesChange(rulesClone);
+    }
+  }
+
   onSymbolizersChange = (symbolizers: GsSymbolizer[]) => {
     const {
       ruleEditIndex,
@@ -428,6 +478,12 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     } = this.props;
 
     const columns: ColumnProps<RuleRecord>[] = [{
+      dataIndex: '',
+      render: this.ruleOrderUpRenderer
+    }, {
+      dataIndex: '',
+      render: this.ruleOrderDownRenderer
+    }, {
       title: (
         <Tooltip title={locale.symbolizersColumnTitle}>
           <Icon type="bg-colors" />

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -50,8 +50,6 @@ export interface RuleTableLocale {
   maxScaleColumnTitle: string;
   amountColumnTitle: string;
   duplicatesColumnTitle: string;
-  ruleMoveUpTip: string;
-  ruleMoveDownTip: string;
   // locale from antd
   filterConfirm?: string;
   filterReset?: string;

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -13,7 +13,6 @@ import {
   Icon,
   Popover,
   Tooltip,
-  Button
 } from 'antd';
 
 import {
@@ -40,6 +39,7 @@ import { SLDRenderer, SLDRendererAdditonalProps } from '../Symbolizer/SLDRendere
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 import DataUtil from '../../Util/DataUtil';
+import RuleReorderButtons from './RuleReorderButtons/RuleReorderButtons';
 
 // i18n
 export interface RuleTableLocale {
@@ -385,51 +385,18 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     );
   }
 
-  ruleOrderDownRenderer = (record: RuleRecord) => {
-    const disableOrderDown = record.key === this.props.rules.length - 1;
-    return this.ruleOrderRenderer(record.key, true, disableOrderDown);
-  }
-
-  ruleOrderUpRenderer = (record: RuleRecord) => {
-    const disableOrderUp = record.key === 0;
-    return this.ruleOrderRenderer(record.key, false, disableOrderUp);
-  }
-
-  ruleOrderRenderer = (ruleIndex: number, moveDown: boolean, disabled: boolean) => {
-    const {
-      locale,
-    } = this.props;
-    const icon = moveDown ? 'down' : 'up';
-    const tooltip = moveDown ? locale.ruleMoveDownTip : locale.ruleMoveUpTip;
-    return (
-      <Button
-        type="default"
-        shape="circle"
-        icon={icon}
-        size="small"
-        title={tooltip}
-        disabled={disabled}
-        onClick={() => {
-          this.onRuleOrderChange(ruleIndex, moveDown);
-        }}
-      />
-    );
-  }
-
-  onRuleOrderChange = (ruleIndex: number, moveDown: boolean) => {
+  ruleReorderRenderer = (record: RuleRecord) => {
     const {
       rules,
       onRulesChange
     } = this.props;
-
-    const nextRuleIndex = moveDown ? ruleIndex + 1 : ruleIndex - 1;
-    const rulesClone = _cloneDeep(rules);
-    // shift rule one position up / down in rules array
-    rulesClone.splice(nextRuleIndex, 0, rulesClone.splice(ruleIndex, 1)[0]);
-
-    if (onRulesChange) {
-      onRulesChange(rulesClone);
-    }
+    return (
+      <RuleReorderButtons
+        ruleIndex={record.key}
+        rules={rules}
+        onRulesMove={onRulesChange}
+      />
+    );
   }
 
   onSymbolizersChange = (symbolizers: GsSymbolizer[]) => {
@@ -479,11 +446,10 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
 
     const columns: ColumnProps<RuleRecord>[] = [{
       dataIndex: '',
-      render: this.ruleOrderUpRenderer
-    }, {
-      dataIndex: '',
-      render: this.ruleOrderDownRenderer
-    }, {
+      width: 70,
+      render: this.ruleReorderRenderer
+    },
+    {
       title: (
         <Tooltip title={locale.symbolizersColumnTitle}>
           <Icon type="bg-colors" />

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -252,13 +252,11 @@ export default {
       minScaleColumnTitle: 'Min. Maßstab',
       maxScaleColumnTitle: 'Max. Maßstab',
       amountColumnTitle: 'Anzahl',
-      duplicatesColumnTitle: 'Doppelte',
+      duplicatesColumnTitle: 'Doppelte'
+    },
+    GsRuleReorderButtons: {
       ruleMoveUpTip: 'Verschiebe Regel eine Position nach oben',
       ruleMoveDownTip: 'Verschiebe Regel eine Position nach unten'
-    },
-    GsReorderButtonGroup: {
-      ruleMoveUpTip: 'Move rule one position up',
-      ruleMoveDownTip: 'Move rule one position down'
     },
     GsRuleGenerator: {
       attribute: 'Attribute',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -252,7 +252,9 @@ export default {
       minScaleColumnTitle: 'Min. Maßstab',
       maxScaleColumnTitle: 'Max. Maßstab',
       amountColumnTitle: 'Anzahl',
-      duplicatesColumnTitle: 'Doppelte'
+      duplicatesColumnTitle: 'Doppelte',
+      ruleMoveUpTip: 'Verschiebe Regel eine Position nach oben',
+      ruleMoveDownTip: 'Verschiebe Regel eine Position nach unten'
     },
     GsRuleGenerator: {
       attribute: 'Attribute',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -256,6 +256,10 @@ export default {
       ruleMoveUpTip: 'Verschiebe Regel eine Position nach oben',
       ruleMoveDownTip: 'Verschiebe Regel eine Position nach unten'
     },
+    GsReorderButtonGroup: {
+      ruleMoveUpTip: 'Move rule one position up',
+      ruleMoveDownTip: 'Move rule one position down'
+    },
     GsRuleGenerator: {
       attribute: 'Attribute',
       generateButtonText: 'Klassifizieren',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -260,6 +260,10 @@ export default {
       ruleMoveUpTip: 'Move rule one position up',
       ruleMoveDownTip: 'Move rule one position down'
     },
+    GsReorderButtonGroup: {
+      ruleMoveUpTip: 'Move rule one position up',
+      ruleMoveDownTip: 'Move rule one position down'
+    },
     GsRuleGenerator: {
       attribute: 'Attribute',
       generateButtonText: 'Classify',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -256,11 +256,9 @@ export default {
       minScaleColumnTitle: 'Min. Scale',
       maxScaleColumnTitle: 'Max. Scale',
       amountColumnTitle: 'Amount',
-      duplicatesColumnTitle: 'Duplicates',
-      ruleMoveUpTip: 'Move rule one position up',
-      ruleMoveDownTip: 'Move rule one position down'
+      duplicatesColumnTitle: 'Duplicates'
     },
-    GsReorderButtonGroup: {
+    GsRuleReorderButtons: {
       ruleMoveUpTip: 'Move rule one position up',
       ruleMoveDownTip: 'Move rule one position down'
     },

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -256,7 +256,9 @@ export default {
       minScaleColumnTitle: 'Min. Scale',
       maxScaleColumnTitle: 'Max. Scale',
       amountColumnTitle: 'Amount',
-      duplicatesColumnTitle: 'Duplicates'
+      duplicatesColumnTitle: 'Duplicates',
+      ruleMoveUpTip: 'Move rule one position up',
+      ruleMoveDownTip: 'Move rule one position down'
     },
     GsRuleGenerator: {
       attribute: 'Attribute',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -194,13 +194,11 @@ export default {
       minScaleColumnTitle: 'Escala Min.',
       maxScaleColumnTitle: 'Escala Max.',
       amountColumnTitle: 'Cantidad',
-      duplicatesColumnTitle: 'Duplicados',
+      duplicatesColumnTitle: 'Duplicados'
+    },
+    GsRuleReorderButtons: {
       ruleMoveUpTip: 'Mueve la regla una posición arriba',
       ruleMoveDownTip: 'Mueve la regla una posición hacia abajo'
-    },
-    GsReorderButtonGroup: {
-      ruleMoveUpTip: 'Move rule one position up',
-      ruleMoveDownTip: 'Move rule one position down'
     },
     GsRuleGenerator: {
       attribute: 'Atributo',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -198,6 +198,10 @@ export default {
       ruleMoveUpTip: 'Mueve la regla una posición arriba',
       ruleMoveDownTip: 'Mueve la regla una posición hacia abajo'
     },
+    GsReorderButtonGroup: {
+      ruleMoveUpTip: 'Move rule one position up',
+      ruleMoveDownTip: 'Move rule one position down'
+    },
     GsRuleGenerator: {
       attribute: 'Atributo',
       generateButtonText: 'Clasificar',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -194,7 +194,9 @@ export default {
       minScaleColumnTitle: 'Escala Min.',
       maxScaleColumnTitle: 'Escala Max.',
       amountColumnTitle: 'Cantidad',
-      duplicatesColumnTitle: 'Duplicados'
+      duplicatesColumnTitle: 'Duplicados',
+      ruleMoveUpTip: 'Mueve la regla una posición arriba',
+      ruleMoveDownTip: 'Mueve la regla una posición hacia abajo'
     },
     GsRuleGenerator: {
       attribute: 'Atributo',


### PR DESCRIPTION
This introduces two buttons (up / down) in order to allow the user to interactively re-order the rules in the `RuleTable` UI.

![grafik](https://user-images.githubusercontent.com/1185547/61630849-1c7d9500-ac89-11e9-9303-28a925da7385.png)

Fixes #1141