### PR TITLE
Add button to clone a rule in RuleTable

### DIFF
--- a/src/Component/Style/Style.spec.tsx
+++ b/src/Component/Style/Style.spec.tsx
@@ -53,6 +53,13 @@ describe('Style', () => {
     expect(wrapper.state().style.rules).toHaveLength(2);
   });
 
+  it('clones Rules', () => {
+    expect(wrapper.state().style.rules).toHaveLength(1);
+    wrapper.state().selectedRowKeys = [0];
+    wrapper.instance().cloneRules();
+    expect(wrapper.state().style.rules).toHaveLength(2);
+  });
+
   it('removes a Rule', () => {
     expect(wrapper.state().style.rules).toHaveLength(1);
     wrapper.instance().removeRule(lineStyle.rules[0]);

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -43,6 +43,7 @@ import './Style.css';
 // i18n
 export interface StyleLocale {
   addRuleBtnText: string;
+  cloneRulesBtnText: string;
   removeRulesBtnText: string;
   nameFieldLabel?: string;
   nameFieldPlaceholder?: string;
@@ -190,6 +191,35 @@ export class Style extends React.Component<StyleProps, StyleState> {
     this.setState({style});
   }
 
+  cloneRules = () => {
+    const {
+      selectedRowKeys,
+      style
+    } = this.state;
+    const styleClone = _cloneDeep(style);
+
+    // create rules to clone
+    let newRules: GsRule[] = [];
+    styleClone.rules.forEach((rule: GsRule, index: number) => {
+      if (selectedRowKeys.includes(index)) {
+        let ruleClone = _cloneDeep(rule);
+        // TODO We need to ensure that rule names are unique
+        const randomId = Math.floor(Math.random() * 10000);
+        ruleClone.name = 'rule_' + randomId;
+        newRules.push(ruleClone);
+      }
+    });
+
+    // apply cloned rules to existing ones
+    styleClone.rules = [...styleClone.rules, ...newRules];
+    if (this.props.onStyleChange) {
+      this.props.onStyleChange(styleClone);
+    }
+    this.setState({
+      style: styleClone
+    });
+  }
+
   removeRules = () => {
     const {
       selectedRowKeys,
@@ -229,6 +259,9 @@ export class Style extends React.Component<StyleProps, StyleState> {
     switch (param.key) {
       case 'addRule':
         this.addRule();
+        break;
+      case 'cloneRules':
+        this.cloneRules();
         break;
       case 'removeRule':
         this.removeRules();
@@ -370,6 +403,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
     } = this.state;
 
     const allowRemove = selectedRowKeys.length > 0 && selectedRowKeys.length < style.rules.length;
+    const allowClone = selectedRowKeys.length  > 0;
 
     return (
       <Menu
@@ -380,6 +414,12 @@ export class Style extends React.Component<StyleProps, StyleState> {
         <Menu.Item key="addRule">
           <Icon type="plus" />
             {locale.addRuleBtnText}
+        </Menu.Item>
+        <Menu.Item key="cloneRules"
+          disabled={!allowClone}
+        >
+          <Icon type="copy" />
+            {locale.cloneRulesBtnText}
         </Menu.Item>
         <Menu.Item key="removeRule"
           disabled={!allowRemove}

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -32,6 +32,7 @@ export default {
     },
     GsStyle: {
         addRuleBtnText: 'Regel hinzufügen',
+        cloneRulesBtnText: 'Regeln duplizieren',
         removeRulesBtnText: 'Regeln entfernen',
         nameFieldLabel: 'Name',
         nameFieldPlaceholder: 'Name eingeben',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -23,6 +23,7 @@ export default {
     },
     GsStyle: {
         addRuleBtnText: 'Add Rule',
+        cloneRulesBtnText: 'Clone Rules',
         removeRulesBtnText: 'Remove Rules',
         nameFieldLabel: 'Name',
         nameFieldPlaceholder: 'Enter Name',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -23,7 +23,7 @@ export default {
     },
     GsStyle: {
         addRuleBtnText: 'Añadir regla',
-        cloneRulesBtnText: 'Duplicadas reglas',
+        cloneRulesBtnText: 'Duplicar reglas',
         removeRulesBtnText: 'Eliminar reglas',
         nameFieldLabel: 'Nombre',
         nameFieldPlaceholder: 'Ingrese nombre',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -23,6 +23,7 @@ export default {
     },
     GsStyle: {
         addRuleBtnText: 'Añadir regla',
+        cloneRulesBtnText: 'Duplicadas reglas',
         removeRulesBtnText: 'Eliminar reglas',
         nameFieldLabel: 'Nombre',
         nameFieldPlaceholder: 'Ingrese nombre',


### PR DESCRIPTION
This adds a tool to clone existing rules in the `RuleTable`, so users can start new rules based on existing ones.

![grafik](https://user-images.githubusercontent.com/1185547/62129115-339a3380-b2d6-11e9-8a31-a497f2c68a8d.png)

Closes #1150