### PR TITLE
Styleguide - Only display non-inherited props

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -6,7 +6,12 @@ module.exports = {
   styleguideDir: './build/styleguide',
   assetsDir: './docs',
   propsParser: require('react-docgen-typescript')
-    .withCustomConfig('./tsconfig.json')
+    .withCustomConfig('./tsconfig.json', {propFilter: (prop) => {
+      if (prop.parent) {
+        return !prop.parent.fileName.includes('node_modules');
+      }
+      return true;
+    }})
     .parse,
   components: 'src/Component/**/*.tsx',
   webpackConfig: webpackConfig,


### PR DESCRIPTION
Our documentation should only display our own specified props, not those inherited from antd, etc, since these bloat up the documentation quite heavily and make it difficult to identify the important props.

This PR changes that so only our props will be displayed in the documentation.

Example:

`OpacityField` before (goes on for around 50+ props):
![image](https://user-images.githubusercontent.com/12186477/64519254-148aba80-d2f4-11e9-93f2-193e3bf7d81b.png)

`OpacityField` after:
![image](https://user-images.githubusercontent.com/12186477/64519277-21a7a980-d2f4-11e9-9c5d-e1e5e69d6921.png)

Code taken from: https://github.com/styleguidist/react-docgen-typescript#parseroptions