### PR TITLE
Fix minors in the update-gh-pages script

### DIFF
--- a/.ci/update-gh-pages.sh
+++ b/.ci/update-gh-pages.sh
@@ -54,11 +54,11 @@ cd $GH_PAGES_DIR
 SRC_DIR=$TRAVIS_BUILD_DIR/build/styleguide
 
 # Cleanup latest directory.
-rm -RF ./latest/*
+rm -Rf ./latest/*
 
 # Copy to latest
 if [ "$TRAVIS_BRANCH" = "master" ]; then
-  cp -r $SRC_DIR/styleguide/ docs/latest/
+  cp -r $SRC_DIR/. latest/
 fi
 
 # Copy to latest and tag


### PR DESCRIPTION
This makes the script run locally when I mockup several of the environment variables of Travis. See e.g. this commit on the `gh_pages`-branch: https://github.com/terrestris/geostyler/commit/1b8ea31c2d48c8d016b6982e5636accd20b63c3a

The docs do not look as if much changed, as we have to list the sections for each component manually… do I understand this correctly? If so, what other otions do we have?

However, the changes herein are separate, and I think these fix the docs autgeneration and publishing.

Please review.