### PR TITLE
Styleguide - Add seperate page for each component 

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -22,9 +22,11 @@ module.exports = {
     'geostyler': path.resolve(__dirname, 'src')
   },
   usageMode: 'expand',
+  pagePerSection: true,
   sections: [{
     name: 'Introduction',
-    content: './docs/README.md'
+    content: './docs/README.md',
+    sectionDepth: 0
   }, {
     name: 'Components',
     sections: [{
@@ -66,7 +68,8 @@ module.exports = {
     }, {
       name: 'UploadButton',
       components: 'src/Component/UploadButton/**/*.tsx'
-    }]
+    }],
+    sectionDepth: 2
   }],
   require: [
     path.join(__dirname, 'node_modules/antd/dist/antd.css')


### PR DESCRIPTION
Creates a separate page for each component. This should enhance the readability of the documentation and should motivate writing more detailed documentation and multiple examples of the same component (where appropriate).