### PR TITLE
Add RuleTable and Style examples

### DIFF
--- a/src/Component/RuleTable/RuleTable.example.md
+++ b/src/Component/RuleTable/RuleTable.example.md
@@ -1,0 +1,53 @@
+This demonstrates the use of `RuleTable`.
+
+```jsx
+import * as React from 'react';
+import { RuleTable } from 'geostyler';
+
+class RuleTableExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      style: {
+        "name": "Demo Style",
+        "rules": [
+          {
+            "name": "Rule 1",
+            "symbolizers": [
+              {
+                "kind": "Mark",
+                "wellKnownName": "Circle"
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    this.onRulesChange = this.onRulesChange.bind(this);
+  }
+
+  onRulesChange(rules) {
+    const style = JSON.parse(JSON.stringify(this.state.style));
+    style.rules = rules;
+    this.setState({style});
+  }
+
+  render() {
+    const {
+      style
+    } = this.state;
+    const rules = style.rules;
+
+    return (
+      <RuleTable
+        rules={rules}
+        onRulesChange={this.onRulesChange}
+      />
+    );
+  }
+}
+
+<RuleTableExample />
+```

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -1,0 +1,77 @@
+This demonstrates the use of `Style`.
+
+```jsx
+import * as React from 'react';
+import { Style } from 'geostyler';
+
+import { Switch } from 'antd';
+
+class StyleExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      compactLayout: false,
+      style: {
+        "name": "Demo Style",
+        "rules": [
+          {
+            "name": "Rule 1",
+            "symbolizers": [
+              {
+                "kind": "Mark",
+                "wellKnownName": "Circle"
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    this.onStyleChange = this.onStyleChange.bind(this);
+    this.onLayoutChange = this.onLayoutChange.bind(this);
+  }
+
+  onStyleChange(style) {
+    this.setState({
+      style: style
+    });
+  }
+
+  onLayoutChange(compact) {
+    this.setState({
+      compactLayout: compact
+    });
+  }
+
+  render() {
+    const {
+      style,
+      compactLayout
+    } = this.state;
+
+    return (
+      <div>
+        <div>
+          <span>Compact Layout </span>
+          <Switch
+            checked={compactLayout}
+            onChange={this.onLayoutChange}
+            checkedChildren="true"
+            unCheckedChildren="false"
+          />
+        </div>
+        <hr/>
+        <Style
+          style={style}
+          onStyleChange={this.onStyleChange}
+          compact={compactLayout}
+        />
+      </div>
+    );
+  }
+
+}
+
+<StyleExample />
+```

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -66,7 +66,7 @@ interface StyleDefaultProps {
 // non default props
 export interface StyleProps extends Partial<StyleDefaultProps> {
   data?: Data;
-  onStyleChange?: (rule: GsStyle) => void;
+  onStyleChange?: (style: GsStyle) => void;
   /** The data projection of example features */
   dataProjection?: string;
   filterUiProps?: Partial<ComparisonFilterProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import WellKnownNameField from './Component/Symbolizer/Field/WellKnownNameField/
 import WidthField from './Component/Symbolizer/Field/WidthField/WidthField';
 import RuleGeneratorWindow from './Component/RuleGenerator/RuleGeneratorWindow';
 import RuleGenerator from './Component/RuleGenerator/RuleGenerator';
+import RuleTable from './Component/RuleTable/RuleTable';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
 
 import { LocaleProvider } from 'antd';
@@ -163,5 +164,6 @@ export {
   WellKnownNameField,
   RuleGeneratorWindow,
   RuleGenerator,
+  RuleTable,
   WidthField
 };


### PR DESCRIPTION
Adds examples for `RuleTable` and `Style` components.

Also added `RuleTable` to index.ts since it was missing there.

Relates to #1172 but does not solve it, as many other components are missing examples as well.