### PR TITLE
1134 gh pages script

### DIFF
--- a/.ci/update-gh-pages.sh
+++ b/.ci/update-gh-pages.sh
@@ -9,16 +9,19 @@ fi
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   # Dont build anything for PR requests, only for merges.
+  echo "Skip script since it processes a Pull Request, not a merge."
   return 0;
 fi
 
 if [ "$TRAVIS_BRANCH" != "master" ] && [ -z "$TRAVIS_TAG" ]; then
   # Only update when the target branch is master or a when running for a tag.
+  echo "Skip script since it is not running on master branch and not running for a tag."
   return 0;
 fi
 
 if [ "$TRAVIS_NODE_VERSION" != "12" ]; then
   # Only proceed if node is set to version 12.
+  echo "Skip script since it is not running on node version 12."
   return 0;
 fi
 

--- a/.ci/update-gh-pages.sh
+++ b/.ci/update-gh-pages.sh
@@ -7,7 +7,7 @@ if [ "$TRAVIS" != "true" ]; then
   return 1;
 fi
 
-if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   # Dont build anything for PR requests, only for merges.
   return 0;
 fi


### PR DESCRIPTION
This fixes the detection of Pull Requests in the `update-gh-pages.sh` script and adds some more logs to get a clearer picture why the script stops.

Related to #1134. 