### PR TITLE
Replace deprecated localeProvider with ConfigProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7978,9 +7978,9 @@
       }
     },
     "geostyler-style": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.0.0.tgz",
-      "integrity": "sha512-a9cfg3ZeQBmPWxjcxkbwQgzNeCdSYFuptOho18rC+A40FiBneoL5vZj+DDv2wX81VvFeSOo3AFhdGOvuUaG0cw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.0.3.tgz",
+      "integrity": "sha512-58kU8aQsjQSEd900n52QX4Esd9Emcbl/yp6DvnSbrItIOWbZVlejHUHVmBEHHXu3A+iV69ffowDbP7bRIm1C9w=="
     },
     "geostyler-wfs-parser": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "geostyler-geojson-parser": "^1.0.0",
     "geostyler-openlayers-parser": "^1.1.3",
     "geostyler-sld-parser": "^2.0.0",
-    "geostyler-style": "^2.0.0",
+    "geostyler-style": "^2.0.3",
     "geostyler-wfs-parser": "^1.0.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Style, Filter } from 'geostyler-style';
-import { LocaleProvider } from 'antd';
+import { ConfigProvider } from 'antd';
 import en_US from '../locale/en_US';
 import { VectorData } from 'geostyler-data';
 import { IconLibrary } from '../Component/Symbolizer/IconSelector/IconSelector';
@@ -43,14 +43,14 @@ export class TestUtil {
    * Shallow rendering for the given component.
    * Useful for testing components as a unit, and to ensure that your tests
    * aren't indirectly asserting on behavior of child components.
-   * This function wraps LocaleProvider around component.
+   * This function wraps ConfigProvider around component.
    *
    * @param {Component} Component The Component to render.
    * @param {Object} props The props to be used.
    * @param {Object} options The options to be set.
    */
   static shallowRenderComponentWithLocale = (Component: any, props?: any, options?: any) => {
-    const wrapper = shallow(<LocaleProvider locale={en_US}><Component {...props} /></LocaleProvider>, options);
+    const wrapper = shallow(<ConfigProvider locale={en_US}><Component {...props} /></ConfigProvider>, options);
     return wrapper;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ import RuleGenerator from './Component/RuleGenerator/RuleGenerator';
 import RuleTable from './Component/RuleTable/RuleTable';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
 
-import { LocaleProvider } from 'antd';
+import { ConfigProvider } from 'antd';
 
 import de_DE from './locale/de_DE';
 import en_US from './locale/en_US';
@@ -126,7 +126,7 @@ export {
   LineEditor,
   LineJoinField,
   locale,
-  LocaleProvider,
+  ConfigProvider,
   localize,
   MarkEditor,
   MaxScaleDenominator,


### PR DESCRIPTION
antd's `localeProvider` component is deprecated and should be replaced with `configProvider`. This was done in this PR.

- [ConfigProvider docs](https://ant.design/components/config-provider/)
- [deprecated localeProvider docs](https://ant.design/components/locale-provider/)